### PR TITLE
(feat): nnnnat reaction theme

### DIFF
--- a/components/Header.js
+++ b/components/Header.js
@@ -6,9 +6,9 @@ import Typography from "material-ui/Typography";
 class Header extends Component {
   render() {
     return (
-      <AppBar position="static" color="primary">
+      <AppBar position="static">
         <Toolbar>
-          <Typography variant="title" color="secondary">App Name</Typography>
+          <Typography variant="title">Reaction Commerce</Typography>
         </Toolbar>
       </AppBar>
     );

--- a/components/Profile.js
+++ b/components/Profile.js
@@ -2,6 +2,7 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { Query } from "react-apollo";
 import gql from "graphql-tag";
+import Typography from "material-ui/Typography";
 
 const GET_VIEWER = gql`
   {
@@ -22,7 +23,7 @@ class Profile extends Component {
   render() {
     const { viewer: { name } } = this.props;
     return (
-      <h1>{name}</h1>
+      <Typography variant="subheading">{name}</Typography>
     );
   }
 }

--- a/lib/theme/reactionTheme.js
+++ b/lib/theme/reactionTheme.js
@@ -1,20 +1,24 @@
 import { createMuiTheme } from "material-ui/styles";
-import green from "material-ui/colors/green";
 
 const theme = createMuiTheme({
   palette: {
     primary: {
-      light: "#ff0000",
-      main: "#ff0000",
-      dark: "#ff0000"
+      light: "#26B0F9",
+      main: "#1999DD",
+      dark: "#172F3C",
+      contrastText: "#FFFFFF"
     },
     secondary: {
-      light: green[300],
-      main: green[500],
-      dark: green[700]
+      light: "#5d8ea9",
+      main: "#5E7480",
+      dark: "#1D1D1D",
+      contrastText: "#000000"
     },
     error: {
-      main: "red"
+      light: "#E54F5D",
+      main: "#CD3F4C",
+      dark: "#3C1F21",
+      contrastText: "#FFFFFF"
     }
   },
   typography: {

--- a/lib/theme/reactionTheme.js
+++ b/lib/theme/reactionTheme.js
@@ -12,7 +12,17 @@ const theme = createMuiTheme({
       light: green[300],
       main: green[500],
       dark: green[700]
+    },
+    error: {
+      main: "red"
     }
+  },
+  typography: {
+    fontFamily: "Source Sans Pro, Helvetica Neue, Helvetica, sans-serif",
+    fontSize: 16,
+    fontWeightLight: 200,
+    fontWeightRegular: 400,
+    fontWeightBold: 700
   }
 });
 

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -1,10 +1,10 @@
 import React from "react";
-import Document, { Head, Main, NextScript } from "next/document";
+import { Document as NextDocument, Head, Main, NextScript } from "next/document";
 import JssProvider from "react-jss/lib/JssProvider";
 import flush from "styled-jsx/server";
 import getPageContext from "./../lib/theme/getPageContext";
 
-class MyDocument extends Document {
+class Document extends NextDocument {
   render() {
     const { pageContext } = this.props;
 
@@ -34,7 +34,7 @@ class MyDocument extends Document {
   }
 }
 
-MyDocument.getInitialProps = (ctx) => {
+Document.getInitialProps = (ctx) => {
   // Resolution order
   //
   // On the server:
@@ -79,4 +79,4 @@ MyDocument.getInitialProps = (ctx) => {
   };
 };
 
-export default MyDocument;
+export default Document;

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -23,10 +23,7 @@ class MyDocument extends Document {
           />
           {/* PWA primary color */}
           <meta name="theme-color" content={pageContext.theme.palette.primary.main} />
-          <link
-            rel="stylesheet"
-            href="https://fonts.googleapis.com/css?family=Roboto:300,400,500"
-          />
+          <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:200,400,700" rel="stylesheet" />
         </Head>
         <body>
           <Main />

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,6 +1,7 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { withStyles } from "material-ui/styles";
+import Typography from "material-ui/Typography";
 import withData from "./../lib/apollo/withData";
 import withRoot from "./../lib/theme/withRoot";
 import Header from "./../components/Header";
@@ -9,7 +10,7 @@ import Profile from "./../components/Profile";
 const styles = (theme) => ({
   root: {
     textAlign: "center",
-    paddingTop: theme.spacing.unit * 20
+    paddingTop: theme.spacing.unit * 0
   }
 });
 
@@ -27,7 +28,7 @@ class Shop extends Component {
       <div className={classes.root}>
         <Header />
         <Profile />
-        <p>Index Page</p>
+        <Typography variant="body2">Index Page</Typography>
       </div>
     );
   }


### PR DESCRIPTION
## Issue
Material UI doesn't use the Reaction styles

## Solution
Material UI has several options for theming the UI lib. This is just a first pass at adding the Reaction colors and type styles to the theme.

## Testing
1. Start up the app and see the font family is now Source Sans Pro and the Primary, Secondary and Error theme options now use colors from the RC [style guide](https://zpl.io/aBO3D8A).

## Notes
Once we get some larger UI built out @cassytaylor and @rymorgan should review and make suggestions on which theme variables we replace with RC styles.