### PR TITLE
fix: image grid sizing issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,3 +61,7 @@ _**NOTE:** The above command is assuming ether the `devserver` or `reaction` is 
  - [MobX](https://mobx.js.org/getting-started.html)
  - [nextjs](https://github.com/zeit/next.js/)
  - [Material UI](https://material-ui-next.com/)
+
+ ## Reference links for development
+ ### CSS in JS
+ - [Responsive Breakbpoints](https://material-ui-next.com/layout/css-in-js/#responsive-breakpoints)

--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ _**NOTE:** Replace the `${port}` with the localhost port you'd like the applicat
 
 _**NOTE:** The above command is assuming ether the `devserver` or `reaction` is also running._
 
+## Testing
+To test locally, run `docker-compose run web yarn test`
+
 ## Features
  - [Docker](https://docs.docker.com)
  - [React](https://reactjs.org/)

--- a/README.md
+++ b/README.md
@@ -55,7 +55,9 @@ _**NOTE:** Replace the `${port}` with the localhost port you'd like the applicat
 _**NOTE:** The above command is assuming ether the `devserver` or `reaction` is also running._
 
 ## Testing
-To test locally, run `docker-compose run web yarn test`
+- To test locally, run `docker-compose run web yarn test`
+- To test without cache, run `docker-compose run web yarn test --no-cache`. This can be helpful if changes aren't showing up.
+- To update a failing snapshot, run `docker-compose run web yarn test -u`.
 
 ## Using MobX
 See our [MobX documentation](docs/MOBX.md)

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ _**NOTE:** Currently we're using the [release 1.11.0 branch](https://github.com/
  2. Start the storefront application in development mode by running `docker-compose up -d --build`
  3. The Storefront will run on [localhost:4000](http://localhost:4000).
  4. Use the account dropdown (user icon), and enter Meteor.loginToken from the above steps and save
+ 5. Add `EXTERNAL_ASSETS_URL=http://localhost:3000` to your `env` file if you wish to see image assets from your classic Reaction Commerce shop
 
 ## Development
 To run the application in development mode execute:

--- a/package-lock.json
+++ b/package-lock.json
@@ -80,6 +80,15 @@
         "js-tokens": "3.0.2"
       }
     },
+    "@babel/runtime": {
+      "version": "7.0.0-beta.46",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.0.0-beta.46.tgz",
+      "integrity": "sha512-/3a3USMKk54BEHhDgY8rtxtaQOs4bp4aQwo6SDtdwmrXmgSgEusWuXNX5oIs/nwzmTD9o8wz2EyAjA+uHDMmJA==",
+      "requires": {
+        "core-js": "2.5.5",
+        "regenerator-runtime": "0.11.1"
+      }
+    },
     "@babel/template": {
       "version": "7.0.0-beta.44",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.44.tgz",
@@ -172,6 +181,11 @@
       "integrity": "sha512-/mQMARXVSuGbwOFFBKA4s0qRKtOaaTgnllp3qU4sMzDVGGAroPblyd529yBALnK/WEY8nHyRGx0/RFUDmhpVmQ==",
       "optional": true
     },
+    "@types/graphql": {
+      "version": "0.12.6",
+      "resolved": "http://registry.npmjs.org/@types/graphql/-/graphql-0.12.6.tgz",
+      "integrity": "sha512-wXAVyLfkG1UMkKOdMijVWFky39+OD/41KftzqfX1Oejd0Gm6dOIKjCihSVECg6X7PHjftxXmfOKA/d1H79ZfvQ=="
+    },
     "@types/jss": {
       "version": "9.5.2",
       "resolved": "https://registry.npmjs.org/@types/jss/-/jss-9.5.2.tgz",
@@ -235,7 +249,8 @@
     "abab": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/abab/-/abab-1.0.4.tgz",
-      "integrity": "sha1-X6rZwsB/YN12dw9xzwJbYqY8/U4="
+      "integrity": "sha1-X6rZwsB/YN12dw9xzwJbYqY8/U4=",
+      "dev": true
     },
     "abbrev": {
       "version": "1.1.1",
@@ -275,6 +290,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.1.0.tgz",
       "integrity": "sha512-KjZwU26uG3u6eZcfGbTULzFcsoz6pegNKtHPksZPOUsiKo5bUmiBPa38FuHZ/Eun+XYh/JCCkS9AS3Lu4McQOQ==",
+      "dev": true,
       "requires": {
         "acorn": "5.5.3"
       }
@@ -432,20 +448,45 @@
       }
     },
     "apollo-link-http": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/apollo-link-http/-/apollo-link-http-1.5.3.tgz",
-      "integrity": "sha512-t49wBXzdXpVdiqr82Lj0x6hORVVtIQQ5hLfVKjmQXiA/uv0o0Np8mAcOBZRYJvpVRHkaLvv5w/4MRbc8h5UGuQ==",
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/apollo-link-http/-/apollo-link-http-1.5.4.tgz",
+      "integrity": "sha512-e9Ng3HfnW00Mh3TI6DhNRfozmzQOtKgdi+qUAsHBOEcTP0PTAmb+9XpeyEEOueLyO0GXhB92HUCIhzrWMXgwyg==",
       "requires": {
-        "apollo-link": "1.2.1",
-        "apollo-link-http-common": "0.2.3"
-      }
-    },
-    "apollo-link-http-common": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/apollo-link-http-common/-/apollo-link-http-common-0.2.3.tgz",
-      "integrity": "sha512-gZ5xp2ZlX9Ie0HR/bVDxD4073UAMdZC/QhPQifh/AV6YCOTuj3ZkaAf89KnuQCifWVXO3yXD/53SWm7VrsjCdQ==",
-      "requires": {
-        "apollo-link": "1.2.1"
+        "apollo-link": "1.2.2",
+        "apollo-link-http-common": "0.2.4"
+      },
+      "dependencies": {
+        "apollo-link": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/apollo-link/-/apollo-link-1.2.2.tgz",
+          "integrity": "sha512-Uk/BC09dm61DZRDSu52nGq0nFhq7mcBPTjy5EEH1eunJndtCaNXQhQz/BjkI2NdrfGI+B+i5he6YSoRBhYizdw==",
+          "requires": {
+            "@types/graphql": "0.12.6",
+            "apollo-utilities": "1.0.11",
+            "zen-observable-ts": "0.8.9"
+          }
+        },
+        "apollo-link-http-common": {
+          "version": "0.2.4",
+          "resolved": "https://registry.npmjs.org/apollo-link-http-common/-/apollo-link-http-common-0.2.4.tgz",
+          "integrity": "sha512-4j6o6WoXuSPen9xh4NBaX8/vL98X1xY2cYzUEK1F8SzvHe2oFONfxJBTekwU8hnvapcuq8Qh9Uct+gelu8T10g==",
+          "requires": {
+            "apollo-link": "1.2.2"
+          }
+        },
+        "zen-observable": {
+          "version": "0.8.8",
+          "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.8.tgz",
+          "integrity": "sha512-HnhhyNnwTFzS48nihkCZIJGsWGFcYUz+XPDlPK5W84Ifji8SksC6m7sQWOf8zdCGhzQ4tDYuMYGu5B0N1dXTtg=="
+        },
+        "zen-observable-ts": {
+          "version": "0.8.9",
+          "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-0.8.9.tgz",
+          "integrity": "sha512-KJz2O8FxbAdAU5CSc8qZ1K2WYEJb1HxS6XDRF+hOJ1rOYcg6eTMmS9xYHCXzqZZzKw6BbXWyF4UpwSsBQnHJeA==",
+          "requires": {
+            "zen-observable": "0.8.8"
+          }
+        }
       }
     },
     "apollo-utilities": {
@@ -515,7 +556,8 @@
     "array-equal": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
-      "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM="
+      "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
+      "dev": true
     },
     "array-flatten": {
       "version": "1.1.1",
@@ -563,7 +605,8 @@
     "asn1": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
+      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
+      "dev": true
     },
     "asn1.js": {
       "version": "4.10.1",
@@ -586,7 +629,8 @@
     "assert-plus": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+      "dev": true
     },
     "assign-symbols": {
       "version": "1.0.0",
@@ -621,12 +665,14 @@
     "async-limiter": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
-      "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
+      "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==",
+      "dev": true
     },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true
     },
     "atob": {
       "version": "2.1.0",
@@ -636,12 +682,14 @@
     "aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+      "dev": true
     },
     "aws4": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
