### PR TITLE
fix: helmet name undefined when shop name and description not set

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -28,8 +28,8 @@ class Shop extends Component {
 
     return (
       <Helmet>
-        <title>{shop.name}</title>
-        <meta name="description" content={shop.description} />
+        <title>{shop && shop.name}</title>
+        <meta name="description" content={shop && shop.description} />
       </Helmet>
     );
   }


### PR DESCRIPTION
App would not load correctly if shop name and description were not saved to DB.

This fix checks to make sure that those fields exist before trying to display.