### PR TITLE
feat: Create PDP tag component

### DIFF
--- a/src/components/ProductDetail/ProductDetail.js
+++ b/src/components/ProductDetail/ProductDetail.js
@@ -9,8 +9,9 @@ import ProductDetailTitle from "components/ProductDetailTitle";
 import VariantList from "components/VariantList";
 import ProductDetailInfo from "components/ProductDetailInfo";
 import MediaGallery from "components/MediaGallery";
+import TagGrid from "components/TagGrid"
 
-const styles = () => ({
+const styles = (theme) => ({
   root: {
     display: "flex",
     justifyContent: "center",
@@ -18,6 +19,9 @@ const styles = () => ({
   },
   pdpContainer: {
     maxWidth: 1440
+  },
+  section: {
+    marginBottom: theme.spacing.unit * 2
   }
 });
 
@@ -48,7 +52,12 @@ class ProductDetail extends Component {
         </Helmet>
         <Grid container className={classes.pdpContainer} spacing={theme.spacing.unit * 3}>
           <Grid item xs={12} sm={6}>
-            <MediaGallery mediaItems={catalogProduct.media} />
+            <div className={classes.section}>
+              <MediaGallery mediaItems={catalogProduct.media} />
+            </div>
+            <div className={classes.section}>
+              <TagGrid tags={catalogProduct.tags} />
+            </div>
           </Grid>
 
           <Grid item xs={12} sm={6}>

--- a/src/components/ProductDetail/ProductDetail.js
+++ b/src/components/ProductDetail/ProductDetail.js
@@ -9,7 +9,7 @@ import ProductDetailTitle from "components/ProductDetailTitle";
 import VariantList from "components/VariantList";
 import ProductDetailInfo from "components/ProductDetailInfo";
 import MediaGallery from "components/MediaGallery";
-import TagGrid from "components/TagGrid"
+import TagGrid from "components/TagGrid";
 
 const styles = (theme) => ({
   root: {

--- a/src/components/ProductDetail/__mocks__/productData.mock.js
+++ b/src/components/ProductDetail/__mocks__/productData.mock.js
@@ -14,6 +14,22 @@ export default {
     min: 12.99,
     max: 330
   },
+  tags: [
+    {
+      node: {
+        position: null,
+        name: "Shoes",
+        slug: "shoes"
+      }
+    },
+    {
+      node: {
+        position: null,
+        name: "Shop",
+        slug: "shop"
+      }
+    }
+  ],
   variants: [
     {
       _id: "cmVhY3Rpb24vY2F0YWxvZ1Byb2R1Y3RWYXJpYW50OjZxaXFQd0JrZUpkdGRRYzRH",

--- a/src/components/ProductDetail/__snapshots__/ProductDetail.test.js.snap
+++ b/src/components/ProductDetail/__snapshots__/ProductDetail.test.js.snap
@@ -5,300 +5,365 @@ exports[`basic snapshot 1`] = `
   className="ProductDetail-root-1"
 >
   <div
-    className="MuiGrid-container-3 MuiGrid-spacing-xs-24-26 ProductDetail-pdpContainer-2"
+    className="MuiGrid-container-4 MuiGrid-spacing-xs-24-27 ProductDetail-pdpContainer-2"
   >
     <div
-      className="MuiGrid-item-4 MuiGrid-grid-xs-12-40 MuiGrid-grid-sm-6-47"
+      className="MuiGrid-item-5 MuiGrid-grid-xs-12-41 MuiGrid-grid-sm-6-48"
     >
       <div
-        className="MuiGrid-container-3 inject-MediaGallery-with-uiStore-root-93"
+        className="ProductDetail-section-3"
       >
         <div
-          className="MuiGrid-item-4 MuiGrid-grid-xs-12-40 MuiGrid-grid-sm-12-53"
+          className="MuiGrid-container-4 inject-MediaGallery-with-uiStore-root-94"
         >
           <div
-            className="inject-MediaGallery-with-uiStore-featured-94"
-          >
-            <img
-              alt=""
-              className="inject-MediaGallery-with-uiStore-featuredImage-95"
-              src="/resources/placeholder.gif"
-            />
-          </div>
-          <div
-            className="MuiGrid-container-3 MuiGrid-spacing-xs-8-24"
+            className="MuiGrid-item-5 MuiGrid-grid-xs-12-41 MuiGrid-grid-sm-12-54"
           >
             <div
-              className="MuiGrid-item-4 MuiGrid-grid-xs-3-31 MuiGrid-grid-sm-2-43"
+              className="inject-MediaGallery-with-uiStore-featured-95"
             >
-              <button
-                className="MuiButtonBase-root-98 inject-MediaGalleryItem-with-uiStore-root-96"
-                disabled={undefined}
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onKeyDown={[Function]}
-                onKeyUp={[Function]}
-                onMouseDown={[Function]}
-                onMouseLeave={[Function]}
-                onMouseUp={[Function]}
-                onTouchEnd={[Function]}
-                onTouchMove={[Function]}
-                onTouchStart={[Function]}
-                tabIndex="0"
-                type="button"
-              >
-                <img
-                  alt=""
-                  className="inject-MediaGalleryItem-with-uiStore-img-97"
-                  src="/resources/placeholder.gif"
-                />
-                <span
-                  className="MuiTouchRipple-root-101"
-                />
-              </button>
+              <img
+                alt=""
+                className="inject-MediaGallery-with-uiStore-featuredImage-96"
+                src="/resources/placeholder.gif"
+              />
             </div>
             <div
-              className="MuiGrid-item-4 MuiGrid-grid-xs-3-31 MuiGrid-grid-sm-2-43"
+              className="MuiGrid-container-4 MuiGrid-spacing-xs-8-25"
             >
-              <button
-                className="MuiButtonBase-root-98 inject-MediaGalleryItem-with-uiStore-root-96"
-                disabled={undefined}
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onKeyDown={[Function]}
-                onKeyUp={[Function]}
-                onMouseDown={[Function]}
-                onMouseLeave={[Function]}
-                onMouseUp={[Function]}
-                onTouchEnd={[Function]}
-                onTouchMove={[Function]}
-                onTouchStart={[Function]}
-                tabIndex="0"
-                type="button"
+              <div
+                className="MuiGrid-item-5 MuiGrid-grid-xs-3-32 MuiGrid-grid-sm-2-44"
               >
-                <img
-                  alt=""
-                  className="inject-MediaGalleryItem-with-uiStore-img-97"
-                  src="/resources/placeholder.gif"
-                />
-                <span
-                  className="MuiTouchRipple-root-101"
-                />
-              </button>
-            </div>
-            <div
-              className="MuiGrid-item-4 MuiGrid-grid-xs-3-31 MuiGrid-grid-sm-2-43"
-            >
-              <button
-                className="MuiButtonBase-root-98 inject-MediaGalleryItem-with-uiStore-root-96"
-                disabled={undefined}
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onKeyDown={[Function]}
-                onKeyUp={[Function]}
-                onMouseDown={[Function]}
-                onMouseLeave={[Function]}
-                onMouseUp={[Function]}
-                onTouchEnd={[Function]}
-                onTouchMove={[Function]}
-                onTouchStart={[Function]}
-                tabIndex="0"
-                type="button"
+                <button
+                  className="MuiButtonBase-root-99 inject-MediaGalleryItem-with-uiStore-root-97"
+                  disabled={undefined}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseUp={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchMove={[Function]}
+                  onTouchStart={[Function]}
+                  tabIndex="0"
+                  type="button"
+                >
+                  <img
+                    alt=""
+                    className="inject-MediaGalleryItem-with-uiStore-img-98"
+                    src="/resources/placeholder.gif"
+                  />
+                  <span
+                    className="MuiTouchRipple-root-102"
+                  />
+                </button>
+              </div>
+              <div
+                className="MuiGrid-item-5 MuiGrid-grid-xs-3-32 MuiGrid-grid-sm-2-44"
               >
-                <img
-                  alt=""
-                  className="inject-MediaGalleryItem-with-uiStore-img-97"
-                  src="/resources/placeholder.gif"
-                />
-                <span
-                  className="MuiTouchRipple-root-101"
-                />
-              </button>
-            </div>
-            <div
-              className="MuiGrid-item-4 MuiGrid-grid-xs-3-31 MuiGrid-grid-sm-2-43"
-            >
-              <button
-                className="MuiButtonBase-root-98 inject-MediaGalleryItem-with-uiStore-root-96"
-                disabled={undefined}
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onKeyDown={[Function]}
-                onKeyUp={[Function]}
-                onMouseDown={[Function]}
-                onMouseLeave={[Function]}
-                onMouseUp={[Function]}
-                onTouchEnd={[Function]}
-                onTouchMove={[Function]}
-                onTouchStart={[Function]}
-                tabIndex="0"
-                type="button"
+                <button
+                  className="MuiButtonBase-root-99 inject-MediaGalleryItem-with-uiStore-root-97"
+                  disabled={undefined}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseUp={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchMove={[Function]}
+                  onTouchStart={[Function]}
+                  tabIndex="0"
+                  type="button"
+                >
+                  <img
+                    alt=""
+                    className="inject-MediaGalleryItem-with-uiStore-img-98"
+                    src="/resources/placeholder.gif"
+                  />
+                  <span
+                    className="MuiTouchRipple-root-102"
+                  />
+                </button>
+              </div>
+              <div
+                className="MuiGrid-item-5 MuiGrid-grid-xs-3-32 MuiGrid-grid-sm-2-44"
               >
-                <img
-                  alt=""
-                  className="inject-MediaGalleryItem-with-uiStore-img-97"
-                  src="/resources/placeholder.gif"
-                />
-                <span
-                  className="MuiTouchRipple-root-101"
-                />
-              </button>
-            </div>
-            <div
-              className="MuiGrid-item-4 MuiGrid-grid-xs-3-31 MuiGrid-grid-sm-2-43"
-            >
-              <button
-                className="MuiButtonBase-root-98 inject-MediaGalleryItem-with-uiStore-root-96"
-                disabled={undefined}
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onKeyDown={[Function]}
-                onKeyUp={[Function]}
-                onMouseDown={[Function]}
-                onMouseLeave={[Function]}
-                onMouseUp={[Function]}
-                onTouchEnd={[Function]}
-                onTouchMove={[Function]}
-                onTouchStart={[Function]}
-                tabIndex="0"
-                type="button"
+                <button
+                  className="MuiButtonBase-root-99 inject-MediaGalleryItem-with-uiStore-root-97"
+                  disabled={undefined}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseUp={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchMove={[Function]}
+                  onTouchStart={[Function]}
+                  tabIndex="0"
+                  type="button"
+                >
+                  <img
+                    alt=""
+                    className="inject-MediaGalleryItem-with-uiStore-img-98"
+                    src="/resources/placeholder.gif"
+                  />
+                  <span
+                    className="MuiTouchRipple-root-102"
+                  />
+                </button>
+              </div>
+              <div
+                className="MuiGrid-item-5 MuiGrid-grid-xs-3-32 MuiGrid-grid-sm-2-44"
               >
-                <img
-                  alt=""
-                  className="inject-MediaGalleryItem-with-uiStore-img-97"
-                  src="/resources/placeholder.gif"
-                />
-                <span
-                  className="MuiTouchRipple-root-101"
-                />
-              </button>
-            </div>
-            <div
-              className="MuiGrid-item-4 MuiGrid-grid-xs-3-31 MuiGrid-grid-sm-2-43"
-            >
-              <button
-                className="MuiButtonBase-root-98 inject-MediaGalleryItem-with-uiStore-root-96"
-                disabled={undefined}
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onKeyDown={[Function]}
-                onKeyUp={[Function]}
-                onMouseDown={[Function]}
-                onMouseLeave={[Function]}
-                onMouseUp={[Function]}
-                onTouchEnd={[Function]}
-                onTouchMove={[Function]}
-                onTouchStart={[Function]}
-                tabIndex="0"
-                type="button"
+                <button
+                  className="MuiButtonBase-root-99 inject-MediaGalleryItem-with-uiStore-root-97"
+                  disabled={undefined}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseUp={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchMove={[Function]}
+                  onTouchStart={[Function]}
+                  tabIndex="0"
+                  type="button"
+                >
+                  <img
+                    alt=""
+                    className="inject-MediaGalleryItem-with-uiStore-img-98"
+                    src="/resources/placeholder.gif"
+                  />
+                  <span
+                    className="MuiTouchRipple-root-102"
+                  />
+                </button>
+              </div>
+              <div
+                className="MuiGrid-item-5 MuiGrid-grid-xs-3-32 MuiGrid-grid-sm-2-44"
               >
-                <img
-                  alt=""
-                  className="inject-MediaGalleryItem-with-uiStore-img-97"
-                  src="/resources/placeholder.gif"
-                />
-                <span
-                  className="MuiTouchRipple-root-101"
-                />
-              </button>
-            </div>
-            <div
-              className="MuiGrid-item-4 MuiGrid-grid-xs-3-31 MuiGrid-grid-sm-2-43"
-            >
-              <button
-                className="MuiButtonBase-root-98 inject-MediaGalleryItem-with-uiStore-root-96"
-                disabled={undefined}
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onKeyDown={[Function]}
-                onKeyUp={[Function]}
-                onMouseDown={[Function]}
-                onMouseLeave={[Function]}
-                onMouseUp={[Function]}
-                onTouchEnd={[Function]}
-                onTouchMove={[Function]}
-                onTouchStart={[Function]}
-                tabIndex="0"
-                type="button"
+                <button
+                  className="MuiButtonBase-root-99 inject-MediaGalleryItem-with-uiStore-root-97"
+                  disabled={undefined}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseUp={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchMove={[Function]}
+                  onTouchStart={[Function]}
+                  tabIndex="0"
+                  type="button"
+                >
+                  <img
+                    alt=""
+                    className="inject-MediaGalleryItem-with-uiStore-img-98"
+                    src="/resources/placeholder.gif"
+                  />
+                  <span
+                    className="MuiTouchRipple-root-102"
+                  />
+                </button>
+              </div>
+              <div
+                className="MuiGrid-item-5 MuiGrid-grid-xs-3-32 MuiGrid-grid-sm-2-44"
               >
-                <img
-                  alt=""
-                  className="inject-MediaGalleryItem-with-uiStore-img-97"
-                  src="/resources/placeholder.gif"
-                />
-                <span
-                  className="MuiTouchRipple-root-101"
-                />
-              </button>
-            </div>
-            <div
-              className="MuiGrid-item-4 MuiGrid-grid-xs-3-31 MuiGrid-grid-sm-2-43"
-            >
-              <button
-                className="MuiButtonBase-root-98 inject-MediaGalleryItem-with-uiStore-root-96"
-                disabled={undefined}
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onKeyDown={[Function]}
-                onKeyUp={[Function]}
-                onMouseDown={[Function]}
-                onMouseLeave={[Function]}
-                onMouseUp={[Function]}
-                onTouchEnd={[Function]}
-                onTouchMove={[Function]}
-                onTouchStart={[Function]}
-                tabIndex="0"
-                type="button"
+                <button
+                  className="MuiButtonBase-root-99 inject-MediaGalleryItem-with-uiStore-root-97"
+                  disabled={undefined}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseUp={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchMove={[Function]}
+                  onTouchStart={[Function]}
+                  tabIndex="0"
+                  type="button"
+                >
+                  <img
+                    alt=""
+                    className="inject-MediaGalleryItem-with-uiStore-img-98"
+                    src="/resources/placeholder.gif"
+                  />
+                  <span
+                    className="MuiTouchRipple-root-102"
+                  />
+                </button>
+              </div>
+              <div
+                className="MuiGrid-item-5 MuiGrid-grid-xs-3-32 MuiGrid-grid-sm-2-44"
               >
-                <img
-                  alt=""
-                  className="inject-MediaGalleryItem-with-uiStore-img-97"
-                  src="/resources/placeholder.gif"
-                />
-                <span
-                  className="MuiTouchRipple-root-101"
-                />
-              </button>
+                <button
+                  className="MuiButtonBase-root-99 inject-MediaGalleryItem-with-uiStore-root-97"
+                  disabled={undefined}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseUp={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchMove={[Function]}
+                  onTouchStart={[Function]}
+                  tabIndex="0"
+                  type="button"
+                >
+                  <img
+                    alt=""
+                    className="inject-MediaGalleryItem-with-uiStore-img-98"
+                    src="/resources/placeholder.gif"
+                  />
+                  <span
+                    className="MuiTouchRipple-root-102"
+                  />
+                </button>
+              </div>
+              <div
+                className="MuiGrid-item-5 MuiGrid-grid-xs-3-32 MuiGrid-grid-sm-2-44"
+              >
+                <button
+                  className="MuiButtonBase-root-99 inject-MediaGalleryItem-with-uiStore-root-97"
+                  disabled={undefined}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseUp={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchMove={[Function]}
+                  onTouchStart={[Function]}
+                  tabIndex="0"
+                  type="button"
+                >
+                  <img
+                    alt=""
+                    className="inject-MediaGalleryItem-with-uiStore-img-98"
+                    src="/resources/placeholder.gif"
+                  />
+                  <span
+                    className="MuiTouchRipple-root-102"
+                  />
+                </button>
+              </div>
             </div>
           </div>
         </div>
       </div>
+      <div
+        className="ProductDetail-section-3"
+      >
+        <section>
+          <h2
+            className="MuiTypography-root-111 MuiTypography-title-117 TagGrid-title-109"
+          >
+            Tags
+          </h2>
+          <div
+            className="MuiGrid-container-4 MuiGrid-spacing-xs-8-25"
+          >
+            <div
+              className="MuiGrid-item-5"
+            >
+              <a
+                className="Link-link-135"
+                href="/tag/shoes"
+                onClick={[Function]}
+              >
+                <div
+                  className="MuiChip-root-136 TagGrid-chip-110"
+                  onClick={undefined}
+                  onKeyDown={[Function]}
+                  role="button"
+                  tabIndex={-1}
+                >
+                  <span
+                    className="MuiChip-label-141"
+                  >
+                    Shoes
+                  </span>
+                </div>
+              </a>
+            </div>
+            <div
+              className="MuiGrid-item-5"
+            >
+              <a
+                className="Link-link-135"
+                href="/tag/shop"
+                onClick={[Function]}
+              >
+                <div
+                  className="MuiChip-root-136 TagGrid-chip-110"
+                  onClick={undefined}
+                  onKeyDown={[Function]}
+                  role="button"
+                  tabIndex={-1}
+                >
+                  <span
+                    className="MuiChip-label-141"
+                  >
+                    Shop
+                  </span>
+                </div>
+              </a>
+            </div>
+          </div>
+        </section>
+      </div>
     </div>
     <div
-      className="MuiGrid-item-4 MuiGrid-grid-xs-12-40 MuiGrid-grid-sm-6-47"
+      className="MuiGrid-item-5 MuiGrid-grid-xs-12-41 MuiGrid-grid-sm-6-48"
     >
       <div
-        className="MuiGrid-item-4 MuiGrid-grid-sm-12-53"
+        className="MuiGrid-item-5 MuiGrid-grid-sm-12-54"
       >
         <h1
-          className="MuiTypography-root-108 MuiTypography-display2-111 MuiTypography-gutterBottom-125"
+          className="MuiTypography-root-111 MuiTypography-display2-114 MuiTypography-gutterBottom-128"
         >
           Reaction Sample Product
         </h1>
       </div>
       <div
-        className="MuiGrid-item-4 MuiGrid-grid-sm-12-53"
+        className="MuiGrid-item-5 MuiGrid-grid-sm-12-54"
       >
         <div
-          className="MuiTypography-root-108 MuiTypography-title-114 MuiTypography-gutterBottom-125"
+          className="MuiTypography-root-111 MuiTypography-title-117 MuiTypography-gutterBottom-128"
         >
           $12.99 - $330
         </div>
         <p
-          className="MuiTypography-root-108 MuiTypography-body1-117"
+          className="MuiTypography-root-111 MuiTypography-body1-120"
         >
           Example Manufacturer
         </p>
         <p
-          className="MuiTypography-root-108 MuiTypography-body1-117"
+          className="MuiTypography-root-111 MuiTypography-body1-120"
         >
           Sign in as administrator to edit.
 You can clone this product from the product grid.
@@ -311,13 +376,13 @@ Details can be added below the image for more specific product information.
         </p>
       </div>
       <ul
-        className="VariantList-variantsList-132"
+        className="VariantList-variantsList-143"
       >
         <li
-          className="VariantList-variantItem-133"
+          className="VariantList-variantItem-144"
         >
           <button
-            className="MuiButtonBase-root-98 VariantItem-variantButton-134 VariantItem-activeVariant-135"
+            className="MuiButtonBase-root-99 VariantItem-variantButton-145 VariantItem-activeVariant-146"
             disabled={undefined}
             onBlur={[Function]}
             onClick={[Function]}
@@ -334,20 +399,20 @@ Details can be added below the image for more specific product information.
             type="button"
           >
             <span
-              className="MuiTypography-root-108 MuiTypography-body1-117"
+              className="MuiTypography-root-111 MuiTypography-body1-120"
             >
               Sample Variant
             </span>
             <span
-              className="MuiTypography-root-108 MuiTypography-body1-117"
+              className="MuiTypography-root-111 MuiTypography-body1-120"
             />
           </button>
         </li>
         <li
-          className="VariantList-variantItem-133"
+          className="VariantList-variantItem-144"
         >
           <button
-            className="MuiButtonBase-root-98 VariantItem-variantButton-134"
+            className="MuiButtonBase-root-99 VariantItem-variantButton-145"
             disabled={undefined}
             onBlur={[Function]}
             onClick={[Function]}
@@ -364,12 +429,12 @@ Details can be added below the image for more specific product information.
             type="button"
           >
             <span
-              className="MuiTypography-root-108 MuiTypography-body1-117"
+              className="MuiTypography-root-111 MuiTypography-body1-120"
             >
               Sample Variant 2
             </span>
             <span
-              className="MuiTypography-root-108 MuiTypography-body1-117"
+              className="MuiTypography-root-111 MuiTypography-body1-120"
             />
           </button>
         </li>

--- a/src/components/TagGrid/TagGrid.js
+++ b/src/components/TagGrid/TagGrid.js
@@ -3,8 +3,8 @@ import PropTypes from "prop-types";
 import { withStyles } from "material-ui/styles";
 import Chip from "material-ui/Chip";
 import Typography from "material-ui/Typography";
-import Link from "components/Link";
 import Grid from "material-ui/Grid";
+import Link from "components/Link";
 
 const styles = (theme) => ({
   title: {

--- a/src/components/TagGrid/TagGrid.js
+++ b/src/components/TagGrid/TagGrid.js
@@ -1,0 +1,65 @@
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+import { withStyles } from "material-ui/styles";
+import Chip from "material-ui/Chip";
+import Typography from "material-ui/Typography";
+import Link from "components/Link";
+import Grid from "material-ui/Grid";
+
+const styles = (theme) => ({
+  title: {
+    marginBottom: theme.spacing.unit
+  },
+  chip: {
+    cursor: "pointer"
+  }
+});
+
+/**
+ * Tag grid - displays a grid of tags
+ */
+@withStyles(styles, { withTheme: true })
+export default class TagGrid extends Component {
+  static propTypes = {
+    /**
+     * CSS class names
+     */
+    classes: PropTypes.object,
+
+    /**
+     * Array of tag nodes [{ node: Object }]
+     */
+    tags: PropTypes.array,
+
+    /**
+     * Theme
+     */
+    theme: PropTypes.object
+  }
+
+  render() {
+    const {
+      classes,
+      tags,
+      theme
+    } = this.props;
+
+
+    if (!Array.isArray(tags)) return null;
+
+    return (
+      <section>
+        <Typography className={classes.title} variant="title">{"Tags"}</Typography>
+        <Grid container spacing={theme.spacing.unit}>
+          {tags.map(({ node: tag }, index) => (
+            <Grid item>
+              <Link route={`/tag/${tag.slug}`}>
+                <Chip className={classes.chip} key={index} label={tag.name} />
+              </Link>
+            </Grid>
+          ))}
+        </Grid>
+      </section>
+    );
+  }
+}

--- a/src/components/TagGrid/TagGrid.test.js
+++ b/src/components/TagGrid/TagGrid.test.js
@@ -1,0 +1,28 @@
+import React from "react";
+import renderer from "react-test-renderer";
+import TagGrid from "./TagGrid";
+
+const tags = [
+  {
+    node: {
+      position: null,
+      name: "Shoes",
+      slug: "shoes"
+    }
+  },
+  {
+    node: {
+      position: null,
+      name: "Shop",
+      slug: "shop"
+    }
+  }
+];
+
+test("basic snapshot", () => {
+  const component = renderer.create((
+    <TagGrid tags={tags} />
+  ));
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});

--- a/src/components/TagGrid/__snapshots__/TagGrid.test.js.snap
+++ b/src/components/TagGrid/__snapshots__/TagGrid.test.js.snap
@@ -1,0 +1,61 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`basic snapshot 1`] = `
+<section>
+  <h2
+    className="MuiTypography-root-3 MuiTypography-title-9 TagGrid-title-1"
+  >
+    Tags
+  </h2>
+  <div
+    className="MuiGrid-container-27 MuiGrid-spacing-xs-8-48"
+  >
+    <div
+      className="MuiGrid-item-28"
+    >
+      <a
+        className="Link-link-117"
+        href="/tag/shoes"
+        onClick={[Function]}
+      >
+        <div
+          className="MuiChip-root-118 TagGrid-chip-2"
+          onClick={undefined}
+          onKeyDown={[Function]}
+          role="button"
+          tabIndex={-1}
+        >
+          <span
+            className="MuiChip-label-123"
+          >
+            Shoes
+          </span>
+        </div>
+      </a>
+    </div>
+    <div
+      className="MuiGrid-item-28"
+    >
+      <a
+        className="Link-link-117"
+        href="/tag/shop"
+        onClick={[Function]}
+      >
+        <div
+          className="MuiChip-root-118 TagGrid-chip-2"
+          onClick={undefined}
+          onKeyDown={[Function]}
+          role="button"
+          tabIndex={-1}
+        >
+          <span
+            className="MuiChip-label-123"
+          >
+            Shop
+          </span>
+        </div>
+      </a>
+    </div>
+  </div>
+</section>
+`;

--- a/src/components/TagGrid/index.js
+++ b/src/components/TagGrid/index.js
@@ -1,0 +1,1 @@
+export { default } from "./TagGrid";


### PR DESCRIPTION
Issue: #27 
Impact: **minor**
Type: **feat**

## Issue

Create a component that displays product tags

## Solution

- Create a component that displays product tags using the `Chip` component.

## Testing

- Start the app and go to `http://localhost:4000/product/example-product`
- See the tag grid to the left with sample tags
- Clicking on a tag should take you to a URL like `/tags/<tag-slug>`

![screen shot 2018-04-26 at 3 18 58 pm](https://user-images.githubusercontent.com/42217/39334829-2fd6b600-4965-11e8-9544-1374be5797b7.png)