-      "integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w=="
+      "integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w==",
+      "dev": true
     },
     "axobject-query": {
       "version": "0.1.0",
@@ -1943,6 +1991,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
       "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+      "dev": true,
       "optional": true,
       "requires": {
         "tweetnacl": "0.14.5"
@@ -1995,6 +2044,7 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
       "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
+      "dev": true,
       "requires": {
         "hoek": "4.2.1"
       }
@@ -2080,7 +2130,8 @@
     "browser-process-hrtime": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-0.1.2.tgz",
-      "integrity": "sha1-Ql1opY00R/AqBKqJQYf86K+Le44="
+      "integrity": "sha1-Ql1opY00R/AqBKqJQYf86K+Le44=",
+      "dev": true
     },
     "browser-resolve": {
       "version": "1.11.2",
@@ -2290,7 +2341,8 @@
     "caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+      "dev": true
     },
     "center-align": {
       "version": "0.1.3",
@@ -2507,6 +2559,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
       "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+      "dev": true,
       "requires": {
         "delayed-stream": "1.0.0"
       }
@@ -2689,6 +2742,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
       "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
+      "dev": true,
       "requires": {
         "boom": "5.2.0"
       },
@@ -2697,6 +2751,7 @@
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
           "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
+          "dev": true,
           "requires": {
             "hoek": "4.2.1"
           }
@@ -2755,12 +2810,14 @@
     "cssom": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.2.tgz",
-      "integrity": "sha1-uANhcMefB6kP8vFuIihAJ6JDhIs="
+      "integrity": "sha1-uANhcMefB6kP8vFuIihAJ6JDhIs=",
+      "dev": true
     },
     "cssstyle": {
       "version": "0.2.37",
       "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.37.tgz",
       "integrity": "sha1-VBCXI0yyUTyDzu06zdwn/yeYfVQ=",
+      "dev": true,
       "requires": {
         "cssom": "0.3.2"
       }
@@ -2793,6 +2850,7 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "dev": true,
       "requires": {
         "assert-plus": "1.0.0"
       }
@@ -2801,6 +2859,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-1.0.0.tgz",
       "integrity": "sha512-ai40PPQR0Fn1lD2PPie79CibnlMN2AYiDhwFX/rZHVsxbs5kNJSjegqXIprhouGXlRdEnfybva7kqRGnB6mypA==",
+      "dev": true,
       "requires": {
         "abab": "1.0.4",
         "whatwg-mimetype": "2.1.0",
@@ -2843,7 +2902,8 @@
     "deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "dev": true
     },
     "deepmerge": {
       "version": "2.1.0",
@@ -2937,7 +2997,8 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true
     },
     "depd": {
       "version": "1.1.2",
@@ -3046,6 +3107,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
       "integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
+      "dev": true,
       "requires": {
         "webidl-conversions": "4.0.2"
       }
@@ -3097,6 +3159,7 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
       "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+      "dev": true,
       "optional": true,
       "requires": {
         "jsbn": "0.1.1"
@@ -3369,6 +3432,7 @@
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.1.tgz",
       "integrity": "sha512-6hTjO1NAWkHnDk3OqQ4YrCuwwmGHL9S3nPlzBOUG/R44rda3wLNrfvQ5fkSGjyhHFKM7ALPKcKGrwvCLe0lC7Q==",
+      "dev": true,
       "requires": {
         "esprima": "3.1.3",
         "estraverse": "4.2.0",
@@ -3380,7 +3444,8 @@
         "esprima": {
           "version": "3.1.3",
           "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
-          "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
+          "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
+          "dev": true
         }
       }
     },
@@ -3865,7 +3930,8 @@
     "extend": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
+      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
+      "dev": true
     },
     "extend-shallow": {
       "version": "3.0.2",
@@ -3964,7 +4030,8 @@
     "extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+      "dev": true
     },
     "fast-deep-equal": {
       "version": "1.1.0",
@@ -4206,12 +4273,14 @@
     "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+      "dev": true
     },
     "form-data": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
       "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
+      "dev": true,
       "requires": {
         "asynckit": "0.4.0",
         "combined-stream": "1.0.6",
@@ -5245,6 +5314,7 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "dev": true,
       "requires": {
         "assert-plus": "1.0.0"
       }
@@ -5495,12 +5565,14 @@
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+      "dev": true
     },
     "har-validator": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
       "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+      "dev": true,
       "requires": {
         "ajv": "5.5.2",
         "har-schema": "2.0.0"
@@ -5510,6 +5582,7 @@
           "version": "5.5.2",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
           "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+          "dev": true,
           "requires": {
             "co": "4.6.0",
             "fast-deep-equal": "1.1.0",
@@ -5620,6 +5693,7 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
       "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
+      "dev": true,
       "requires": {
         "boom": "4.3.1",
         "cryptiles": "3.1.2",
@@ -5640,7 +5714,8 @@
     "hoek": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
-      "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
+      "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA==",
+      "dev": true
     },
     "hoist-non-react-statics": {
       "version": "2.5.0",
@@ -5665,6 +5740,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
       "integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
+      "dev": true,
       "requires": {
         "whatwg-encoding": "1.0.3"
       }
@@ -5708,6 +5784,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "dev": true,
       "requires": {
         "assert-plus": "1.0.0",
         "jsprim": "1.4.1",
@@ -6159,7 +6236,8 @@
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true
     },
     "is-utf8": {
       "version": "0.2.1",
@@ -6199,7 +6277,8 @@
     "isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+      "dev": true
     },
     "istanbul-api": {
       "version": "1.3.1",
@@ -7203,12 +7282,14 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "dev": true,
       "optional": true
     },
     "jsdom": {
       "version": "11.10.0",
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.10.0.tgz",
       "integrity": "sha512-x5No5FpJgBg3j5aBwA8ka6eGuS5IxbC8FOkmyccKvObtFT0bDMict/LOxINZsZGZSfGdNomLZ/qRV9Bpq/GIBA==",
+      "dev": true,
       "requires": {
         "abab": "1.0.4",
         "acorn": "5.5.3",
@@ -7241,7 +7322,8 @@
         "parse5": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz",
-          "integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA=="
+          "integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA==",
+          "dev": true
         }
       }
     },
@@ -7258,7 +7340,8 @@
     "json-schema": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+      "dev": true
     },
     "json-schema-traverse": {
       "version": "0.3.1",
@@ -7283,7 +7366,8 @@
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "dev": true
     },
     "json5": {
       "version": "0.5.1",
@@ -7300,6 +7384,7 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
       "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "dev": true,
       "requires": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
@@ -7421,6 +7506,11 @@
       "resolved": "https://registry.npmjs.org/keycode/-/keycode-2.2.0.tgz",
       "integrity": "sha1-PQr1bce4uOXLqNCpfxByBO7CKwQ="
     },
+    "keymirror": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/keymirror/-/keymirror-0.1.1.tgz",
+      "integrity": "sha1-kYiJ6hP40KQufFVyUO7nE63JXDU="
+    },
     "kind-of": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
@@ -7453,7 +7543,8 @@
     "left-pad": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
-      "integrity": "sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA=="
+      "integrity": "sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA==",
+      "dev": true
     },
     "leven": {
       "version": "2.1.0",
@@ -7465,6 +7556,7 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "dev": true,
       "requires": {
         "prelude-ls": "1.1.2",
         "type-check": "0.3.2"
@@ -7562,7 +7654,8 @@
     "lodash.sortby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
-      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
+      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
+      "dev": true
     },
     "longest": {
       "version": "1.0.1",
@@ -7622,13 +7715,13 @@
       }
     },
     "material-ui": {
-      "version": "1.0.0-beta.41",
-      "resolved": "https://registry.npmjs.org/material-ui/-/material-ui-1.0.0-beta.41.tgz",
-      "integrity": "sha512-eUFD7mrrAIHPY/KGX23SDWJE5Xg5TAm4rH+E71yrKjmVOwrXT1YBxw1LUw9r+Y4XQD7rhGmGrUQan5CJAWUG5A==",
+      "version": "1.0.0-beta.47",
+      "resolved": "https://registry.npmjs.org/material-ui/-/material-ui-1.0.0-beta.47.tgz",
+      "integrity": "sha512-SLyYStYSGrrhBtDQS6j2lpKeP3Nfi4vn+PA24xwuL+qSLJODD1EiQpn7w13Ky7Ni3M3Q1svBmHNnZLIKeOL85w==",
       "requires": {
+        "@babel/runtime": "7.0.0-beta.46",
         "@types/jss": "9.5.2",
         "@types/react-transition-group": "2.0.8",
-        "babel-runtime": "6.26.0",
         "brcast": "3.0.1",
         "classnames": "2.2.5",
         "deepmerge": "2.1.0",
@@ -7647,13 +7740,29 @@
         "prop-types": "15.6.1",
         "react-event-listener": "0.5.3",
         "react-jss": "8.4.0",
-        "react-lifecycles-compat": "1.1.4",
-        "react-popper": "0.8.3",
+        "react-lifecycles-compat": "3.0.4",
+        "react-popper": "0.10.4",
         "react-scrollbar-size": "2.1.0",
         "react-transition-group": "2.3.0",
         "recompose": "0.26.0",
         "scroll": "2.0.3",
         "warning": "3.0.0"
+      },
+      "dependencies": {
+        "react-lifecycles-compat": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
+          "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+        },
+        "react-popper": {
+          "version": "0.10.4",
+          "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-0.10.4.tgz",
+          "integrity": "sha1-rypBXqIike3VBGeNev2opu4ylao=",
+          "requires": {
+            "popper.js": "1.14.3",
+            "prop-types": "15.6.1"
+          }
+        }
       }
     },
     "maximatch": {
@@ -8349,12 +8458,14 @@
     "nwmatcher": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.4.4.tgz",
-      "integrity": "sha512-3iuY4N5dhgMpCUrOVnuAdGrgxVqV2cJpM+XNccjR2DKOB1RUP0aA+wGXEiNziG/UKboFyGBIoKOaNlJxx8bciQ=="
+      "integrity": "sha512-3iuY4N5dhgMpCUrOVnuAdGrgxVqV2cJpM+XNccjR2DKOB1RUP0aA+wGXEiNziG/UKboFyGBIoKOaNlJxx8bciQ==",
+      "dev": true
     },
     "oauth-sign": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
+      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+      "dev": true
     },
     "object-assign": {
       "version": "4.1.1",
@@ -8522,6 +8633,7 @@
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+      "dev": true,
       "requires": {
         "deep-is": "0.1.3",
         "fast-levenshtein": "2.0.6",
@@ -8534,7 +8646,8 @@
         "wordwrap": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-          "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
+          "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+          "dev": true
         }
       }
     },
