### PR TITLE
feat: Add metatags to Product Detail Page

### DIFF
--- a/src/components/ProductDetail/ProductDetail.js
+++ b/src/components/ProductDetail/ProductDetail.js
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import { withStyles } from "material-ui/styles";
 import Grid from "material-ui/Grid";
 import Typography from "material-ui/Typography";
+import Helmet from "react-helmet";
 
 // PDP Components
 import ProductDetailTitle from "components/ProductDetailTitle";

--- a/src/components/ProductDetail/ProductDetail.js
+++ b/src/components/ProductDetail/ProductDetail.js
@@ -38,6 +38,10 @@ class ProductDetail extends Component {
 
     return (
       <div className={classes.root}>
+        <Helmet>
+          <title>{catalogProduct.title}</title>
+          <meta name="description" content={catalogProduct.description} />
+        </Helmet>
         <Grid container className={classes.pdpContainer} spacing={theme.spacing.unit * 3}>
           <Grid item sm={6}>
             {/* TODO: Left Content, remove when adding initial components */}

--- a/src/components/ProductDetail/sampleData.js
+++ b/src/components/ProductDetail/sampleData.js
@@ -1,5 +1,6 @@
 // Sample Catalog Product Data
 export default {
   title: "Title",
-  pageTitle: "SubTitle"
+  pageTitle: "SubTitle",
+  description: "Product description"
 };


### PR DESCRIPTION
Issue: #20 
Impact: **minor**
Type: **feat**

## Issue

Add title and description meta tags to the Product Detail Pag

## Solution 
-Import `react-helmet` into the PDP page file
- add `title` and `meta description` tags via `react-helmet`

## Test

- Start the app, go to `http://localhost:4000`, and click any product
- See that title and description meta tags are updated based on the sample data

## Notes
Better sample sample data is being added in PR #53. If there are conflicts with the sample data in this PR, use the data in #53 instead.