### PR TITLE
feat: PDP Header (title & pageTitle)

### DIFF
--- a/src/components/ProductDetail/ProductDetail.js
+++ b/src/components/ProductDetail/ProductDetail.js
@@ -4,6 +4,9 @@ import { withStyles } from "material-ui/styles";
 import Grid from "material-ui/Grid";
 import Typography from "material-ui/Typography";
 
+// PDP Components
+import ProductDetailTitle from "components/ProductDetailTitle";
+
 const styles = () => ({
   root: {
     display: "flex",
@@ -24,12 +27,13 @@ const styles = () => ({
 @withStyles(styles, { withTheme: true })
 class ProductDetail extends Component {
   static propTypes = {
+    catalogProduct: PropTypes.object,
     classes: PropTypes.object,
     theme: PropTypes.object
   }
 
   render() {
-    const { classes, theme } = this.props;
+    const { classes, theme, catalogProduct } = this.props;
 
     return (
       <div className={classes.root}>
@@ -40,8 +44,10 @@ class ProductDetail extends Component {
           </Grid>
 
           <Grid item sm={6}>
-            {/* TODO: Right Content, remove when adding initial components */}
-            <Typography variant="display1">Right Container</Typography>
+            <ProductDetailTitle
+              pageTitle={catalogProduct.pageTitle}
+              title={catalogProduct.title}
+            />
           </Grid>
         </Grid>
       </div>

--- a/src/components/ProductDetail/ProductDetail.test.js
+++ b/src/components/ProductDetail/ProductDetail.test.js
@@ -2,9 +2,10 @@ import React from "react";
 import renderer from "react-test-renderer";
 import { shallow } from "enzyme";
 import ProductDetail from "./ProductDetail";
+import sampleData from "./sampleData";
 
 test("basic snapshot", () => {
-  const component = renderer.create(shallow(<ProductDetail />).get(0));
+  const component = renderer.create(shallow(<ProductDetail catalogProduct={sampleData} />).get(0));
   const tree = component.toJSON();
   expect(tree).toMatchSnapshot();
 });

--- a/src/components/ProductDetail/__snapshots__/ProductDetail.test.js.snap
+++ b/src/components/ProductDetail/__snapshots__/ProductDetail.test.js.snap
@@ -19,11 +19,20 @@ exports[`basic snapshot 1`] = `
     <div
       className="MuiGrid-item-4 MuiGrid-grid-sm-6-47"
     >
-      <h1
-        className="MuiTypography-root-93 MuiTypography-display1-97"
+      <div
+        className="MuiGrid-item-4 MuiGrid-grid-sm-12-53"
       >
-        Right Container
-      </h1>
+        <h1
+          className="MuiTypography-root-93 MuiTypography-display2-96 MuiTypography-gutterBottom-110"
+        >
+          Title
+        </h1>
+        <h2
+          className="MuiTypography-root-93 MuiTypography-title-99 MuiTypography-colorPrimary-113"
+        >
+          SubTitle
+        </h2>
+      </div>
     </div>
   </div>
 </div>

--- a/src/components/ProductDetail/sampleData.js
+++ b/src/components/ProductDetail/sampleData.js
@@ -1,0 +1,5 @@
+// Sample Catalog Product Data
+export default {
+  title: "Title",
+  pageTitle: "SubTitle"
+};

--- a/src/components/ProductDetailTitle/ProductDetailTitle.js
+++ b/src/components/ProductDetailTitle/ProductDetailTitle.js
@@ -22,7 +22,7 @@ class ProductDetailTitle extends Component {
   render() {
     const { title, pageTitle } = this.props;
     return (
-      <Grid xs={12}>
+      <Grid item sm={12}>
         {title && <Typography gutterBottom={true} variant="display2">{title}</Typography>}
         {pageTitle && <Typography color="primary" component="h2" variant="title">{pageTitle}</Typography>}
       </Grid>

--- a/src/components/ProductDetailTitle/ProductDetailTitle.js
+++ b/src/components/ProductDetailTitle/ProductDetailTitle.js
@@ -1,0 +1,33 @@
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+import Typography from "material-ui/Typography";
+import Grid from "material-ui/Grid";
+
+/**
+ * Product detail title and pageTitle (subtitle)
+ * @class ProductDetailTitle
+ */
+class ProductDetailTitle extends Component {
+  static propTypes = {
+    /**
+     * Subtitle
+     */
+    pageTitle: PropTypes.string,
+
+    /**
+     * Main title, the h1 for the page
+     */
+    title: PropTypes.string
+  }
+  render() {
+    const { title, pageTitle } = this.props;
+    return (
+      <Grid xs={12}>
+        {title && <Typography gutterBottom={true} variant="display2">{title}</Typography>}
+        {pageTitle && <Typography color="primary" component="h2" variant="title">{pageTitle}</Typography>}
+      </Grid>
+    );
+  }
+}
+
+export default ProductDetailTitle;

--- a/src/components/ProductDetailTitle/ProductDetailTitle.js
+++ b/src/components/ProductDetailTitle/ProductDetailTitle.js
@@ -21,6 +21,10 @@ class ProductDetailTitle extends Component {
   }
   render() {
     const { title, pageTitle } = this.props;
+
+    // Render nothing if neither the title nor pageTitle exists
+    if (!title && !pageTitle) return null;
+
     return (
       <Grid item sm={12}>
         {title && <Typography gutterBottom={true} variant="display2">{title}</Typography>}

--- a/src/components/ProductDetailTitle/ProductDetailTitle.test.js
+++ b/src/components/ProductDetailTitle/ProductDetailTitle.test.js
@@ -7,3 +7,21 @@ test("basic snapshot", () => {
   const tree = component.toJSON();
   expect(tree).toMatchSnapshot();
 });
+
+test("snapshot with only title", () => {
+  const component = renderer.create(<ProductDetailTitle title="Title" />);
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+test("snapshot with only pageTitle", () => {
+  const component = renderer.create(<ProductDetailTitle pageTitle="Subtitle" />);
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+test("snapshot with neither title nor pageTitle", () => {
+  const component = renderer.create(<ProductDetailTitle />);
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});

--- a/src/components/ProductDetailTitle/ProductDetailTitle.test.js
+++ b/src/components/ProductDetailTitle/ProductDetailTitle.test.js
@@ -1,0 +1,9 @@
+import React from "react";
+import renderer from "react-test-renderer";
+import ProductDetailTitle from "./ProductDetailTitle";
+
+test("basic snapshot", () => {
+  const component = renderer.create(<ProductDetailTitle title="Title" pageTitle="Subtitle" />);
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});

--- a/src/components/ProductDetailTitle/__snapshots__/ProductDetailTitle.test.js.snap
+++ b/src/components/ProductDetailTitle/__snapshots__/ProductDetailTitle.test.js.snap
@@ -1,0 +1,18 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`basic snapshot 1`] = `
+<div
+  className="MuiGrid-item-2 MuiGrid-grid-sm-12-51"
+>
+  <h1
+    className="MuiTypography-root-91 MuiTypography-display2-94 MuiTypography-gutterBottom-108"
+  >
+    Title
+  </h1>
+  <h2
+    className="MuiTypography-root-91 MuiTypography-title-97 MuiTypography-colorPrimary-111"
+  >
+    Subtitle
+  </h2>
+</div>
+`;

--- a/src/components/ProductDetailTitle/__snapshots__/ProductDetailTitle.test.js.snap
+++ b/src/components/ProductDetailTitle/__snapshots__/ProductDetailTitle.test.js.snap
@@ -16,3 +16,29 @@ exports[`basic snapshot 1`] = `
   </h2>
 </div>
 `;
+
+exports[`snapshot with neither title nor pageTitle 1`] = `null`;
+
+exports[`snapshot with only pageTitle 1`] = `
+<div
+  className="MuiGrid-item-2 MuiGrid-grid-sm-12-51"
+>
+  <h2
+    className="MuiTypography-root-91 MuiTypography-title-97 MuiTypography-colorPrimary-111"
+  >
+    Subtitle
+  </h2>
+</div>
+`;
+
+exports[`snapshot with only title 1`] = `
+<div
+  className="MuiGrid-item-2 MuiGrid-grid-sm-12-51"
+>
+  <h1
+    className="MuiTypography-root-91 MuiTypography-display2-94 MuiTypography-gutterBottom-108"
+  >
+    Title
+  </h1>
+</div>
+`;

--- a/src/components/ProductDetailTitle/index.js
+++ b/src/components/ProductDetailTitle/index.js
@@ -1,0 +1,1 @@
+export { default } from "./ProductDetailTitle";

--- a/src/pages/product.js
+++ b/src/pages/product.js
@@ -7,6 +7,9 @@ import withShop from "containers/shop/withShop";
 import Layout from "components/Layout";
 import ProductDetail from "components/ProductDetail";
 
+// TODO: Data will eventually come from GraphQL
+import sampleData from "components/ProductDetail/sampleData";
+
 @withData
 @withRoot
 @withShop
@@ -23,7 +26,7 @@ class ProductDetailPage extends Component {
   render() {
     return (
       <Layout>
-        <ProductDetail />
+        <ProductDetail catalogProduct={sampleData} />
       </Layout>
     );
   }


### PR DESCRIPTION
Issue: #21
Impact: **minor**
Type: **feat**

## Issue

Create a title component for the PDP page that includes a title and page title if they are passed in as props.

## Solution 

Create a component that can

- Display title & pageTitle
- Display title alone
- Display pageTitle alone
- Not render if neither title nor pageTitle exists

## Test

- Start the app and go to `http://localhost:4000/product/1234`
- See Title and Subtitle