@@ -8825,7 +8938,8 @@
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+      "dev": true
     },
     "pify": {
       "version": "3.0.0",
@@ -8871,7 +8985,8 @@
     "pn": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
-      "integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA=="
+      "integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==",
+      "dev": true
     },
     "popper.js": {
       "version": "1.14.3",
@@ -8886,7 +9001,8 @@
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "dev": true
     },
     "prepend-http": {
       "version": "1.0.4",
@@ -9245,20 +9361,6 @@
         "theming": "1.3.0"
       }
     },
-    "react-lifecycles-compat": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-1.1.4.tgz",
-      "integrity": "sha512-g3pdexIqkn+CVvSpYIoyON8zUbF9kgfhp672gyz7wQ7PQyXVmJtah+GDYqpHpOrdwex3F77iv+alq79iux9HZw=="
-    },
-    "react-popper": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-0.8.3.tgz",
-      "integrity": "sha1-D3MzMTfJ+wr27EB00tBYWgoEYeE=",
-      "requires": {
-        "popper.js": "1.14.3",
-        "prop-types": "15.6.1"
-      }
-    },
     "react-reconciler": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.7.0.tgz",
@@ -9557,6 +9659,7 @@
       "version": "2.85.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.85.0.tgz",
       "integrity": "sha512-8H7Ehijd4js+s6wuVPLjwORxD4zeuyjYugprdOXlPSqaApmL/QOy+EB/beICHVCHkGMKNh5rvihb5ov+IDw4mg==",
