### PR TITLE
Add inventory status badges to variants and options

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "graphql-tag": "^2.8.0",
     "isomorphic-fetch": "^2.2.1",
     "js-cookie": "^2.2.0",
+    "keymirror": "^0.1.1",
     "material-ui": "^1.0.0-beta.41",
     "mdi-material-ui": "^3.2.0",
     "mobx": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -30,9 +30,9 @@
     ]
   },
   "dependencies": {
-    "apollo-cache-inmemory": "^1.1.9",
-    "apollo-client": "^2.2.5",
-    "apollo-link-http": "^1.5.1",
+    "apollo-cache-inmemory": "^1.1.11",
+    "apollo-client": "^2.2.7",
+    "apollo-link-http": "^1.5.4",
     "body-parser": "^1.18.2",
     "chalk": "^2.3.2",
     "classnames": "^2.2.5",
@@ -42,7 +42,7 @@
     "isomorphic-fetch": "^2.2.1",
     "js-cookie": "^2.2.0",
     "keymirror": "^0.1.1",
-    "material-ui": "^1.0.0-beta.41",
+    "material-ui": "^1.0.0-beta.44",
     "mdi-material-ui": "^3.2.0",
     "mobx": "^4.1.1",
     "mobx-react": "^5.0.0",
@@ -52,7 +52,7 @@
     "passport-cookie": "^1.0.6",
     "prop-types": "^15.6.1",
     "react": "^16.3.0",
-    "react-apollo": "^2.1.2",
+    "react-apollo": "^2.1.3",
     "react-dom": "^16.3.0",
     "react-helmet": "^5.2.0"
   },

