### PR TITLE
refactor: use next/config for runtime configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
 NODE_ENV=development
-GRAPHQL_URL=http://devserver.reaction-api:3030/graphql-alpha
+INTERNAL_GRAPHQL_URL=http://devserver.reaction-api:3030/graphql-alpha
+EXTERNAL_GRAPHQL_URL=http://localhost:3030/graphql-alpha
 METEOR_TOKEN=${get the Reaction meteor.loginToken from local-storage}

--- a/README.md
+++ b/README.md
@@ -32,10 +32,8 @@ _**NOTE:** Currently we're using the [release 1.11.0 branch](https://github.com/
 **Setting up the Storefront's environment**
  1. Create a new `.env` file in the root of this project or copy the example one by running `cp .env.example .env`
  2. Replace the METEOR_TOKEN with the Meteor.loginToken from the above steps.
- 3. Create a new `browser.config.js` file in the `src` directory of this project or copy the example one by running `cp src/browser.config.example.js browser.config.js`
- 4. Replace the METEOR_TOKEN with the Meteor.loginToken from the above steps.
- 5. Start the storefront application in development mode by running `docker-compose up -d --build`
- 6. The Storefront will run on [localhost:4000](http://localhost:4000).
+ 3. Start the storefront application in development mode by running `docker-compose up -d --build`
+ 4. The Storefront will run on [localhost:4000](http://localhost:4000).
 
 ## Development
 To run the application in development mode execute:

--- a/next.config.js
+++ b/next.config.js
@@ -2,7 +2,8 @@ const initExport = {
   serverRuntimeConfig: { // Will only be available on the server side
     dev: process.env.NODE_ENV !== "production",
     appPath: process.env.NODE_ENV === "production" ? "./build/app" : "./src",
-    graphqlUrl: process.env.INTERNAL_GRAPHQL_URL
+    graphqlUrl: process.env.INTERNAL_GRAPHQL_URL,
+    meteorToken: process.env.METEOR_TOKEN
   },
   publicRuntimeConfig: { // Will be available on both server and client
     graphqlUrl: process.env.EXTERNAL_GRAPHQL_URL,

--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,13 @@
-
 const initExport = {
+  serverRuntimeConfig: { // Will only be available on the server side
+    dev: process.env.NODE_ENV !== "production",
+    appPath: process.env.NODE_ENV === "production" ? "./build/app" : "./src",
+    graphqlUrl: process.env.INTERNAL_GRAPHQL_URL
+  },
+  publicRuntimeConfig: { // Will be available on both server and client
+    graphqlUrl: process.env.EXTERNAL_GRAPHQL_URL,
+    meteorToken: process.env.METEOR_TOKEN
+  },
   webpack: (config) => {
     config.module.rules.push({
       test: /\.(gql|graphql)$/,

--- a/src/browser.config.example.js
+++ b/src/browser.config.example.js
@@ -1,5 +1,0 @@
-// Browser config
-export default {
-  GRAPHQL_URL: "http://devserver.reaction-api:3030/graphql-alpha",
-  METEOR_TOKEN: "${get the Reaction meteor.loginToken from local-storage}"
-};

--- a/src/containers/tags/withNavigationTags.js
+++ b/src/containers/tags/withNavigationTags.js
@@ -115,8 +115,11 @@ export default (Component) => (
             // Send the previous result if the new result contians no additional data
             return previousResult;
           }
-        }).catch((error) => {
-          console.log(error); /* eslint-disable-line no-console */
+        }).catch(() => {
+          /*
+            Catch errors, namely `TypeError: Cannot set property 'networkStatus' of undefined` which seems to be
+            an Apollo issue: https://github.com/apollographql/apollo-client/issues/2539
+          */
         });
       }
     }

--- a/src/lib/apollo/initApolloBrowser.js
+++ b/src/lib/apollo/initApolloBrowser.js
@@ -6,6 +6,7 @@ import getConfig from "next/config";
 
 // Config
 const { publicRuntimeConfig: { graphqlUrl, meteorToken } } = getConfig();
+let apolloClient = null;
 
 if (!process.browser) {
   global.fetch = fetch;
@@ -25,11 +26,16 @@ const create = (initialState) =>
     cache: new InMemoryCache().restore(initialState || {})
   });
 
+
 /**
  * @name initApolloBrowser
  * @param {*} initialState Initial state to initialize the Apollo client with
  * @return {ApolloClient} Apollo client instance
  */
-export default function initApolloBrowser(initialState) {
-  return create(initialState);
+export default function initApolloBorwser(initialState) {
+  if (!apolloClient) {
+    apolloClient = create(initialState);
+  }
+
+  return apolloClient;
 }

--- a/src/lib/apollo/initApolloBrowser.js
+++ b/src/lib/apollo/initApolloBrowser.js
@@ -2,10 +2,10 @@ import { ApolloClient } from "apollo-client";
 import { HttpLink } from "apollo-link-http";
 import { InMemoryCache } from "apollo-cache-inmemory";
 import fetch from "isomorphic-fetch";
-import config from "browser.config";
+import getConfig from "next/config";
 
-// Enviroment variables from .env
-const { METEOR_TOKEN, GRAPHQL_URL } = config;
+// Config
+const { publicRuntimeConfig: { graphqlUrl, meteorToken } } = getConfig();
 
 if (!process.browser) {
   global.fetch = fetch;
@@ -16,9 +16,9 @@ const create = (initialState) =>
     connectToDevTools: true,
     ssrMode: false,
     link: new HttpLink({
-      uri: `${GRAPHQL_URL}`,
+      uri: `${graphqlUrl}`,
       headers: {
-        "meteor-login-token": `${METEOR_TOKEN}`
+        "meteor-login-token": `${meteorToken}`
       },
       credentials: "same-origin"
     }),

--- a/src/lib/apollo/initApolloServer.js
+++ b/src/lib/apollo/initApolloServer.js
@@ -2,9 +2,10 @@ import { ApolloClient } from "apollo-client";
 import { HttpLink } from "apollo-link-http";
 import { InMemoryCache } from "apollo-cache-inmemory";
 import fetch from "isomorphic-fetch";
+import getConfig from "next/config";
 
-// Enviroment variables from config.client
-const { env: { METEOR_TOKEN, GRAPHQL_URL } } = process;
+// Config
+const { serverRuntimeConfig: { graphqlUrl, meteorToken } } = getConfig();
 
 let apolloClient = null;
 
@@ -17,9 +18,9 @@ const create = (initialState) =>
     connectToDevTools: false,
     ssrMode: true,
     link: new HttpLink({
-      uri: `${GRAPHQL_URL}`,
+      uri: `${graphqlUrl}`,
       headers: {
-        "meteor-login-token": `${METEOR_TOKEN}`
+        "meteor-login-token": `${meteorToken}`
       },
       credentials: "same-origin"
     }),

--- a/src/lib/apollo/initApolloServer.js
+++ b/src/lib/apollo/initApolloServer.js
@@ -7,8 +7,6 @@ import getConfig from "next/config";
 // Config
 const { serverRuntimeConfig: { graphqlUrl, meteorToken } } = getConfig();
 
-let apolloClient = null;
-
 if (!process.browser) {
   global.fetch = fetch;
 }
@@ -28,14 +26,10 @@ const create = (initialState) =>
   });
 
 /**
- * @name initApolloBrowser
+ * @name initApolloServer
  * @param {*} initialState Initial state to initialize the Apollo client with
  * @return {ApolloClient} Apollo client instance
  */
-export default function initApolloBorwser(initialState) {
-  if (!apolloClient) {
-    apolloClient = create(initialState);
-  }
-
-  return apolloClient;
+export default function initApolloServer(initialState) {
+  return create(initialState);
 }


### PR DESCRIPTION
## Issue

Consolidate values from `browser.config.js` into `.env` having an internal and external GraphQL API URL, and provide those values to server and client.

## Other considerations

`src/config.js` remains as it seems `getConfig()` is undefined if included `server.js`. The values in `config.js` aren't needed by anything else, so it seems fine for now.

## Testing
**Pre-req**: How your `.env` file should look
```
NODE_ENV=development
INTERNAL_GRAPHQL_URL=http://devserver.reaction-api:3030/graphql-alpha
EXTERNAL_GRAPHQL_URL=http://localhost:3030/graphql-alpha
METEOR_TOKEN=${get the Reaction meteor.loginToken from local-storage}
```

1. In `.env` ensure you have a meteor login token set 
2. Start the app with `docker-compose up`. You may need to do `docker-compose down && docker-compose up`
3. See tags show up, as well as `Hello Admin`

