### PR TITLE
chore: update circle config to save artifacts for coverage and junit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -152,15 +152,15 @@ jobs:
               --env-file docker-cache/.env \
               --name reactionapp_next_starterkit \
               "$DOCKER_REPOSITORY:$CIRCLE_SHA1" \
-              yarn run test --coverage
+              yarn run test:ci
       - run:
           name: Copy test artifacts from Remote Docker
           command: |
             docker cp \
-              reactionapp_next_starterkit:/usr/local/src/reaction-app/coverage \
+              reactionapp_next_starterkit:/usr/local/src/reaction-app/reports \
               reports
       - store_test_results:
-          path: reports/lcov-report
+          path: reports/junit
       - store_artifacts:
           path: reports
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6796,6 +6796,28 @@
         }
       }
     },
+    "jest-junit": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/jest-junit/-/jest-junit-3.6.0.tgz",
+      "integrity": "sha512-zczUffyyJVvKldrkQZYlbytNDcxeuSSlysXqyEqOp/XiW/on5QDBMJMsmuY7Nmkve3KdA4U/tRkSiG/C2ewrjw==",
+      "dev": true,
+      "requires": {
+        "mkdirp": "0.5.1",
+        "strip-ansi": "4.0.0",
+        "xml": "1.0.1"
+      },
+      "dependencies": {
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "3.0.0"
+          }
+        }
+      }
+    },
     "jest-leak-detector": {
       "version": "22.4.3",
       "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-22.4.3.tgz",
@@ -11922,6 +11944,12 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
       "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ="
+    },
+    "xml": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
+      "integrity": "sha1-eLpyAgApxbyHuKgaPPzXS0ovweU=",
+      "dev": true
     },
     "xml-name-validator": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "lint": "eslint .",
     "start": "NODE_ENV=production node build/app/server.js",
     "test": "yarn run test:unit",
+    "test:ci": "yarn run test:unit --ci --runInBand --colors",
     "test:unit": "jest",
     "test:unit:watch": "jest --watch"
   },
@@ -72,12 +73,23 @@
     "eslint-plugin-promise": "^3.7.0",
     "eslint-plugin-react": "^7.7.0",
     "jest": "^22.4.3",
+    "jest-junit": "^3.6.0",
     "jest-transform-graphql": "2.1.0",
     "react-test-renderer": "^16.3.1",
     "rimraf": "^2.6.2",
     "snyk": "^1.73.0"
   },
   "jest": {
+    "collectCoverage": true,
+    "collectCoverageFrom": [
+      "**/*.{js,jsx}",
+      "!**/reports/**",
+      "!**/dist/**",
+      "!**/node_modules/**",
+      "!**/vendor/**"
+    ],
+    "coverageDirectory": "reports/coverage",
+    "testResultsProcessor": "jest-junit",
     "roots": [
       "./src"
     ],
@@ -86,5 +98,9 @@
       "\\.(gql|graphql)$": "jest-transform-graphql",
       ".*": "babel-jest"
     }
+  },
+  "jest-junit": {
+    "output": "reports/junit/junit.xml",
+    "suiteName": "jest-tests"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4113,6 +4113,14 @@ jest-jasmine2@^22.4.3:
     jest-util "^22.4.3"
     source-map-support "^0.5.0"
 
+jest-junit@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/jest-junit/-/jest-junit-3.6.0.tgz#f4c4358e5286364a4324dc14abddd526aadfbd38"
+  dependencies:
+    mkdirp "^0.5.1"
+    strip-ansi "^4.0.0"
+    xml "^1.0.1"
+
 jest-leak-detector@^22.4.3:
   version "22.4.3"
   resolved "https://registry.yarnpkg.com/jest-leak-detector/-/jest-leak-detector-22.4.3.tgz#2b7b263103afae8c52b6b91241a2de40117e5b35"
@@ -7624,6 +7632,10 @@ xml2js@^0.4.17:
   dependencies:
     sax ">=0.6.0"
     xmlbuilder "~9.0.1"
+
+xml@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/xml/-/xml-1.0.1.tgz#78ba72020029c5bc87b8a81a3cfcd74b4a2fc1e5"
 
 xmlbuilder@~9.0.1:
   version "9.0.7"


### PR DESCRIPTION
Adds `jest-junit` npm lib for junit compatible xml reporting of jest tests. 
Updates the circle `config.yml` file to save test artifacts to reports directory