+      "dev": true,
       "requires": {
         "aws-sign2": "0.7.0",
         "aws4": "1.7.0",
@@ -9586,6 +9689,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
       "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
+      "dev": true,
       "requires": {
         "lodash": "4.17.5"
       }
@@ -9594,6 +9698,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.5.tgz",
       "integrity": "sha1-UoF3D2jgyXGeUWP9P6tIIhX0/aU=",
+      "dev": true,
       "requires": {
         "request-promise-core": "1.1.1",
         "stealthy-require": "1.1.1",
@@ -9792,7 +9897,8 @@
     "sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+      "dev": true
     },
     "schema-utils": {
       "version": "0.4.5",
@@ -10096,6 +10202,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
       "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
+      "dev": true,
       "requires": {
         "hoek": "4.2.1"
       }
@@ -10582,6 +10689,7 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.1.tgz",
       "integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
+      "dev": true,
       "requires": {
         "asn1": "0.2.3",
         "assert-plus": "1.0.0",
@@ -10639,7 +10747,8 @@
     "stealthy-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
-      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
+      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
+      "dev": true
     },
     "stifle": {
       "version": "1.0.4",
@@ -10724,7 +10833,8 @@
     "stringstream": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
+      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
+      "dev": true
     },
     "strip-ansi": {
       "version": "3.0.1",
@@ -10796,7 +10906,8 @@
     "symbol-tree": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
-      "integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY="
+      "integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY=",
+      "dev": true
     },
     "table": {
       "version": "4.0.2",
@@ -11115,6 +11226,7 @@
       "version": "2.3.4",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
       "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+      "dev": true,
       "requires": {
         "punycode": "1.4.1"
       },
@@ -11122,7 +11234,8 @@
         "punycode": {
           "version": "1.4.1",
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+          "dev": true
         }
       }
     },
@@ -11130,6 +11243,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
       "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+      "dev": true,
       "requires": {
         "punycode": "2.1.0"
       }
@@ -11148,6 +11262,7 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "dev": true,
       "requires": {
         "safe-buffer": "5.1.1"
       }
@@ -11156,12 +11271,14 @@
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "dev": true,
       "optional": true
     },
     "type-check": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "dev": true,
       "requires": {
         "prelude-ls": "1.1.2"
       }