--- a/src/components/Badge/Badge.js
+++ b/src/components/Badge/Badge.js
@@ -10,10 +10,10 @@ const styles = (theme) => ({
     borderRadius: 4,
     height: "auto",
     fontSize: "0.7rem",
-    paddingBottom: theme.spacing.unit * 0.5,
+    paddingBottom: theme.spacing.unithalf,
     paddingLeft: theme.spacing.unit,
     paddingRight: theme.spacing.unit,
-    paddingTop: theme.spacing.unit * 0.5,
+    paddingTop: theme.spacing.unithalf,
     position: "absolute",
     zIndex: 100
   },
@@ -37,7 +37,7 @@ const styles = (theme) => ({
     backgroundColor: theme.palette.error.main
   },
   bestseller: {
-    backgroundColor: theme.palette.primary.light
+    backgroundColor: theme.palette.reaction.bestseller
   },
   warning: {
     backgroundColor: "transparent",
@@ -61,7 +61,7 @@ export default class Badge extends Component {
   render() {
     const {
       classes: {
-        badge, status, labelStyle, soldOut, backorder, warning, alignRight
+        alignRight, badge, backorder, bestseller, sale, status, labelStyle, soldOut, warning
       },
       className,
       type,
@@ -70,9 +70,11 @@ export default class Badge extends Component {
 
     const badgeClasses = classNames(
       badge,
-      { [status]: type === INVENTORY_STATUS.SOLD_OUT || type === INVENTORY_STATUS.BACKORDER },
-      { [soldOut]: type === INVENTORY_STATUS.SOLD_OUT },
       { [backorder]: type === INVENTORY_STATUS.BACKORDER },
+      { [bestseller]: type === INVENTORY_STATUS.BESTSELLER },
+      { [sale]: type === INVENTORY_STATUS.SALE },
+      { [status]: type !== INVENTORY_STATUS.LOW_QUANTITY },
+      { [soldOut]: type === INVENTORY_STATUS.SOLD_OUT },
       { [alignRight]: type === INVENTORY_STATUS.LOW_QUANTITY },
       className
     );

--- a/src/components/Badge/Badge.js
+++ b/src/components/Badge/Badge.js
@@ -2,6 +2,7 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import classNames from "classnames";
 import { withStyles } from "material-ui/styles";
+import { INVENTORY_STATUS } from "lib/utils";
 
 const styles = (theme) => ({
   badge: {
@@ -40,7 +41,7 @@ const styles = (theme) => ({
   },
   warning: {
     backgroundColor: "transparent",
-    top: theme.spacing.unit
+    color: theme.palette.secondary.main
   },
   alignRight: {
     right: 0
@@ -69,16 +70,16 @@ export default class Badge extends Component {
 
     const badgeClasses = classNames(
       badge,
-      { [status]: type === "backorder" || type === "sold_out" },
-      { [soldOut]: type === "sold_out" },
-      { [backorder]: type === "backorder" },
-      { [alignRight]: type === "low_inventory" },
+      { [status]: type === INVENTORY_STATUS.SOLD_OUT || type === INVENTORY_STATUS.BACKORDER },
+      { [soldOut]: type === INVENTORY_STATUS.SOLD_OUT },
+      { [backorder]: type === INVENTORY_STATUS.BACKORDER },
+      { [alignRight]: type === INVENTORY_STATUS.LOW_QUANTITY },
       className
     );
 
     const labelClasses = classNames(
       labelStyle,
-      { [warning]: type === "low_inventory" }
+      { [warning]: type === INVENTORY_STATUS.LOW_QUANTITY }
     );
 
     return (

--- a/src/components/Badge/Badge.js
+++ b/src/components/Badge/Badge.js
@@ -1,0 +1,90 @@
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+import classNames from "classnames";
+import { withStyles } from "material-ui/styles";
+
+const styles = (theme) => ({
+  badge: {
+    ...theme.typography.caption,
+    borderRadius: 4,
+    height: "auto",
+    fontSize: "0.7rem",
+    paddingBottom: theme.spacing.unit * 0.5,
+    paddingLeft: theme.spacing.unit,
+    paddingRight: theme.spacing.unit,
+    paddingTop: theme.spacing.unit * 0.5,
+    position: "absolute",
+    zIndex: 100
+  },
+  labelStyle: {
+    fontWeight: theme.typography.fontWeightBold,
+    position: "relative",
+    padding: 0
+  },
+  status: {
+    color: theme.palette.primary.contrastText,
+    left: theme.spacing.unit,
+    top: theme.spacing.unit
+  },
+  soldOut: {
+    backgroundColor: theme.palette.secondary.main
+  },
+  backorder: {
+    backgroundColor: theme.palette.secondary.dark
+  },
+  sale: {
+    backgroundColor: theme.palette.error.main
+  },
+  bestseller: {
+    backgroundColor: theme.palette.primary.light
+  },
+  warning: {
+    backgroundColor: "transparent",
+    top: theme.spacing.unit
+  },
+  alignRight: {
+    right: 0
+  }
+});
+
+@withStyles(styles)
+export default class Badge extends Component {
+  static propTypes = {
+    className: PropTypes.string,
+    classes: PropTypes.object,
+    isLowInventory: PropTypes.bool,
+    label: PropTypes.string,
+    type: PropTypes.string
+  }
+
+  render() {
+    const {
+      classes: {
+        badge, status, labelStyle, soldOut, backorder, warning, alignRight
+      },
+      className,
+      type,
+      label
+    } = this.props;
+
+    const badgeClasses = classNames(
+      badge,
+      { [status]: type === "backorder" || type === "sold_out" },
+      { [soldOut]: type === "sold_out" },
+      { [backorder]: type === "backorder" },
+      { [alignRight]: type === "low_inventory" },
+      className
+    );
+
+    const labelClasses = classNames(
+      labelStyle,
+      { [warning]: type === "low_inventory" }
+    );
+
+    return (
+      <div className={badgeClasses}>
+        <span className={labelClasses}>{label}</span>
+      </div>
+    );
+  }
+}

--- a/src/components/Badge/Badge.js
+++ b/src/components/Badge/Badge.js
@@ -52,36 +52,36 @@ const styles = (theme) => ({
 export default class Badge extends Component {
   static propTypes = {
     className: PropTypes.string,
-    classes: PropTypes.object,
+    classes: PropTypes.object.isRequired,
     isLowInventory: PropTypes.bool,
-    label: PropTypes.string,
-    type: PropTypes.string
+    label: PropTypes.string.isRequired,
+    type: PropTypes.string.isRequired
   }
 
   render() {
     const {
-      classes: {
-        alignRight, badge, backorder, bestseller, sale, status, labelStyle, soldOut, warning
-      },
+      classes,
       className,
       type,
       label
     } = this.props;
 
     const badgeClasses = classNames(
-      badge,
-      { [backorder]: type === INVENTORY_STATUS.BACKORDER },
-      { [bestseller]: type === INVENTORY_STATUS.BESTSELLER },
-      { [sale]: type === INVENTORY_STATUS.SALE },
-      { [status]: type !== INVENTORY_STATUS.LOW_QUANTITY },
-      { [soldOut]: type === INVENTORY_STATUS.SOLD_OUT },
-      { [alignRight]: type === INVENTORY_STATUS.LOW_QUANTITY },
+      classes.badge,
+      {
+        [classes.backorder]: type === INVENTORY_STATUS.BACKORDER,
+        [classes.bestseller]: type === INVENTORY_STATUS.BESTSELLER,
+        [classes.sale]: type === INVENTORY_STATUS.SALE,
+        [classes.status]: type !== INVENTORY_STATUS.LOW_QUANTITY,
+        [classes.soldOut]: type === INVENTORY_STATUS.SOLD_OUT,
+        [classes.alignRight]: type === INVENTORY_STATUS.LOW_QUANTITY
+      },
       className
     );
 
     const labelClasses = classNames(
-      labelStyle,
-      { [warning]: type === INVENTORY_STATUS.LOW_QUANTITY }
+      classes.labelStyle,
+      { [classes.warning]: type === INVENTORY_STATUS.LOW_QUANTITY }
     );
 
     return (

--- a/src/components/Badge/Badge.js
+++ b/src/components/Badge/Badge.js
@@ -20,6 +20,7 @@ const styles = (theme) => ({
   labelStyle: {
     fontWeight: theme.typography.fontWeightBold,
     position: "relative",
+    whiteSpace: "nowrap",
     padding: 0
   },
   status: {

--- a/src/components/Badge/Badge.test.js
+++ b/src/components/Badge/Badge.test.js
@@ -1,0 +1,16 @@
+import React from "react";
+import renderer from "react-test-renderer";
+import { MuiThemeProvider } from "material-ui/styles";
+import theme from "lib/theme/reactionTheme";
+import Badge from "./Badge";
+import badge from "./__mocks__/badge.mock";
+
+test("basic snapshot", () => {
+  const component = renderer.create((
+    <MuiThemeProvider theme={theme}>
+      <Badge type={badge.type} label={badge.label} />
+    </MuiThemeProvider>
+  ));
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});

--- a/src/components/Badge/__mocks__/badge.mock.js
+++ b/src/components/Badge/__mocks__/badge.mock.js
@@ -1,0 +1,6 @@
+import { INVENTORY_STATUS } from "lib/utils";
+
+export default {
+  type: INVENTORY_STATUS.SALE,
+  label: "Sale"
+};

--- a/src/components/Badge/__snapshots__/Badge.test.js.snap
+++ b/src/components/Badge/__snapshots__/Badge.test.js.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`basic snapshot 1`] = `
+<div
+  className="Badge-badge-1 Badge-sale-6 Badge-status-3"
+>
+  <span
+    className="Badge-labelStyle-2"
+  >
+    Sale
+  </span>
+</div>
+`;

--- a/src/components/Badge/index.js
+++ b/src/components/Badge/index.js
@@ -1,0 +1,1 @@
+export { default } from "./Badge";

--- a/src/components/ProductDetail/__mocks__/productData.mock.js
+++ b/src/components/ProductDetail/__mocks__/productData.mock.js
@@ -44,6 +44,9 @@ export default {
       title: "Sample Variant",
       price: 19.99,
       optionTitle: "Untitled Option",
+      isLowQuantity: false,
+      isSoldOut: true,
+      isBackorder: false,
       options: [
         {
           _id: "cmVhY3Rpb24vY2F0YWxvZ1Byb2R1Y3RWYXJpYW50OlNNcjRyaERGbll2Rk10RFRY",
@@ -53,7 +56,10 @@ export default {
           ],
           title: "Option 1 - Red Dwarf",
           price: 19.99,
-          optionTitle: "Red"
+          optionTitle: "Red",
+          isLowQuantity: false,
+          isSoldOut: true,
+          isBackorder: true
         },
         {
           _id: "cmVhY3Rpb24vY2F0YWxvZ1Byb2R1Y3RWYXJpYW50OkNKb1JCbTl2UnJvcmM5bXha",
@@ -63,7 +69,10 @@ export default {
           ],
           title: "Option 2 - Green Tomato",
           price: 12.99,
-          optionTitle: "Green"
+          optionTitle: "Green",
+          isLowQuantity: false,
+          isSoldOut: false,
+          isBackorder: false
         }
 
       ]
@@ -76,6 +85,9 @@ export default {
       title: "Sample Variant 2",
       price: 10.99,
       optionTitle: "Untitled Option",
+      isLowQuantity: false,
+      isSoldOut: false,
+      isBackorder: false,
       options: [
         {
           _id: "cmVhY3Rpb24vY2F0YWxvZ1Byb2R1Y3RWYXJpYW50OkhaUHFmaVBIV0xabWZ1aHZp",
@@ -85,7 +97,10 @@ export default {
           ],
           title: "Sample Variant 2 - Blue Option",
           price: 200,
-          optionTitle: "Blue"
+          optionTitle: "Blue",
+          isLowQuantity: false,
+          isSoldOut: false,
+          isBackorder: false
         },
         {
           _id: "cmVhY3Rpb24vY2F0YWxvZ1Byb2R1Y3RWYXJpYW50Old5em43emZhQkFYS1hja3BT",
@@ -95,7 +110,10 @@ export default {
           ],
           title: "Sample Variant 2 - Red Option",
           price: 330,
-          optionTitle: "Red"
+          optionTitle: "Red",
+          isLowQuantity: false,
+          isSoldOut: false,
+          isBackorder: false
         }
 
       ]

--- a/src/components/ProductDetail/__snapshots__/ProductDetail.test.js.snap
+++ b/src/components/ProductDetail/__snapshots__/ProductDetail.test.js.snap
@@ -382,7 +382,7 @@ Details can be added below the image for more specific product information.
           className="VariantList-variantItem-144"
         >
           <button
-            className="MuiButtonBase-root-99 VariantItem-variantButton-145 VariantItem-activeVariant-146"
+            className="MuiButtonBase-root-99 VariantItem-variantButton-146 VariantItem-activeVariant-147"
             disabled={undefined}
             onBlur={[Function]}
             onClick={[Function]}
@@ -407,12 +407,25 @@ Details can be added below the image for more specific product information.
               className="MuiTypography-root-111 MuiTypography-body1-120"
             />
           </button>
+          <div
+            className="VariantList-alert-145"
+          >
+            <div
+              className="Badge-badge-148 Badge-status-150 Badge-soldOut-151"
+            >
+              <span
+                className="Badge-labelStyle-149"
+              >
+                Sold Out
+              </span>
+            </div>
+          </div>
         </div>
         <div
           className="VariantList-variantItem-144"
         >
           <button
-            className="MuiButtonBase-root-99 VariantItem-variantButton-145"
+            className="MuiButtonBase-root-99 VariantItem-variantButton-146"
             disabled={undefined}
             onBlur={[Function]}
             onClick={[Function]}
@@ -439,28 +452,28 @@ Details can be added below the image for more specific product information.
           </button>
         </div>
         <div
-          className="Divider-container-147"
+          className="Divider-container-157"
         >
           <hr
-            className="Divider-item-149"
+            className="Divider-item-159"
           />
           <span
-            className="MuiTypography-root-111 MuiTypography-body1-120 Divider-label-148"
+            className="MuiTypography-root-111 MuiTypography-body1-120 Divider-label-158"
           >
             Available Options
           </span>
           <hr
-            className="Divider-item-149"
+            className="Divider-item-159"
           />
         </div>
         <div
-          className="MuiGrid-container-4 MuiGrid-spacing-xs-8-25 OptionsList-root-150"
+          className="MuiGrid-container-4 MuiGrid-spacing-xs-8-25 OptionsList-root-160"
         >
           <div
             className="MuiGrid-item-5"
           >
             <button
-              className="MuiButtonBase-root-99 ProductDetailOption-optionButton-151"
+              className="MuiButtonBase-root-99 ProductDetailOption-optionButton-163"
               disabled={undefined}
               onBlur={[Function]}
               onClick={[Function]}
@@ -477,17 +490,30 @@ Details can be added below the image for more specific product information.
               type="button"
             >
               <span
-                className="MuiTypography-root-111 MuiTypography-body1-120 ProductDetailOption-optionText-152"
+                className="MuiTypography-root-111 MuiTypography-body1-120 ProductDetailOption-optionText-164"
               >
                 Red
               </span>
             </button>
+            <div
+              className="OptionsList-alert-161"
+            >
+              <div
+                className="Badge-badge-148 Badge-backorder-152 Badge-status-150 OptionsList-badge-162"
+              >
+                <span
+                  className="Badge-labelStyle-149"
+                >
+                  Backorder
+                </span>
+              </div>
+            </div>
           </div>
           <div
             className="MuiGrid-item-5"
           >
             <button
-              className="MuiButtonBase-root-99 ProductDetailOption-optionButton-151"
+              className="MuiButtonBase-root-99 ProductDetailOption-optionButton-163"
               disabled={undefined}
               onBlur={[Function]}
               onClick={[Function]}
@@ -504,7 +530,7 @@ Details can be added below the image for more specific product information.
               type="button"
             >
               <span
-                className="MuiTypography-root-111 MuiTypography-body1-120 ProductDetailOption-optionText-152"
+                className="MuiTypography-root-111 MuiTypography-body1-120 ProductDetailOption-optionText-164"
               >
                 Green
               </span>

--- a/src/components/ProductDetailOptionsList/ProductDetailOptionsList.js
+++ b/src/components/ProductDetailOptionsList/ProductDetailOptionsList.js
@@ -5,12 +5,25 @@ import { withStyles } from "material-ui/styles";
 import { observable, action, computed } from "mobx";
 import { observer } from "mobx-react";
 import { Router } from "routes";
+import Badge from "components/Badge";
+import { inventoryStatus } from "lib/utils";
 import ProductDetailOption from "components/ProductDetailOption";
 
 const styles = (theme) => ({
   root: {
+    position: "relative",
     marginTop: theme.spacing.unit,
     marginBottom: theme.spacing.unit
+  },
+  alert: {
+    display: "flex",
+    top: -theme.spacing.unit * 2,
+    right: theme.spacing.unit * 1
+  },
+  badge: {
+    fontSize: "0.5rem",
+    top: -theme.spacing.unit,
+    left: theme.spacing.unit * 11
   }
 });
 
@@ -45,6 +58,19 @@ export default class OptionsList extends Component {
     });
   }
 
+  renderInventoryStatus(option) {
+    const { classes } = this.props;
+    const status = inventoryStatus(option);
+
+    if (!status) return null;
+
+    return (
+      <div className={classes.alert}>
+        <Badge className={classes.badge} type={status.type} label={status.label} />
+      </div>
+    );
+  }
+
   render() {
     const { classes: { root }, options, theme } = this.props;
 
@@ -59,6 +85,7 @@ export default class OptionsList extends Component {
               selectedOption={this.selectedOption}
               option={option}
             />
+            {this.renderInventoryStatus(option)}
           </Grid>
         ))
         }

--- a/src/components/ProductDetailOptionsList/__snapshots__/ProductDetailOptionsList.test.js.snap
+++ b/src/components/ProductDetailOptionsList/__snapshots__/ProductDetailOptionsList.test.js.snap
@@ -2,13 +2,13 @@
 
 exports[`basic snapshot 1`] = `
 <div
-  className="MuiGrid-container-2 MuiGrid-spacing-xs-8-23 OptionsList-root-1"
+  className="MuiGrid-container-4 MuiGrid-spacing-xs-8-25 OptionsList-root-1"
 >
   <div
-    className="MuiGrid-item-3"
+    className="MuiGrid-item-5"
   >
     <button
-      className="MuiButtonBase-root-95 ProductDetailOption-optionButton-92"
+      className="MuiButtonBase-root-97 ProductDetailOption-optionButton-94"
       disabled={undefined}
       onBlur={[Function]}
       onClick={[Function]}
@@ -25,17 +25,17 @@ exports[`basic snapshot 1`] = `
       type="button"
     >
       <span
-        className="MuiTypography-root-98 MuiTypography-body1-107 ProductDetailOption-optionText-93"
+        className="MuiTypography-root-100 MuiTypography-body1-109 ProductDetailOption-optionText-95"
       >
         Blue
       </span>
     </button>
   </div>
   <div
-    className="MuiGrid-item-3"
+    className="MuiGrid-item-5"
   >
     <button
-      className="MuiButtonBase-root-95 ProductDetailOption-optionButton-92"
+      className="MuiButtonBase-root-97 ProductDetailOption-optionButton-94"
       disabled={undefined}
       onBlur={[Function]}
       onClick={[Function]}
@@ -52,7 +52,7 @@ exports[`basic snapshot 1`] = `
       type="button"
     >
       <span
-        className="MuiTypography-root-98 MuiTypography-body1-107 ProductDetailOption-optionText-93"
+        className="MuiTypography-root-100 MuiTypography-body1-109 ProductDetailOption-optionText-95"
       >
         Red
       </span>

--- a/src/components/ProductGrid/ProductGrid.test.js
+++ b/src/components/ProductGrid/ProductGrid.test.js
@@ -1,6 +1,8 @@
 import React from "react";
 import renderer from "react-test-renderer";
 import { Provider } from "mobx-react";
+import { MuiThemeProvider } from "material-ui/styles";
+import theme from "lib/theme/reactionTheme";
 import ProductGrid from "./ProductGrid";
 import products from "./__mocks__/products.mock";
 
@@ -14,9 +16,11 @@ const uiStore = {
 
 test("basic snapshot", () => {
   const component = renderer.create((
-    <Provider uiStore={uiStore}>
-      <ProductGrid catalogItems={products} primaryShopId="123" />
-    </Provider>
+    <MuiThemeProvider theme={theme}>
+      <Provider uiStore={uiStore}>
+        <ProductGrid catalogItems={products} primaryShopId="123" />
+      </Provider>
+    </MuiThemeProvider>
   ));
   const tree = component.toJSON();
   expect(tree).toMatchSnapshot();

--- a/src/components/ProductGrid/__snapshots__/ProductGrid.test.js.snap
+++ b/src/components/ProductGrid/__snapshots__/ProductGrid.test.js.snap
@@ -10,7 +10,7 @@ exports[`basic snapshot 1`] = `
     >
       <div>
         <a
-          className="Link-link-106"
+          className="Link-link-98"
           href="/product/men's-lightweigth-synchilla"
           onClick={[Function]}
         >
@@ -18,14 +18,10 @@ exports[`basic snapshot 1`] = `
             className="inject-ProductItem-with-uiStore-productMedia-93"
           >
             <div
-              className="MuiChip-root-107 inject-ProductItem-with-uiStore-chip-94 inject-ProductItem-with-uiStore-status-96 inject-ProductItem-with-uiStore-statusSoldOut-97"
-              onClick={undefined}
-              onKeyDown={[Function]}
-              role="button"
-              tabIndex={-1}
+              className="Badge-badge-99 Badge-status-101 Badge-soldOut-102"
             >
               <span
-                className="MuiChip-label-112 inject-ProductItem-with-uiStore-chipLabel-95"
+                className="Badge-labelStyle-100"
               >
                 Sold Out
               </span>
@@ -52,17 +48,17 @@ exports[`basic snapshot 1`] = `
               />
               <img
                 alt=""
-                className="inject-ProductItem-with-uiStore-img-102"
+                className="inject-ProductItem-with-uiStore-img-94"
                 onLoad={[Function]}
                 src="http://localhost:3000/assets/files/Media/aHEWna7yeBvNFM9bL/small/25580_CICN.png"
               />
             </picture>
             <div
-              className="inject-ProductItem-with-uiStore-imgLoading-103"
+              className="inject-ProductItem-with-uiStore-imgLoading-95"
             >
               <svg
                 aria-hidden="true"
-                className="MuiSvgIcon-root-138 inject-ProductItem-with-uiStore-loadingIcon-104"
+                className="MuiSvgIcon-root-132 inject-ProductItem-with-uiStore-loadingIcon-96"
                 color={undefined}
                 focusable="false"
                 viewBox="0 0 24 24"
@@ -78,12 +74,12 @@ exports[`basic snapshot 1`] = `
               className="inject-ProductItem-with-uiStore-productInfo-92"
             >
               <aside
-                className="MuiTypography-root-114 MuiTypography-body2-122"
+                className="MuiTypography-root-108 MuiTypography-body2-116"
               >
                 Men's Lightweigth Synchilla
               </aside>
               <p
-                className="MuiTypography-root-114 MuiTypography-body1-123"
+                className="MuiTypography-root-108 MuiTypography-body1-117"
               >
                 $
                 7.99 - 77.99
@@ -91,7 +87,7 @@ exports[`basic snapshot 1`] = `
             </div>
             <div>
               <p
-                className="MuiTypography-root-114 MuiTypography-body1-123"
+                className="MuiTypography-root-108 MuiTypography-body1-117"
               >
                 Patagonia
               </p>
@@ -105,7 +101,7 @@ exports[`basic snapshot 1`] = `
     >
       <div>
         <a
-          className="Link-link-106"
+          className="Link-link-98"
           href="/product/example-product"
           onClick={[Function]}
         >
@@ -134,17 +130,17 @@ exports[`basic snapshot 1`] = `
               />
               <img
                 alt=""
-                className="inject-ProductItem-with-uiStore-img-102"
+                className="inject-ProductItem-with-uiStore-img-94"
                 onLoad={[Function]}
                 src="http://localhost:3000/assets/files/Media/mmY4m9gwPK2uFEZ8w/small/product_image.png"
               />
             </picture>
             <div
-              className="inject-ProductItem-with-uiStore-imgLoading-103"
+              className="inject-ProductItem-with-uiStore-imgLoading-95"
             >
               <svg
                 aria-hidden="true"
-                className="MuiSvgIcon-root-138 inject-ProductItem-with-uiStore-loadingIcon-104"
+                className="MuiSvgIcon-root-132 inject-ProductItem-with-uiStore-loadingIcon-96"
                 color={undefined}
                 focusable="false"
                 viewBox="0 0 24 24"
@@ -160,12 +156,12 @@ exports[`basic snapshot 1`] = `
               className="inject-ProductItem-with-uiStore-productInfo-92"
             >
               <aside
-                className="MuiTypography-root-114 MuiTypography-body2-122"
+                className="MuiTypography-root-108 MuiTypography-body2-116"
               >
                 Basic Reaction Product
               </aside>
               <p
-                className="MuiTypography-root-114 MuiTypography-body1-123"
+                className="MuiTypography-root-108 MuiTypography-body1-117"
               >
                 $
                 12.99 - 19.99
@@ -173,7 +169,7 @@ exports[`basic snapshot 1`] = `
             </div>
             <div>
               <p
-                className="MuiTypography-root-114 MuiTypography-body1-123"
+                className="MuiTypography-root-108 MuiTypography-body1-117"
               >
                 Reaction Commerce
               </p>

--- a/src/components/ProductItem/ProductItem.js
+++ b/src/components/ProductItem/ProductItem.js
@@ -7,8 +7,8 @@ import Fade from "material-ui/transitions/Fade";
 import Hidden from "material-ui/Hidden";
 import Typography from "material-ui/Typography";
 import LoadingIcon from "mdi-material-ui/Loading";
-
 import Link from "components/Link";
+import Badge from "components/Badge";
 import { styles } from "./styles";
 
 const PRODUCT_PLACE_HOLDER = "/resources/placeholder.gif";
@@ -38,12 +38,12 @@ class ProductItem extends Component {
   }
 
   get productStatus() {
-    const { classes, product: { isBackorder, isSoldOut } } = this.props;
+    const { product: { isBackorder, isSoldOut } } = this.props;
     let status;
     if (isSoldOut && isBackorder) {
-      status = { label: "Backorder", style: `${classes.status} ${classes.statusBackorder}` };
+      status = { type: "backorder", label: "Backorder" };
     } else if (isSoldOut && !isBackorder) {
-      status = { label: "Sold Out", style: `${classes.status} ${classes.statusSoldOut}` };
+      status = { type: "sold_out", label: "Sold Out" };
     }
     return status;
   }
@@ -114,14 +114,17 @@ class ProductItem extends Component {
     );
   }
 
+  renderBadge() {
+
+  }
+
   renderProductMedia() {
     const { classes } = this.props;
-    const chipClasses = { root: classes.chip, label: classes.chipLabel };
-    const { label, style } = this.productStatus || {};
+    const { type, label } = this.productStatus || {};
     return (
       <div className={classes.productMedia}>
-        {this.productStatus && <Chip label={label} classes={chipClasses} className={style} />}
-        {this.productLowQuantity && <Chip label={"Low Inventory"} classes={chipClasses} className={classes.warning} />}
+        {this.productStatus && <Badge type={type} label={label} />}
+        {this.productLowQuantity && <Badge type={"low_inventory"} label="Low Inventory" />}
         {this.renderProductImage()}
       </div>
     );

--- a/src/components/ProductItem/ProductItem.js
+++ b/src/components/ProductItem/ProductItem.js
@@ -2,13 +2,13 @@ import React, { Component, Fragment } from "react";
 import PropTypes from "prop-types";
 import { withStyles } from "material-ui/styles";
 import { inject, observer } from "mobx-react";
-import Chip from "material-ui/Chip";
 import Fade from "material-ui/transitions/Fade";
 import Hidden from "material-ui/Hidden";
 import Typography from "material-ui/Typography";
 import LoadingIcon from "mdi-material-ui/Loading";
 import Link from "components/Link";
 import Badge from "components/Badge";
+import { inventoryStatus, isProductLowQuantity, INVENTORY_STATUS } from "lib/utils";
 import { styles } from "./styles";
 
 const PRODUCT_PLACE_HOLDER = "/resources/placeholder.gif";
@@ -35,22 +35,6 @@ class ProductItem extends Component {
     const { product: { slug } } = this.props;
     const url = `/product/${slug}`;
     return url;
-  }
-
-  get productStatus() {
-    const { product: { isBackorder, isSoldOut } } = this.props;
-    let status;
-    if (isSoldOut && isBackorder) {
-      status = { type: "backorder", label: "Backorder" };
-    } else if (isSoldOut && !isBackorder) {
-      status = { type: "sold_out", label: "Sold Out" };
-    }
-    return status;
-  }
-
-  get productLowQuantity() {
-    const { product: { isLowQuantity, isSoldOut } } = this.props;
-    return isLowQuantity && !isSoldOut;
   }
 
   onImageLoad = () => {
@@ -119,12 +103,13 @@ class ProductItem extends Component {
   }
 
   renderProductMedia() {
-    const { classes } = this.props;
-    const { type, label } = this.productStatus || {};
+    const { classes, product } = this.props;
+    const status = inventoryStatus(product);
+
     return (
       <div className={classes.productMedia}>
-        {this.productStatus && <Badge type={type} label={label} />}
-        {this.productLowQuantity && <Badge type={"low_inventory"} label="Low Inventory" />}
+        {status && <Badge type={status.type} label={status.label} />}
+        {isProductLowQuantity(product) && <Badge type={INVENTORY_STATUS.LOW_QUANTITY} label="Low Inventory" />}
         {this.renderProductImage()}
       </div>
     );

--- a/src/components/ProductItem/__snapshots__/ProductItem.test.js.snap
+++ b/src/components/ProductItem/__snapshots__/ProductItem.test.js.snap
@@ -3,7 +3,7 @@
 exports[`basic snapshot 1`] = `
 <div>
   <a
-    className="Link-link-16"
+    className="Link-link-8"
     href="/product/undefined"
     onClick={[Function]}
   >
@@ -32,17 +32,17 @@ exports[`basic snapshot 1`] = `
         />
         <img
           alt=""
-          className="inject-ProductItem-with-uiStore-img-12"
+          className="inject-ProductItem-with-uiStore-img-4"
           onLoad={[Function]}
           src="http://localhost:300/resources/placeholder.gif"
         />
       </picture>
       <div
-        className="inject-ProductItem-with-uiStore-imgLoading-13"
+        className="inject-ProductItem-with-uiStore-imgLoading-5"
       >
         <svg
           aria-hidden="true"
-          className="MuiSvgIcon-root-41 inject-ProductItem-with-uiStore-loadingIcon-14"
+          className="MuiSvgIcon-root-33 inject-ProductItem-with-uiStore-loadingIcon-6"
           color={undefined}
           focusable="false"
           viewBox="0 0 24 24"
@@ -58,17 +58,17 @@ exports[`basic snapshot 1`] = `
         className="inject-ProductItem-with-uiStore-productInfo-2"
       >
         <aside
-          className="MuiTypography-root-17 MuiTypography-body2-25"
+          className="MuiTypography-root-9 MuiTypography-body2-17"
         />
         <p
-          className="MuiTypography-root-17 MuiTypography-body1-26"
+          className="MuiTypography-root-9 MuiTypography-body1-18"
         >
           $
         </p>
       </div>
       <div>
         <p
-          className="MuiTypography-root-17 MuiTypography-body1-26"
+          className="MuiTypography-root-9 MuiTypography-body1-18"
         />
       </div>
     </div>

--- a/src/components/ProductItem/styles.js
+++ b/src/components/ProductItem/styles.js
@@ -14,44 +14,6 @@ export const styles = (theme) => ({
     backgroundColor: theme.palette.primary.contrastText,
     position: "relative"
   },
-  "chip": {
-    ...theme.typography.caption,
-    borderRadius: 4,
-    height: "auto",
-    fontSize: 12,
-    paddingBottom: theme.spacing.unit * 0.5,
-    paddingLeft: theme.spacing.unit,
-    paddingRight: theme.spacing.unit,
-    paddingTop: theme.spacing.unit * 0.5,
-    position: "absolute",
-    zIndex: 100
-  },
-  "chipLabel": {
-    fontWeight: theme.typography.fontWeightBold,
-    padding: 0
-  },
-  "status": {
-    color: theme.palette.primary.contrastText,
-    left: theme.spacing.unit,
-    top: theme.spacing.unit
-  },
-  "statusSoldOut": {
-    backgroundColor: theme.palette.secondary.main
-  },
-  "statusBackorder": {
-    backgroundColor: theme.palette.secondary.dark
-  },
-  "statusSale": {
-    backgroundColor: theme.palette.error.main
-  },
-  "statusBestseller": {
-    backgroundColor: theme.palette.primary.light
-  },
-  "warning": {
-    backgroundColor: "transparent",
-    right: theme.spacing.unit,
-    top: theme.spacing.unit
-  },
   "img": {
     height: "auto",
     width: "100%"

--- a/src/components/VariantList/VariantList.js
+++ b/src/components/VariantList/VariantList.js
@@ -3,18 +3,26 @@ import PropTypes from "prop-types";
 import { withStyles } from "material-ui/styles";
 import { observable, action, computed } from "mobx";
 import { observer } from "mobx-react";
-
 import { Router } from "routes";
 import VariantItem from "components/VariantItem";
 import ProductDetailOptionsList from "components/ProductDetailOptionsList";
+import Badge from "components/Badge";
+import { inventoryStatus } from "lib/utils";
 import Divider from "components/Divider";
 
 const styles = (theme) => ({
   variantsContainer: {
   },
   variantItem: {
+    position: "relative",
     marginTop: theme.spacing.unit * 1.25,
     marginBottom: theme.spacing.unit * 1.25
+  },
+  alert: {
+    display: "flex",
+    position: "absolute",
+    top: -theme.spacing.unit * 2,
+    right: theme.spacing.unit * 11
   }
 });
 
@@ -55,16 +63,30 @@ export default class VariantList extends Component {
   }
 
   renderVariant = (variant) => {
-    const { classes: { variantItem } } = this.props;
+    const { classes } = this.props;
     const active = (this.selectedVariant === variant._id);
 
     return (
-      <div className={variantItem} key={variant._id}>
+      <div className={classes.variantItem} key={variant._id}>
         <VariantItem
           active={active}
           handleClick={this.handleClick}
           variant={variant}
         />
+        {this.renderInventoryStatus(variant)}
+      </div>
+    );
+  }
+
+  renderInventoryStatus(variant) {
+    const { classes } = this.props;
+    const status = inventoryStatus(variant);
+
+    if (!status) return null;
+
+    return (
+      <div className={classes.alert}>
+        <Badge type={status.type} label={status.label} />
       </div>
     );
   }

--- a/src/components/VariantList/__snapshots__/VariantList.test.js.snap
+++ b/src/components/VariantList/__snapshots__/VariantList.test.js.snap
@@ -8,7 +8,7 @@ exports[`basic snapshot 1`] = `
     className="VariantList-variantItem-2"
   >
     <button
-      className="MuiButtonBase-root-5 VariantItem-variantButton-3 VariantItem-activeVariant-4"
+      className="MuiButtonBase-root-6 VariantItem-variantButton-4 VariantItem-activeVariant-5"
       disabled={undefined}
       onBlur={[Function]}
       onClick={[Function]}
@@ -25,20 +25,33 @@ exports[`basic snapshot 1`] = `
       type="button"
     >
       <span
-        className="MuiTypography-root-8 MuiTypography-body1-17"
+        className="MuiTypography-root-9 MuiTypography-body1-18"
       >
         Sample Variant
       </span>
       <span
-        className="MuiTypography-root-8 MuiTypography-body1-17"
+        className="MuiTypography-root-9 MuiTypography-body1-18"
       />
     </button>
+    <div
+      className="VariantList-alert-3"
+    >
+      <div
+        className="Badge-badge-33 Badge-status-35 Badge-soldOut-36"
+      >
+        <span
+          className="Badge-labelStyle-34"
+        >
+          Sold Out
+        </span>
+      </div>
+    </div>
   </div>
   <div
     className="VariantList-variantItem-2"
   >
     <button
-      className="MuiButtonBase-root-5 VariantItem-variantButton-3"
+      className="MuiButtonBase-root-6 VariantItem-variantButton-4"
       disabled={undefined}
       onBlur={[Function]}
       onClick={[Function]}
@@ -55,38 +68,38 @@ exports[`basic snapshot 1`] = `
       type="button"
     >
       <span
-        className="MuiTypography-root-8 MuiTypography-body1-17"
+        className="MuiTypography-root-9 MuiTypography-body1-18"
       >
         Sample Variant 2
       </span>
       <span
-        className="MuiTypography-root-8 MuiTypography-body1-17"
+        className="MuiTypography-root-9 MuiTypography-body1-18"
       />
     </button>
   </div>
   <div
-    className="Divider-container-32"
+    className="Divider-container-42"
   >
     <hr
-      className="Divider-item-34"
+      className="Divider-item-44"
     />
     <span
-      className="MuiTypography-root-8 MuiTypography-body1-17 Divider-label-33"
+      className="MuiTypography-root-9 MuiTypography-body1-18 Divider-label-43"
     >
       Available Options
     </span>
     <hr
-      className="Divider-item-34"
+      className="Divider-item-44"
     />
   </div>
   <div
-    className="MuiGrid-container-36 MuiGrid-spacing-xs-8-57 OptionsList-root-35"
+    className="MuiGrid-container-48 MuiGrid-spacing-xs-8-69 OptionsList-root-45"
   >
     <div
-      className="MuiGrid-item-37"
+      className="MuiGrid-item-49"
     >
       <button
-        className="MuiButtonBase-root-5 ProductDetailOption-optionButton-126"
+        className="MuiButtonBase-root-6 ProductDetailOption-optionButton-138"
         disabled={undefined}
         onBlur={[Function]}
         onClick={[Function]}
@@ -103,17 +116,30 @@ exports[`basic snapshot 1`] = `
         type="button"
       >
         <span
-          className="MuiTypography-root-8 MuiTypography-body1-17 ProductDetailOption-optionText-127"
+          className="MuiTypography-root-9 MuiTypography-body1-18 ProductDetailOption-optionText-139"
         >
           Red
         </span>
       </button>
+      <div
+        className="OptionsList-alert-46"
+      >
+        <div
+          className="Badge-badge-33 Badge-backorder-37 Badge-status-35 OptionsList-badge-47"
+        >
+          <span
+            className="Badge-labelStyle-34"
+          >
+            Backorder
+          </span>
+        </div>
+      </div>
     </div>
     <div
-      className="MuiGrid-item-37"
+      className="MuiGrid-item-49"
     >
       <button
-        className="MuiButtonBase-root-5 ProductDetailOption-optionButton-126"
+        className="MuiButtonBase-root-6 ProductDetailOption-optionButton-138"
         disabled={undefined}
         onBlur={[Function]}
         onClick={[Function]}
@@ -130,7 +156,7 @@ exports[`basic snapshot 1`] = `
         type="button"
       >
         <span
-          className="MuiTypography-root-8 MuiTypography-body1-17 ProductDetailOption-optionText-127"
+          className="MuiTypography-root-9 MuiTypography-body1-18 ProductDetailOption-optionText-139"
         >
           Green
         </span>

--- a/src/lib/apollo/initApolloBrowser.js
+++ b/src/lib/apollo/initApolloBrowser.js
@@ -23,7 +23,7 @@ const create = (initialState, options = {}) =>
       },
       credentials: "same-origin"
     }),
-    cache: new InMemoryCache().restore(initialState || {})
+    cache: new InMemoryCache().restore({})
   });
 
 

--- a/src/lib/theme/reactionTheme.js
+++ b/src/lib/theme/reactionTheme.js
@@ -23,9 +23,13 @@ const theme = createMuiTheme({
     reaction: {
       activeElementBorderColor: "#94E8D1",
       activeElementBackground: "#E6E6E6",
+      bestseller: "#8CE0C9",
       borderColor: "#CCCCCC"
     }
 
+  },
+  spacing: {
+    unithalf: 4
   },
   typography: {
     fontFamily: "Source Sans Pro, Helvetica Neue, Helvetica, sans-serif",

--- a/src/lib/utils/index.js
+++ b/src/lib/utils/index.js
@@ -22,6 +22,8 @@ export function inventoryStatus(product) {
     status = { type: INVENTORY_STATUS.BACKORDER, label: "Backorder" };
   } else if (product.isSoldOut && !product.isBackorder) {
     status = { type: INVENTORY_STATUS.SOLD_OUT, label: "Sold Out" };
+  } else if (product.isLowQuantity && !product.isSoldOut) {
+    status = { type: INVENTORY_STATUS.LOW_QUANTITY, label: "Low Inventory" };
   }
 
   return status;

--- a/src/lib/utils/index.js
+++ b/src/lib/utils/index.js
@@ -1,0 +1,36 @@
+import keyMirror from "keymirror";
+
+export const INVENTORY_STATUS = keyMirror({
+  SOLD_OUT: null,
+  BACKORDER: null,
+  LOW_QUANTITY: null
+});
+
+
+/**
+ * Determines a product's inventory status
+ *
+ * @param {Object} product - The product
+ * @returns {Object} - The computed product status
+ */
+export function inventoryStatus(product) {
+  let status = null;
+
+  if (product.isSoldOut && product.isBackorder) {
+    status = { type: INVENTORY_STATUS.BACKORDER, label: "Backorder" };
+  } else if (product.isSoldOut && !product.isBackorder) {
+    status = { type: INVENTORY_STATUS.SOLD_OUT, label: "Sold Out" };
+  }
+
+  return status;
+}
+
+/**
+ * Determines if a product has low inventory.
+ *
+ * @param {Object} product - The product
+ * @returns {Boolean} - Indicates whether the product has low inventory
+ */
+export function isProductLowQuantity(product) {
+  return product.isLowQuantity && !product.isSoldOut;
+}

--- a/src/lib/utils/index.js
+++ b/src/lib/utils/index.js
@@ -1,9 +1,11 @@
 import keyMirror from "keymirror";
 
 export const INVENTORY_STATUS = keyMirror({
-  SOLD_OUT: null,
   BACKORDER: null,
-  LOW_QUANTITY: null
+  BESTSELLER: null,
+  LOW_QUANTITY: null,
+  SOLD_OUT: null,
+  SALE: null
 });
 
 

--- a/src/pages/_document.js
+++ b/src/pages/_document.js
@@ -70,7 +70,7 @@ class HTMLDocument extends Document {
               // PWA primary color
               { name: "theme-color", content: pageContext.theme.palette.primary.main }
             ]}
-            link={[{ rel: "preload", as: "font", href: "https://fonts.googleapis.com/css?family=Source+Sans+Pro:200,400,700" }]}
+            link={[{ href: "https://fonts.googleapis.com/css?family=Source+Sans+Pro:200,400,700" }]}
           />
           {helmet.base.toComponent()}
           {helmet.title.toComponent()}

--- a/yarn.lock
+++ b/yarn.lock
@@ -82,9 +82,13 @@
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/@reactioncommerce/eslint-config/-/eslint-config-1.7.0.tgz#2d7523651a9d787d8504ee84545f6a6babf5998d"
 
-"@types/async@2.0.47":
-  version "2.0.47"
-  resolved "https://registry.yarnpkg.com/@types/async/-/async-2.0.47.tgz#f49ba1dd1f189486beb6e1d070a850f6ab4bd521"
+"@types/async@2.0.49":
+  version "2.0.49"
+  resolved "https://registry.yarnpkg.com/@types/async/-/async-2.0.49.tgz#92e33d13f74c895cb9a7f38ba97db8431ed14bc0"
+
+"@types/graphql@0.12.6":
+  version "0.12.6"
+  resolved "https://registry.yarnpkg.com/@types/graphql/-/graphql-0.12.6.tgz#3d619198585fcabe5f4e1adfb5cf5f3388c66c13"
 
 "@types/jss@^9.3.0":
   version "9.5.2"
@@ -275,33 +279,33 @@ anymatch@^2.0.0:
     micromatch "^3.1.4"
     normalize-path "^2.1.1"
 
-apollo-cache-inmemory@^1.1.9:
-  version "1.1.12"
-  resolved "https://registry.yarnpkg.com/apollo-cache-inmemory/-/apollo-cache-inmemory-1.1.12.tgz#ab489bf046b3e026556ab28bdebb6e010cac9531"
+apollo-cache-inmemory@^1.1.11:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/apollo-cache-inmemory/-/apollo-cache-inmemory-1.2.0.tgz#a5b98fd67a810215b2d03e4a924cf0c554d6ebb4"
   dependencies:
-    apollo-cache "^1.1.7"
-    apollo-utilities "^1.0.11"
-    graphql-anywhere "^4.1.8"
+    apollo-cache "^1.1.8"
+    apollo-utilities "^1.0.12"
+    graphql-anywhere "^4.1.9"
 
-apollo-cache@^1.1.7:
-  version "1.1.7"
-  resolved "https://registry.yarnpkg.com/apollo-cache/-/apollo-cache-1.1.7.tgz#5817018a2fbfc05a21ba319bd17a3e7538110cc5"
+apollo-cache@^1.1.8:
+  version "1.1.8"
+  resolved "https://registry.yarnpkg.com/apollo-cache/-/apollo-cache-1.1.8.tgz#b078d33dec876d52b5a81a325d3c254d4e362d3c"
   dependencies:
-    apollo-utilities "^1.0.11"
+    apollo-utilities "^1.0.12"
 
-apollo-client@^2.2.5:
-  version "2.2.8"
-  resolved "https://registry.yarnpkg.com/apollo-client/-/apollo-client-2.2.8.tgz#b604d31ab2d2dd00db3105d8793b93ee02ce567e"
+apollo-client@^2.2.7:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/apollo-client/-/apollo-client-2.3.0.tgz#6c8c9cfef5eaa28d89094078b5b4a59e9b6babaa"
   dependencies:
     "@types/zen-observable" "^0.5.3"
-    apollo-cache "^1.1.7"
+    apollo-cache "^1.1.8"
     apollo-link "^1.0.0"
     apollo-link-dedup "^1.0.0"
-    apollo-utilities "^1.0.11"
+    apollo-utilities "^1.0.12"
     symbol-observable "^1.0.2"
-    zen-observable "^0.7.0"
+    zen-observable "^0.8.0"
   optionalDependencies:
-    "@types/async" "2.0.47"
+    "@types/async" "2.0.49"
 
 apollo-link-dedup@^1.0.0:
   version "1.0.8"
@@ -309,18 +313,18 @@ apollo-link-dedup@^1.0.0:
   dependencies:
     apollo-link "^1.2.1"
 
-apollo-link-http-common@^0.2.3:
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/apollo-link-http-common/-/apollo-link-http-common-0.2.3.tgz#82ae0d4ff0cdd7c5c8826411d9dd7f7d8049ca46"
+apollo-link-http-common@^0.2.4:
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/apollo-link-http-common/-/apollo-link-http-common-0.2.4.tgz#877603f7904dc8f70242cac61808b1f8d034b2c3"
   dependencies:
-    apollo-link "^1.2.1"
+    apollo-link "^1.2.2"
 
-apollo-link-http@^1.5.1:
-  version "1.5.3"
-  resolved "https://registry.yarnpkg.com/apollo-link-http/-/apollo-link-http-1.5.3.tgz#3aa0d3ecfe5666ef0c360f359c425ff6ea1d285b"
+apollo-link-http@^1.5.4:
+  version "1.5.4"
+  resolved "https://registry.yarnpkg.com/apollo-link-http/-/apollo-link-http-1.5.4.tgz#b80b7b4b342c655b6a5614624b076a36be368f43"
   dependencies:
-    apollo-link "^1.2.1"
-    apollo-link-http-common "^0.2.3"
+    apollo-link "^1.2.2"
+    apollo-link-http-common "^0.2.4"
 
 apollo-link@^1.0.0, apollo-link@^1.2.1:
   version "1.2.1"
@@ -330,9 +334,21 @@ apollo-link@^1.0.0, apollo-link@^1.2.1:
     apollo-utilities "^1.0.0"
     zen-observable-ts "^0.8.6"
 
-apollo-utilities@^1.0.0, apollo-utilities@^1.0.11:
+apollo-link@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/apollo-link/-/apollo-link-1.2.2.tgz#54c84199b18ac1af8d63553a68ca389c05217a03"
+  dependencies:
+    "@types/graphql" "0.12.6"
+    apollo-utilities "^1.0.0"
+    zen-observable-ts "^0.8.9"
+
+apollo-utilities@^1.0.0:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/apollo-utilities/-/apollo-utilities-1.0.11.tgz#cd36bfa6e5c04eea2caf0c204a0f38a0ad550802"
+
+apollo-utilities@^1.0.12:
+  version "1.0.12"
+  resolved "https://registry.yarnpkg.com/apollo-utilities/-/apollo-utilities-1.0.12.tgz#9e2b2a34cf89f3bf0d73a664effd8c1bb5d1b7f7"
 
 append-transform@^0.4.0:
   version "0.4.0"
@@ -3238,11 +3254,11 @@ graphlib@^2.1.1:
   dependencies:
     lodash "^4.11.1"
 
-graphql-anywhere@^4.1.8:
-  version "4.1.8"
-  resolved "https://registry.yarnpkg.com/graphql-anywhere/-/graphql-anywhere-4.1.8.tgz#23882e6a16ec824febbe5bca40937cdd76c5acdc"
+graphql-anywhere@^4.1.9:
+  version "4.1.9"
+  resolved "https://registry.yarnpkg.com/graphql-anywhere/-/graphql-anywhere-4.1.9.tgz#831bbf2c4972bd104a60175ba107ab3ae65008d1"
   dependencies:
-    apollo-utilities "^1.0.11"
+    apollo-utilities "^1.0.12"
 
 graphql-tag@^2.8.0:
   version "2.8.0"
@@ -4641,9 +4657,9 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
-material-ui@^1.0.0-beta.41:
-  version "1.0.0-beta.42"
-  resolved "https://registry.yarnpkg.com/material-ui/-/material-ui-1.0.0-beta.42.tgz#a0dea15fd433d521b41912802041eee8b3f30589"
+material-ui@^1.0.0-beta.44:
+  version "1.0.0-beta.44"
+  resolved "https://registry.yarnpkg.com/material-ui/-/material-ui-1.0.0-beta.44.tgz#8cbe436bb82a5fcbcd687e619e6b20ad6c56c0de"
   dependencies:
     "@types/jss" "^9.3.0"
     "@types/react-transition-group" "^2.0.8"
@@ -4670,7 +4686,7 @@ material-ui@^1.0.0-beta.41:
     react-popper "^0.10.0"
     react-scrollbar-size "^2.0.2"
     react-transition-group "^2.2.1"
-    recompose "^0.26.0"
+    recompose "^0.26.0 || ^0.27.0"
     scroll "^2.0.3"
     warning "^3.0.0"
 
@@ -5793,12 +5809,12 @@ rc@^1.0.1, rc@^1.1.6, rc@^1.1.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-apollo@^2.1.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/react-apollo/-/react-apollo-2.1.2.tgz#fc355a3975b3f5d7de59db283380a38807e8bf3f"
+react-apollo@^2.1.3:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/react-apollo/-/react-apollo-2.1.3.tgz#5eb02cdf18cc4bdeb615bda94baedb50354e94e5"
   dependencies:
     fbjs "^0.8.16"
-    hoist-non-react-statics "^2.3.1"
+    hoist-non-react-statics "^2.5.0"
     invariant "^2.2.2"
     lodash "4.17.5"
     prop-types "^15.6.0"
@@ -5857,6 +5873,10 @@ react-jss@^8.1.0:
 react-lifecycles-compat@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-2.0.2.tgz#00a23160eec17a43b94dd74f95d44a1a2c3c5ec1"
+
+react-lifecycles-compat@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.2.tgz#7279047275bd727a912e25f734c0559527e84eff"
 
 react-popper@^0.10.0:
   version "0.10.1"
@@ -5975,13 +5995,15 @@ realpath-native@^1.0.0:
   dependencies:
     util.promisify "^1.0.0"
 
-recompose@^0.26.0:
-  version "0.26.0"
-  resolved "https://registry.yarnpkg.com/recompose/-/recompose-0.26.0.tgz#9babff039cb72ba5bd17366d55d7232fbdfb2d30"
+"recompose@^0.26.0 || ^0.27.0":
+  version "0.27.0"
+  resolved "https://registry.yarnpkg.com/recompose/-/recompose-0.27.0.tgz#8230ebd651bf1159097006f79083fe224b1501cf"
   dependencies:
+    babel-runtime "^6.26.0"
     change-emitter "^0.1.2"
     fbjs "^0.8.1"
     hoist-non-react-statics "^2.3.1"
+    react-lifecycles-compat "^3.0.2"
     symbol-observable "^1.0.4"
 
 recursive-copy@2.0.6:
@@ -7732,9 +7754,19 @@ zen-observable-ts@^0.8.6:
   dependencies:
     zen-observable "^0.7.0"
 
+zen-observable-ts@^0.8.9:
+  version "0.8.9"
+  resolved "https://registry.yarnpkg.com/zen-observable-ts/-/zen-observable-ts-0.8.9.tgz#d3c97af08c0afdca37ebcadf7cc3ee96bda9bab1"
+  dependencies:
+    zen-observable "^0.8.0"
+
 zen-observable@^0.7.0:
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/zen-observable/-/zen-observable-0.7.1.tgz#f84075c0ee085594d3566e1d6454207f126411b3"
+
+zen-observable@^0.8.0:
+  version "0.8.8"
+  resolved "https://registry.yarnpkg.com/zen-observable/-/zen-observable-0.8.8.tgz#1ea93995bf098754a58215a1e0a7309e5749ec42"
 
 zip@^1.2.0:
   version "1.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4455,6 +4455,10 @@ keycode@^2.1.9:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/keycode/-/keycode-2.2.0.tgz#3d0af56dc7b8b8e5cba8d0a97f107204eec22b04"
 
+keymirror@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/keymirror/-/keymirror-0.1.1.tgz#918889ea13f8d0a42e7c557250eee713adc95c35"
+
 kind-of@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-2.0.1.tgz#018ec7a4ce7e3a86cb9141be519d24c8faa981b5"


### PR DESCRIPTION
Add inventory status badges to variants/options lists. 

**NOTE**: The badge style will be updated when the designers finish the design of the PDP page.

### Testing
1. Add a new product with a variant and an option and publish the product.
2. By default the variant will have a backorder badge.
3. Verify a backorder badge is visible on the new product variant in the  grid and PDP.
4. Toggle the backorder switch to turn off backordering
5. Grid and PDP should display a "Sold Out" badge
6. Repeat steps 3-5 for the variant option.