@@ -11480,6 +11597,7 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "dev": true,
       "requires": {
         "assert-plus": "1.0.0",
         "core-util-is": "1.0.2",
@@ -11498,6 +11616,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz",
       "integrity": "sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=",
+      "dev": true,
       "requires": {
         "browser-process-hrtime": "0.1.2"
       }
@@ -11550,7 +11669,8 @@
     "webidl-conversions": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
-      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="
+      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+      "dev": true
     },
     "webpack": {
       "version": "3.10.0",
@@ -11691,6 +11811,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.3.tgz",
       "integrity": "sha512-jLBwwKUhi8WtBfsMQlL4bUUcT8sMkAtQinscJAe/M4KHCkHuUJAF6vuB0tueNIw4c8ziO6AkRmgY+jL3a0iiPw==",
+      "dev": true,
       "requires": {
         "iconv-lite": "0.4.19"
       }
@@ -11703,12 +11824,14 @@
     "whatwg-mimetype": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.1.0.tgz",
-      "integrity": "sha512-FKxhYLytBQiUKjkYteN71fAUA3g6KpNXoho1isLiLSB3N1G4F35Q5vUxWfKFhBwi5IWF27VE6WxhrnnC+m0Mew=="
+      "integrity": "sha512-FKxhYLytBQiUKjkYteN71fAUA3g6KpNXoho1isLiLSB3N1G4F35Q5vUxWfKFhBwi5IWF27VE6WxhrnnC+m0Mew==",
+      "dev": true
     },
     "whatwg-url": {
       "version": "6.4.1",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.4.1.tgz",
       "integrity": "sha512-FwygsxsXx27x6XXuExA/ox3Ktwcbf+OAvrKmLulotDAiO1Q6ixchPFaHYsis2zZBZSJTR0+dR+JVtf7MlbqZjw==",
+      "dev": true,
       "requires": {
         "lodash.sortby": "4.7.0",
         "tr46": "1.0.1",
@@ -11857,6 +11980,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-4.1.0.tgz",
       "integrity": "sha512-ZGh/8kF9rrRNffkLFV4AzhvooEclrOH0xaugmqGsIfFgOE/pIz4fMc4Ef+5HSQqTEug2S9JZIWDR47duDSLfaA==",
+      "dev": true,
       "requires": {
         "async-limiter": "1.0.0",
         "safe-buffer": "5.1.1"
@@ -11876,7 +12000,8 @@
     "xml-name-validator": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
-      "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw=="
+      "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
+      "dev": true
     },
     "xml2js": {
       "version": "0.4.19",

--- a/src/components/ProductGrid/ProductGrid.js
+++ b/src/components/ProductGrid/ProductGrid.js
@@ -1,12 +1,23 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import Grid from "material-ui/Grid";
+import { withStyles } from "material-ui/styles";
 
 import ProductItem from "components/ProductItem";
 
-class ProductGrid extends Component {
+const styles = () => ({
+  productGridContainer: {
+    maxWidth: "1440px",
+    marginLeft: "auto",
+    marginRight: "auto"
+  }
+});
+
+@withStyles(styles)
+export default class ProductGrid extends Component {
   static propTypes = {
-    catalogItems: PropTypes.arrayOf(PropTypes.object)
+    catalogItems: PropTypes.arrayOf(PropTypes.object),
+    classes: PropTypes.object
   };
 
   renderProduct(edge) {
@@ -42,10 +53,10 @@ class ProductGrid extends Component {
   }
 
   render() {
-    const { catalogItems } = this.props;
+    const { catalogItems, classes } = this.props;
 
     return (
-      <section>
+      <section className={classes.productGridContainer}>
         <Grid container spacing={24}>
           {(catalogItems && catalogItems.length) ? catalogItems.map(this.renderProduct) : null}
         </Grid>
@@ -53,5 +64,3 @@ class ProductGrid extends Component {
     );
   }
 }
-
-export default ProductGrid;

--- a/src/components/ProductGrid/__snapshots__/ProductGrid.test.js.snap
+++ b/src/components/ProductGrid/__snapshots__/ProductGrid.test.js.snap
@@ -12,7 +12,7 @@ exports[`basic snapshot 1`] = `
     >
       <div>
         <a
-          className="Link-link-107"
+          className="Link-link-99"
           href="/product/men's-lightweigth-synchilla"
           onClick={[Function]}
         >
@@ -20,14 +20,10 @@ exports[`basic snapshot 1`] = `
             className="inject-ProductItem-with-uiStore-productMedia-94"
           >
             <div
-              className="MuiChip-root-108 inject-ProductItem-with-uiStore-chip-95 inject-ProductItem-with-uiStore-status-97 inject-ProductItem-with-uiStore-statusSoldOut-98"
-              onClick={undefined}
-              onKeyDown={[Function]}
-              role="button"
-              tabIndex={-1}
+              className="Badge-badge-100 Badge-status-102 Badge-soldOut-103"
             >
               <span
-                className="MuiChip-label-113 inject-ProductItem-with-uiStore-chipLabel-96"
+                className="Badge-labelStyle-101"
               >
                 Sold Out
               </span>
@@ -54,17 +50,17 @@ exports[`basic snapshot 1`] = `
               />
               <img
                 alt=""
-                className="inject-ProductItem-with-uiStore-img-103"
+                className="inject-ProductItem-with-uiStore-img-95"
                 onLoad={[Function]}
                 src="http://localhost:3000/assets/files/Media/aHEWna7yeBvNFM9bL/small/25580_CICN.png"
               />
             </picture>
             <div
-              className="inject-ProductItem-with-uiStore-imgLoading-104"
+              className="inject-ProductItem-with-uiStore-imgLoading-96"
             >
               <svg
                 aria-hidden="true"
-                className="MuiSvgIcon-root-139 inject-ProductItem-with-uiStore-loadingIcon-105"
+                className="MuiSvgIcon-root-133 inject-ProductItem-with-uiStore-loadingIcon-97"
                 color={undefined}
                 focusable="false"
                 viewBox="0 0 24 24"
@@ -80,12 +76,12 @@ exports[`basic snapshot 1`] = `
               className="inject-ProductItem-with-uiStore-productInfo-93"
             >
               <aside
-                className="MuiTypography-root-115 MuiTypography-body2-123"
+                className="MuiTypography-root-109 MuiTypography-body2-117"
               >
                 Men's Lightweigth Synchilla
               </aside>
               <p
-                className="MuiTypography-root-115 MuiTypography-body1-124"
+                className="MuiTypography-root-109 MuiTypography-body1-118"
               >
                 $
                 7.99 - 77.99
@@ -93,7 +89,7 @@ exports[`basic snapshot 1`] = `
             </div>
             <div>
               <p
-                className="MuiTypography-root-115 MuiTypography-body1-124"
+                className="MuiTypography-root-109 MuiTypography-body1-118"
               >
                 Patagonia
               </p>
@@ -107,7 +103,7 @@ exports[`basic snapshot 1`] = `
     >
       <div>
         <a
-          className="Link-link-107"
+          className="Link-link-99"
           href="/product/example-product"
           onClick={[Function]}
         >
@@ -136,17 +132,17 @@ exports[`basic snapshot 1`] = `
               />
               <img
                 alt=""
-                className="inject-ProductItem-with-uiStore-img-103"
+                className="inject-ProductItem-with-uiStore-img-95"
                 onLoad={[Function]}
                 src="http://localhost:3000/assets/files/Media/mmY4m9gwPK2uFEZ8w/small/product_image.png"
               />
             </picture>
             <div
-              className="inject-ProductItem-with-uiStore-imgLoading-104"
+              className="inject-ProductItem-with-uiStore-imgLoading-96"
             >
               <svg
                 aria-hidden="true"
-                className="MuiSvgIcon-root-139 inject-ProductItem-with-uiStore-loadingIcon-105"
+                className="MuiSvgIcon-root-133 inject-ProductItem-with-uiStore-loadingIcon-97"
                 color={undefined}
                 focusable="false"
                 viewBox="0 0 24 24"
@@ -162,12 +158,12 @@ exports[`basic snapshot 1`] = `
               className="inject-ProductItem-with-uiStore-productInfo-93"
             >
               <aside
-                className="MuiTypography-root-115 MuiTypography-body2-123"
+                className="MuiTypography-root-109 MuiTypography-body2-117"
               >
                 Basic Reaction Product
               </aside>
               <p
-                className="MuiTypography-root-115 MuiTypography-body1-124"
+                className="MuiTypography-root-109 MuiTypography-body1-118"
               >
                 $
                 12.99 - 19.99
@@ -175,7 +171,7 @@ exports[`basic snapshot 1`] = `
             </div>
             <div>
               <p
-                className="MuiTypography-root-115 MuiTypography-body1-124"
+                className="MuiTypography-root-109 MuiTypography-body1-118"
               >
                 Reaction Commerce
               </p>

--- a/src/components/ProductGrid/__snapshots__/ProductGrid.test.js.snap
+++ b/src/components/ProductGrid/__snapshots__/ProductGrid.test.js.snap
@@ -1,31 +1,33 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`basic snapshot 1`] = `
-<section>
+<section
+  className="ProductGrid-productGridContainer-1"
+>
   <div
-    className="MuiGrid-container-1 MuiGrid-spacing-xs-24-24"
+    className="MuiGrid-container-2 MuiGrid-spacing-xs-24-25"
   >
     <div
-      className="MuiGrid-item-2 MuiGrid-grid-xs-12-38 MuiGrid-grid-sm-4-43 MuiGrid-grid-md-3-55"
+      className="MuiGrid-item-3 MuiGrid-grid-xs-12-39 MuiGrid-grid-sm-4-44 MuiGrid-grid-md-3-56"
     >
       <div>
         <a
-          className="Link-link-106"
+          className="Link-link-107"
           href="/product/men's-lightweigth-synchilla"
           onClick={[Function]}
         >
           <div
-            className="inject-ProductItem-with-uiStore-productMedia-93"
+            className="inject-ProductItem-with-uiStore-productMedia-94"
           >
             <div
-              className="MuiChip-root-107 inject-ProductItem-with-uiStore-chip-94 inject-ProductItem-with-uiStore-status-96 inject-ProductItem-with-uiStore-statusSoldOut-97"
+              className="MuiChip-root-108 inject-ProductItem-with-uiStore-chip-95 inject-ProductItem-with-uiStore-status-97 inject-ProductItem-with-uiStore-statusSoldOut-98"
               onClick={undefined}
               onKeyDown={[Function]}
               role="button"
               tabIndex={-1}
             >
               <span
-                className="MuiChip-label-112 inject-ProductItem-with-uiStore-chipLabel-95"
+                className="MuiChip-label-113 inject-ProductItem-with-uiStore-chipLabel-96"
               >
                 Sold Out
               </span>
@@ -52,17 +54,17 @@ exports[`basic snapshot 1`] = `
               />
               <img
                 alt=""
-                className="inject-ProductItem-with-uiStore-img-102"
+                className="inject-ProductItem-with-uiStore-img-103"
                 onLoad={[Function]}
                 src="http://localhost:3000/assets/files/Media/aHEWna7yeBvNFM9bL/small/25580_CICN.png"
               />
             </picture>
             <div
-              className="inject-ProductItem-with-uiStore-imgLoading-103"
+              className="inject-ProductItem-with-uiStore-imgLoading-104"
             >
               <svg
                 aria-hidden="true"
-                className="MuiSvgIcon-root-138 inject-ProductItem-with-uiStore-loadingIcon-104"
+                className="MuiSvgIcon-root-139 inject-ProductItem-with-uiStore-loadingIcon-105"
                 color={undefined}
                 focusable="false"
                 viewBox="0 0 24 24"
@@ -75,15 +77,15 @@ exports[`basic snapshot 1`] = `
           </div>
           <div>
             <div
-              className="inject-ProductItem-with-uiStore-productInfo-92"
+              className="inject-ProductItem-with-uiStore-productInfo-93"
             >
               <aside
-                className="MuiTypography-root-114 MuiTypography-body2-122"
+                className="MuiTypography-root-115 MuiTypography-body2-123"
               >
                 Men's Lightweigth Synchilla
               </aside>
               <p
-                className="MuiTypography-root-114 MuiTypography-body1-123"
+                className="MuiTypography-root-115 MuiTypography-body1-124"
               >
                 $
                 7.99 - 77.99
@@ -91,7 +93,7 @@ exports[`basic snapshot 1`] = `
             </div>
             <div>
               <p
-                className="MuiTypography-root-114 MuiTypography-body1-123"
+                className="MuiTypography-root-115 MuiTypography-body1-124"
               >
                 Patagonia
               </p>
@@ -101,16 +103,16 @@ exports[`basic snapshot 1`] = `
       </div>
     </div>
     <div
-      className="MuiGrid-item-2 MuiGrid-grid-xs-12-38 MuiGrid-grid-sm-4-43 MuiGrid-grid-md-3-55"
+      className="MuiGrid-item-3 MuiGrid-grid-xs-12-39 MuiGrid-grid-sm-4-44 MuiGrid-grid-md-3-56"
     >
       <div>
         <a
-          className="Link-link-106"
+          className="Link-link-107"
           href="/product/example-product"
           onClick={[Function]}
         >
           <div
-            className="inject-ProductItem-with-uiStore-productMedia-93"
+            className="inject-ProductItem-with-uiStore-productMedia-94"
           >
             <picture
               style={
@@ -134,17 +136,17 @@ exports[`basic snapshot 1`] = `
               />
               <img
                 alt=""
-                className="inject-ProductItem-with-uiStore-img-102"
+                className="inject-ProductItem-with-uiStore-img-103"
                 onLoad={[Function]}
                 src="http://localhost:3000/assets/files/Media/mmY4m9gwPK2uFEZ8w/small/product_image.png"
               />
             </picture>
             <div
-              className="inject-ProductItem-with-uiStore-imgLoading-103"
+              className="inject-ProductItem-with-uiStore-imgLoading-104"
             >
               <svg
                 aria-hidden="true"
-                className="MuiSvgIcon-root-138 inject-ProductItem-with-uiStore-loadingIcon-104"
+                className="MuiSvgIcon-root-139 inject-ProductItem-with-uiStore-loadingIcon-105"
                 color={undefined}
                 focusable="false"
                 viewBox="0 0 24 24"
@@ -157,15 +159,15 @@ exports[`basic snapshot 1`] = `
           </div>
           <div>
             <div
-              className="inject-ProductItem-with-uiStore-productInfo-92"
+              className="inject-ProductItem-with-uiStore-productInfo-93"
             >
               <aside
-                className="MuiTypography-root-114 MuiTypography-body2-122"
+                className="MuiTypography-root-115 MuiTypography-body2-123"
               >
                 Basic Reaction Product
               </aside>
               <p
-                className="MuiTypography-root-114 MuiTypography-body1-123"
+                className="MuiTypography-root-115 MuiTypography-body1-124"
               >
                 $
                 12.99 - 19.99
@@ -173,7 +175,7 @@ exports[`basic snapshot 1`] = `
             </div>
             <div>
               <p
-                className="MuiTypography-root-114 MuiTypography-body1-123"
+                className="MuiTypography-root-115 MuiTypography-body1-124"
               >
                 Reaction Commerce
               </p>

--- a/src/components/ProductItem/styles.js
+++ b/src/components/ProductItem/styles.js
@@ -53,18 +53,8 @@ export const styles = (theme) => ({
     top: theme.spacing.unit
   },
   "img": {
-    // height: "auto",
     width: "100%",
-    objectFit: "cover",
-    [theme.breakpoints.down("sm")]: {
-      height: 3200
-    },
-    [theme.breakpoints.down("md")]: {
-      height: 225
-    },
-    [theme.breakpoints.down("lg")]: {
-      height: 325
-    }
+    height: "auto"
   },
   "imgLoading": {
     alignItems: "center",

--- a/src/components/ProductItem/styles.js
+++ b/src/components/ProductItem/styles.js
@@ -53,8 +53,18 @@ export const styles = (theme) => ({
     top: theme.spacing.unit
   },
   "img": {
-    height: "auto",
-    width: "100%"
+    // height: "auto",
+    width: "100%",
+    objectFit: "cover",
+    [theme.breakpoints.down("sm")]: {
+      height: 3200
+    },
+    [theme.breakpoints.down("md")]: {
+      height: 225
+    },
+    [theme.breakpoints.down("lg")]: {
+      height: 325
+    }
   },
   "imgLoading": {
     alignItems: "center",

--- a/src/pages/tag.js
+++ b/src/pages/tag.js
@@ -33,25 +33,18 @@ export default class TagShop extends Component {
     return (
       <Helmet>
         <title>{pageTitle}</title>
-        <meta name="description" content={shop.description} />
+        <meta name="description" content={shop && shop.description} />
       </Helmet>
     );
   }
 
   render() {
-    const { shop } = this.props;
-    const meta = {
-      description: shop.description,
-      siteName: shop.name,
-      title: shop.name
-    };
+    const { catalogItems } = this.props;
 
     return (
       <Layout title="Reaction Shop">
         {this.renderHelmet()}
-        <FacebookSocial meta={meta} />
-        <TwitterSocial meta={meta} />
-        <ProductGrid catalogItems={this.props.catalogItems} />
+        <ProductGrid catalogItems={catalogItems} />
       </Layout>
     );
   }

--- a/src/pages/tag.js
+++ b/src/pages/tag.js
@@ -8,7 +8,6 @@ import withRoot from "lib/theme/withRoot";
 import withShop from "containers/shop/withShop";
 import Layout from "components/Layout";
 import ProductGrid from "components/ProductGrid";
-import { FacebookSocial, TwitterSocial } from "components/Social";
 
 @withData
 @withShop


### PR DESCRIPTION
Fixes Issues #65 & #71 

Product grid items have three different sizes. The heights of medium and large items were affecting the grid heights, as there were not stable. In addition, there was no container, so the grid was always full-width

This PR adds a fixed height to product grid images, to keep the grid... a grid. It also adds a 1440px container, as discussed in ticket #71, to contain the grid.

It uses `material-ui-next`s built in CSS-in-JS `sm`, `md`, and `lg` breakpoints.

The PR also adds some docs (a link to the actual Material UI docs).

This PR also removes leftover test code from #59 