### PR TITLE
MobX Refactor

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,5 @@ NODE_ENV=development
 INTERNAL_GRAPHQL_URL=http://devserver.reaction-api:3030/graphql-alpha
 EXTERNAL_GRAPHQL_URL=http://localhost:3030/graphql-alpha
 EXTERNAL_ASSETS_URL=http://localhost:3000
+PLACEHOLDER_IMAGE_URL_GALLERY=/resources/placeholder.gif
+PLACEHOLDER_IMAGE_URL_GRID=/resources/placeholder.gif

--- a/docs/MOBX.md
+++ b/docs/MOBX.md
@@ -16,36 +16,20 @@ The mobx `RoutingStore` data store provides data related to the current route. T
 `UIStore` data store provides data related to various UI elements of the app. The values are set at various places throughout the app.
 
 ## Adding a new observable prop to an existing store
-To create a new observable, add the `@observable` decorator before a `property = value` set. Then, add a setter and getter to allow data to be viewed and manipulated. If needed, add an `@action` function inside the store.
+To create a new observable, add the `@observable` decorator before a `property = value` set. For each type of action that could set the prop, add a class method with `@action` decorator.
 
-Using our [`cartOpen` @observable](https://github.com/reactioncommerce/reaction-next-starterkit/blob/master/src/lib/stores/UIStore.js) as an example:
+Using our [`isCartOpen` @observable](https://github.com/reactioncommerce/reaction-next-starterkit/blob/master/src/lib/stores/UIStore.js) as an example:
 
 - Set the observable default data:
 ```
-@observable _cartOpen = false;
-```
-
-- Add a getter, using the `@computed` decorator:
-```
-@computed
-get cartOpen() {
-  return this._cartOpen;
-}
-```
-
-- Add a setter, to be used to set a new value to the data store:
-```
-set cartOpen(value) {
-  this._cartOpen = value;
-}
+@observable isCartOpen = false;
 ```
 
 - Add an action, using the `@action` decorator, to change the value of the `@observable`:
 ```
-@action
-toggleCartOpen = () => {
-  this.cartOpen = !this.cartOpen;
-};
+@action toggleCartOpen() {
+  this.isCartOpen = !this.isCartOpen;
+}
 ```
 
 Link: [Creating observables (MobX official documentation)](https://mobx.js.org/refguide/api.html#creating-observables)

--- a/docs/MOBX.md
+++ b/docs/MOBX.md
@@ -27,8 +27,8 @@ Using our [`isCartOpen` @observable](https://github.com/reactioncommerce/reactio
 
 - Add an action, using the `@action` decorator, to change the value of the `@observable`:
 ```
-@action toggleCartOpen() {
-  this.isCartOpen = !this.isCartOpen;
+@action openCart() {
+  this.isCartOpen = true;
 }
 ```
 

--- a/next.config.js
+++ b/next.config.js
@@ -8,8 +8,8 @@ const initExport = {
     externalAssetsUrl: process.env.EXTERNAL_ASSETS_URL,
     graphqlUrl: process.env.EXTERNAL_GRAPHQL_URL,
     placeholderImageUrls: {
-      galleryFeatured: "/resources/placeholder.gif",
-      productGrid: "/resources/placeholder.gif"
+      galleryFeatured: process.env.PLACEHOLDER_IMAGE_URL_GALLERY,
+      productGrid: process.env.PLACEHOLDER_IMAGE_URL_GRID
     }
   },
   webpack: (config) => {

--- a/next.config.js
+++ b/next.config.js
@@ -6,7 +6,11 @@ const initExport = {
   },
   publicRuntimeConfig: { // Will be available on both server and client
     externalAssetsUrl: process.env.EXTERNAL_ASSETS_URL,
-    graphqlUrl: process.env.EXTERNAL_GRAPHQL_URL
+    graphqlUrl: process.env.EXTERNAL_GRAPHQL_URL,
+    placeholderImageUrls: {
+      galleryFeatured: "/resources/placeholder.gif",
+      productGrid: "/resources/placeholder.gif"
+    }
   },
   webpack: (config) => {
     config.module.rules.push({

--- a/package.json
+++ b/package.json
@@ -53,9 +53,9 @@
     "passport": "^0.4.0",
     "passport-cookie": "^1.0.6",
     "prop-types": "^15.6.1",
-    "react": "^16.3.0",
+    "react": "16.3.2",
     "react-apollo": "^2.1.3",
-    "react-dom": "^16.3.0",
+    "react-dom": "16.3.2",
     "react-helmet": "^5.2.0"
   },
   "devDependencies": {

--- a/src/components/Cart/Cart.js
+++ b/src/components/Cart/Cart.js
@@ -16,18 +16,23 @@ const styles = () => ({
 class Cart extends Component {
   static propTypes = {
     classes: PropTypes.object,
-    uiStore: PropTypes.object
+    uiStore: PropTypes.shape({
+      toggleCartOpen: PropTypes.func
+    }).isRequired
   };
 
   static defaultProps = {
-    classes: {},
-    uiStore: {}
+    classes: {}
+  };
+
+  handleClose = () => {
+    this.props.uiStore.toggleCartOpen();
   };
 
   render() {
     const { classes, uiStore } = this.props;
     return (
-      <Drawer anchor="right" open={uiStore.cartOpen} onClose={uiStore.toggleCartOpen}>
+      <Drawer anchor="right" open={uiStore.isCartOpen} onClose={this.handleClose}>
         <div className={classes.cart}>Cart Component</div>
       </Drawer>
     );

--- a/src/components/Cart/Cart.js
+++ b/src/components/Cart/Cart.js
@@ -17,7 +17,7 @@ class Cart extends Component {
   static propTypes = {
     classes: PropTypes.object,
     uiStore: PropTypes.shape({
-      toggleCartOpen: PropTypes.func
+      closeCart: PropTypes.func
     }).isRequired
   };
 
@@ -26,7 +26,7 @@ class Cart extends Component {
   };
 
   handleClose = () => {
-    this.props.uiStore.toggleCartOpen();
+    this.props.uiStore.closeCart();
   };
 
   render() {

--- a/src/components/Cart/CartToggle.js
+++ b/src/components/Cart/CartToggle.js
@@ -1,24 +1,16 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
-import { inject } from "mobx-react";
 import IconButton from "material-ui/IconButton";
 import CartIcon from "mdi-material-ui/Cart";
 
-@inject("uiStore")
 class CartToggle extends Component {
   static propTypes = {
-    uiStore: PropTypes.shape({
-      toggleCartOpen: PropTypes.func
-    }).isRequired
-  };
-
-  handleClick = () => {
-    this.props.uiStore.toggleCartOpen();
+    onClick: PropTypes.func
   };
 
   render() {
     return (
-      <IconButton color="inherit" onClick={this.handleClick}>
+      <IconButton color="inherit" onClick={this.props.onClick}>
         <CartIcon />
       </IconButton>
     );

--- a/src/components/Cart/CartToggle.js
+++ b/src/components/Cart/CartToggle.js
@@ -1,24 +1,24 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
-import { inject, observer } from "mobx-react";
+import { inject } from "mobx-react";
 import IconButton from "material-ui/IconButton";
 import CartIcon from "mdi-material-ui/Cart";
 
 @inject("uiStore")
-@observer
 class CartToggle extends Component {
   static propTypes = {
-    uiStore: PropTypes.object
+    uiStore: PropTypes.shape({
+      toggleCartOpen: PropTypes.func
+    }).isRequired
   };
 
-  static defaultProps = {
-    uiStore: {}
+  handleClick = () => {
+    this.props.uiStore.toggleCartOpen();
   };
 
   render() {
-    const { uiStore } = this.props;
     return (
-      <IconButton color="inherit" onClick={uiStore.toggleCartOpen}>
+      <IconButton color="inherit" onClick={this.handleClick}>
         <CartIcon />
       </IconButton>
     );

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -5,6 +5,7 @@ import Hidden from "material-ui/Hidden";
 import Toolbar from "material-ui/Toolbar";
 import Typography from "material-ui/Typography";
 import { withStyles } from "material-ui/styles";
+import { inject } from "mobx-react";
 import { NavigationDesktop } from "components/NavigationDesktop";
 import { NavigationMobile, NavigationToggleMobile } from "components/NavigationMobile";
 import { CartToggle } from "components/Cart";
@@ -28,6 +29,7 @@ const styles = (theme) => ({
 });
 
 @withStyles(styles)
+@inject("uiStore")
 class Header extends Component {
   static propTypes = {
     classes: PropTypes.object,
@@ -37,6 +39,10 @@ class Header extends Component {
   static defaultProps = {
     classes: {},
     uiStore: {}
+  };
+
+  handleCartToggleClick = () => {
+    this.props.uiStore.toggleCartOpen();
   };
 
   render() {
@@ -60,7 +66,7 @@ class Header extends Component {
           </div>
 
           <AccountDropdown />
-          <CartToggle />
+          <CartToggle onClick={this.handleCartToggleClick} />
         </Toolbar>
 
         <NavigationMobile />

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -33,12 +33,18 @@ const styles = (theme) => ({
 class Header extends Component {
   static propTypes = {
     classes: PropTypes.object,
-    uiStore: PropTypes.object
+    uiStore: PropTypes.shape({
+      toggleCartOpen: PropTypes.func.isRequired,
+      toggleMenuDrawerOpen: PropTypes.func.isRequired
+    }).isRequired
   };
 
   static defaultProps = {
-    classes: {},
-    uiStore: {}
+    classes: {}
+  };
+
+  handleNavigationToggleClick = () => {
+    this.props.uiStore.toggleMenuDrawerOpen();
   };
 
   handleCartToggleClick = () => {
@@ -52,7 +58,7 @@ class Header extends Component {
       <AppBar position="static" elevation={0}>
         <Toolbar className={toolbar}>
           <Hidden mdUp>
-            <NavigationToggleMobile />
+            <NavigationToggleMobile onClick={this.handleNavigationToggleClick} />
           </Hidden>
 
           <div className={controls}>

--- a/src/components/MediaGallery/MediaGallery.js
+++ b/src/components/MediaGallery/MediaGallery.js
@@ -72,11 +72,16 @@ class MediaGallery extends Component {
 
   state = { featuredMediaIndex: 0 };
 
-  getClickHandler(index) {
-    return () => {
-      this.setState({ featuredMediaIndex: index });
-    };
-  }
+  /**
+   * @name handleMediaItemClick
+   * @param {SyntheticEvent} event Event
+   * @param {Object} media The `media` prop of the MediaGalleryItem that was clicked
+   * @param {Number} index The `index` prop of the MediaGalleryItem that was clicked
+   * @returns {undefined} Nothing
+   */
+  handleMediaItemClick = (event, media, index) => {
+    this.setState({ featuredMediaIndex: index });
+  };
 
   renderFeaturedImage() {
     const { classes, mediaItems, uiStore } = this.props;
@@ -112,8 +117,9 @@ class MediaGallery extends Component {
                 sm={2}
               >
                 <MediaGalleryItem
+                  index={index}
                   media={media}
-                  onClick={this.getClickHandler(index)}
+                  onClick={this.handleMediaItemClick}
                 />
               </Grid>
             ))}

--- a/src/components/MediaGallery/MediaGallery.js
+++ b/src/components/MediaGallery/MediaGallery.js
@@ -2,7 +2,6 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import Grid from "material-ui/Grid";
 import withStyles from "material-ui/styles/withStyles";
-import { action, computed, observable } from "mobx";
 import { inject, observer } from "mobx-react";
 import MediaGalleryItem from "components/MediaGalleryItem";
 
@@ -37,8 +36,6 @@ const styles = (theme) => ({
   }
 });
 
-const placeholderImage = "/resources/placeholder.gif";
-
 /**
  * Product detail media gallery
  * @class ProductDetailMediaGallery
@@ -59,7 +56,7 @@ class MediaGallery extends Component {
     mediaItems: PropTypes.arrayOf(PropTypes.object),
 
     /**
-     * UIStore
+     * MUI Theme
      */
     theme: PropTypes.object,
 
@@ -69,42 +66,28 @@ class MediaGallery extends Component {
     uiStore: PropTypes.object
   }
 
-  constructor(props) {
-    super(props);
+  static defaultProps = {
+    mediaItems: []
+  };
 
-    this.featuredMedia = Array.isArray(props.mediaItems) && props.mediaItems[0];
-  }
+  state = { featuredMediaIndex: 0 };
 
-  @observable _featuredMedia
-
-  @computed get featuredMedia() {
-    return this._featuredMedia;
-  }
-
-  set featuredMedia(value) {
-    this._featuredMedia = value;
-  }
-
-  /**
-   * Media item click handler
-   * @param {SyntheticEvent} event - Event
-   * @param {Object} mediaItem - Media item object
-   * @returns {undefined}
-   */
-  @action handleMediaItemClick = (event, mediaItem) => {
-    this.featuredMedia = mediaItem;
+  getClickHandler(index) {
+    return () => {
+      this.setState({ featuredMediaIndex: index });
+    };
   }
 
   renderFeaturedImage() {
-    const { featuredMedia } = this;
-    const { classes, uiStore } = this.props;
+    const { classes, mediaItems, uiStore } = this.props;
     const { publicRuntimeConfig } = uiStore.appConfig;
+    const featuredMedia = mediaItems[this.state.featuredMediaIndex];
     const mediaUrl = featuredMedia && featuredMedia.URLs && featuredMedia.URLs.large;
 
     return (
       <img
         className={classes.featuredImage}
-        src={`${publicRuntimeConfig.externalAssetsUrl}${mediaUrl || placeholderImage}`}
+        src={`${publicRuntimeConfig.externalAssetsUrl}${mediaUrl || publicRuntimeConfig.placeholderImageUrls.galleryFeatured}`}
         alt=""
       />
     );
@@ -112,9 +95,6 @@ class MediaGallery extends Component {
 
   render() {
     const { classes, mediaItems, theme } = this.props;
-
-    // If all props are undefined then skip rendering component
-    if (!mediaItems) return null;
 
     return (
       <Grid container className={classes.root}>
@@ -133,7 +113,7 @@ class MediaGallery extends Component {
               >
                 <MediaGalleryItem
                   media={media}
-                  onClick={this.handleMediaItemClick}
+                  onClick={this.getClickHandler(index)}
                 />
               </Grid>
             ))}

--- a/src/components/NavigationDesktop/NavigationItemDesktop.js
+++ b/src/components/NavigationDesktop/NavigationItemDesktop.js
@@ -1,19 +1,18 @@
 import React, { Component, Fragment } from "react";
 import PropTypes from "prop-types";
 import Button from "material-ui/Button";
-import Divider from "material-ui/Divider";
-import Grid from "material-ui/Grid";
-import ListItemText from "material-ui/List/ListItemText";
-import MenuList from "material-ui/Menu/MenuList";
-import MenuItem from "material-ui/Menu/MenuItem";
-import Popover from "material-ui/Popover";
 import ChevronDownIcon from "mdi-material-ui/ChevronDown";
 import ChevronUpIcon from "mdi-material-ui/ChevronUp";
+import Divider from "material-ui/Divider";
+import Grid from "material-ui/Grid";
+import Link from "components/Link";
+import ListItemText from "material-ui/List/ListItemText";
+import MenuItem from "material-ui/Menu/MenuItem";
+import MenuList from "material-ui/Menu/MenuList";
+import Popover from "material-ui/Popover";
 
-import { observer } from "mobx-react";
-import { action, computed, observable } from "mobx";
 import { withStyles } from "material-ui/styles";
-import { Router } from "../../routes";
+import { Router } from "routes";
 
 const styles = (theme) => ({
   popover: {
@@ -27,7 +26,6 @@ const styles = (theme) => ({
 });
 
 @withStyles(styles)
-@observer
 class NavigationItemDesktop extends Component {
   static propTypes = {
     classes: PropTypes.object,
@@ -39,36 +37,25 @@ class NavigationItemDesktop extends Component {
     navItem: {}
   };
 
+  state = { isSubNavOpen: false };
+
   get hasSubNavItems() {
     const { navItem: { subTags } } = this.props;
     return subTags && Array.isArray(subTags.edges) && subTags.edges.length > 0;
   }
 
-  @observable _isSubNavOpen = false;
-
-  @computed
-  get isSubNavOpen() {
-    return this._isSubNavOpen;
-  }
-
-  set isSubNavOpen(value) {
-    this._isSubNavOpen = value;
-  }
-
-  @action
   onClick = () => {
     const { navItem } = this.props;
 
     if (this.hasSubNavItems) {
-      this.isSubNavOpen = !this.isSubNavOpen;
+      this.setState({ isSubNavOpen: !this.state.isSubNavOpen });
     } else {
       Router.pushRoute("tag", { slug: navItem.slug });
     }
   };
 
-  @action
   onClose = () => {
-    this.isSubNavOpen = false;
+    this.setState({ isSubNavOpen: false });
   };
 
   renderSubNav(navItemGroup) {
@@ -77,7 +64,9 @@ class NavigationItemDesktop extends Component {
         <Divider />
         {navItemGroup.subTags.edges.map(({ node: navItem }, index) => (
           <MenuItem dense key={index}>
-            <ListItemText primary={navItem.name} />
+            <Link route={`/tag/${navItem.slug}`}>
+              <ListItemText primary={navItem.name} />
+            </Link>
           </MenuItem>
         ))}
       </Fragment>
@@ -95,7 +84,7 @@ class NavigationItemDesktop extends Component {
           anchorPosition={{ top: 64 }}
           elevation={1}
           onClose={this.onClose}
-          open={this.isSubNavOpen}
+          open={this.state.isSubNavOpen}
         >
           <Grid container className={classes.grid} spacing={16}>
             {subTags.edges.map(({ node: navItemGroup }, index) => (
@@ -123,7 +112,7 @@ class NavigationItemDesktop extends Component {
       <Fragment>
         <Button color="inherit" onClick={this.onClick}>
           {navItem.name}
-          {this.hasSubNavItems && <Fragment>{this.isSubNavOpen ? <ChevronUpIcon /> : <ChevronDownIcon />}</Fragment>}
+          {this.hasSubNavItems && <Fragment>{this.state.isSubNavOpen ? <ChevronUpIcon /> : <ChevronDownIcon />}</Fragment>}
         </Button>
         {this.hasSubNavItems && this.renderPopover()}
       </Fragment>

--- a/src/components/NavigationMobile/NavigationItemMobile.js
+++ b/src/components/NavigationMobile/NavigationItemMobile.js
@@ -10,8 +10,6 @@ import MenuItem from "material-ui/Menu/MenuItem";
 import ChevronDownIcon from "mdi-material-ui/ChevronDown";
 import ChevronUpIcon from "mdi-material-ui/ChevronUp";
 
-import { observer } from "mobx-react";
-import { action, computed, observable } from "mobx";
 import { withStyles } from "material-ui/styles";
 
 const styles = (theme) => ({
@@ -26,7 +24,6 @@ const styles = (theme) => ({
 });
 
 @withStyles(styles)
-@observer
 class NavigationItemMobile extends Component {
   static propTypes = {
     classes: PropTypes.object,
@@ -38,31 +35,25 @@ class NavigationItemMobile extends Component {
     navItem: {}
   };
 
+  state = { isSubNavOpen: false };
+
   get hasSubNavItems() {
     const { navItem: { subTags } } = this.props;
     return Array.isArray(subTags.edges) && subTags.edges.length > 0;
   }
 
-  @observable _isSubNavOpen = false;
-
-  @computed
-  get isSubNavOpen() {
-    return this._isSubNavOpen;
-  }
-
-  set isSubNavOpen(value) {
-    this._isSubNavOpen = value;
-  }
-
-  @action
   onClick = () => {
     const { navItem } = this.props;
 
     if (this.hasSubNavItems) {
-      this.isSubNavOpen = !this.isSubNavOpen;
+      this.setState({ isSubNavOpen: !this.state.isSubNavOpen });
     } else {
-      Router.pushRoute("tag", { slug: navItem.name });
+      Router.pushRoute("tag", { slug: navItem.slug });
     }
+  };
+
+  onClose = () => {
+    this.setState({ isSubNavOpen: false });
   };
 
   renderSubNav(navItemGroup) {
@@ -82,7 +73,7 @@ class NavigationItemMobile extends Component {
   renderCollapse() {
     const { classes, navItem: { subTags } } = this.props;
     return (
-      <Collapse in={this.isSubNavOpen} timeout="auto" unmountOnExit>
+      <Collapse in={this.state.isSubNavOpen} timeout="auto" unmountOnExit>
         <MenuList component="div" disablePadding>
           {subTags.edges.map(({ node: navItemGroup }, index) => (
             <MenuList disablePadding key={index}>
@@ -105,7 +96,7 @@ class NavigationItemMobile extends Component {
           <ListItemText classes={{ primary: classes.primary }} primary={navItem.name} />
           {this.hasSubNavItems && (
             <ListItemIcon className={classes.icon}>
-              {this.isSubNavOpen ? <ChevronUpIcon /> : <ChevronDownIcon />}
+              {this.state.isSubNavOpen ? <ChevronUpIcon /> : <ChevronDownIcon />}
             </ListItemIcon>
           )}
         </MenuItem>

--- a/src/components/NavigationMobile/NavigationMobile.js
+++ b/src/components/NavigationMobile/NavigationMobile.js
@@ -21,24 +21,27 @@ class NavigationMobile extends Component {
   static propTypes = {
     classes: PropTypes.object,
     navItems: PropTypes.object,
-    uiStore: PropTypes.object
+    uiStore: PropTypes.object.isRequired
   };
 
   static defaultProps = {
     classes: {},
-    navItems: [],
-    uiStore: {}
+    navItems: []
   };
 
   renderNavItem(navItem, index) {
     return <NavigationItemMobile key={index} navItem={navItem.node} />;
   }
 
+  handleClose = () => {
+    this.props.uiStore.toggleMenuDrawerOpen();
+  };
+
   render() {
     const { classes, navItems, uiStore } = this.props;
 
     return (
-      <Drawer open={uiStore.menuDrawerOpen} onClose={uiStore.toggleMenuDrawerOpen}>
+      <Drawer open={uiStore.isMenuDrawerOpen} onClose={this.handleClose}>
         <nav className={classes.nav}>
           <MenuList>{navItems.edges && navItems.edges.map(this.renderNavItem)}</MenuList>
         </nav>

--- a/src/components/NavigationMobile/NavigationMobile.js
+++ b/src/components/NavigationMobile/NavigationMobile.js
@@ -21,7 +21,9 @@ class NavigationMobile extends Component {
   static propTypes = {
     classes: PropTypes.object,
     navItems: PropTypes.object,
-    uiStore: PropTypes.object.isRequired
+    uiStore: PropTypes.shape({
+      closeMenuDrawer: PropTypes.func
+    }).isRequired
   };
 
   static defaultProps = {
@@ -34,7 +36,7 @@ class NavigationMobile extends Component {
   }
 
   handleClose = () => {
-    this.props.uiStore.toggleMenuDrawerOpen();
+    this.props.uiStore.closeMenuDrawer();
   };
 
   render() {

--- a/src/components/NavigationMobile/NavigationToggleMobile.js
+++ b/src/components/NavigationMobile/NavigationToggleMobile.js
@@ -1,22 +1,16 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
-import { inject } from "mobx-react";
 import IconButton from "material-ui/IconButton";
 import MenuIcon from "mdi-material-ui/Menu";
 
-@inject("uiStore")
 class NavigationToggleMobile extends Component {
   static propTypes = {
-    uiStore: PropTypes.object.isRequired
-  };
-
-  handleClick = () => {
-    this.props.uiStore.toggleMenuDrawerOpen();
+    onClick: PropTypes.func
   };
 
   render() {
     return (
-      <IconButton color="inherit" onClick={this.handleClick}>
+      <IconButton color="inherit" onClick={this.props.onClick}>
         <MenuIcon />
       </IconButton>
     );

--- a/src/components/NavigationMobile/NavigationToggleMobile.js
+++ b/src/components/NavigationMobile/NavigationToggleMobile.js
@@ -1,24 +1,22 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
-import { inject, observer } from "mobx-react";
+import { inject } from "mobx-react";
 import IconButton from "material-ui/IconButton";
 import MenuIcon from "mdi-material-ui/Menu";
 
 @inject("uiStore")
-@observer
 class NavigationToggleMobile extends Component {
   static propTypes = {
-    uiStore: PropTypes.object
+    uiStore: PropTypes.object.isRequired
   };
 
-  static defaultProps = {
-    uiStore: {}
+  handleClick = () => {
+    this.props.uiStore.toggleMenuDrawerOpen();
   };
 
   render() {
-    const { uiStore } = this.props;
     return (
-      <IconButton color="inherit" onClick={uiStore.toggleMenuDrawerOpen}>
+      <IconButton color="inherit" onClick={this.handleClick}>
         <MenuIcon />
       </IconButton>
     );

--- a/src/components/ProductDetail/ProductDetail.js
+++ b/src/components/ProductDetail/ProductDetail.js
@@ -2,6 +2,7 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { withStyles } from "material-ui/styles";
 import Grid from "material-ui/Grid";
+import { inject, observer } from "mobx-react";
 import Helmet from "react-helmet";
 
 // PDP Components
@@ -10,6 +11,7 @@ import VariantList from "components/VariantList";
 import ProductDetailInfo from "components/ProductDetailInfo";
 import MediaGallery from "components/MediaGallery";
 import TagGrid from "components/TagGrid";
+import { Router } from "routes";
 
 const styles = (theme) => ({
   root: {
@@ -32,15 +34,72 @@ const styles = (theme) => ({
  * @returns {React.Component} React component node that represents a product detail view
  */
 @withStyles(styles, { withTheme: true })
+@inject("uiStore")
+@observer
 class ProductDetail extends Component {
   static propTypes = {
     classes: PropTypes.object,
     product: PropTypes.object,
-    theme: PropTypes.object
+    theme: PropTypes.object,
+    uiStore: PropTypes.object.isRequired
   }
 
+  componentWillMount() {
+    const { product } = this.props;
+
+    // Select first variant by default
+    this.selectVariant(product.variants[0]);
+  }
+
+  selectVariant(variant, optionId) {
+    const { product, uiStore } = this.props;
+
+    // Select the variant, and if it has options, the first option
+    const variantId = variant._id;
+    let selectOptionId = optionId;
+    if (!selectOptionId && variant.options && variant.options.length) {
+      selectOptionId = variant.options[0]._id;
+    }
+
+    uiStore.setPDPSelectedVariantId(variantId, selectOptionId);
+
+    Router.pushRoute("product", {
+      slugOrId: product.slug,
+      variantId: selectOptionId || variantId
+    });
+  }
+
+  /**
+   * @name handleSelectVariant
+   * @summary Called when a variant is selected in the variant list
+   * @private
+   * @ignore
+   * @param {Object} variant The variant object that was selected
+   * @returns {undefined} No return
+   */
+  handleSelectVariant = (variant) => {
+    this.selectVariant(variant);
+  };
+
+  /**
+   * @name handleSelectOption
+   * @summary Called when an option is selected in the option list
+   * @private
+   * @ignore
+   * @param {Object} option The option object that was selected
+   * @returns {undefined} No return
+   */
+  handleSelectOption = (option) => {
+    const { product, uiStore } = this.props;
+
+    // If we are clicking an option, it must be for the current selected variant
+    const variant = product.variants.find((vnt) => vnt._id === uiStore.pdpSelectedVariantId);
+
+    this.selectVariant(variant, option._id);
+  };
+
   render() {
-    const { classes, theme, product } = this.props;
+    const { classes, product, theme, uiStore } = this.props;
 
     return (
       <div className={classes.root}>
@@ -68,7 +127,14 @@ class ProductDetail extends Component {
               description={product.description}
               vendor={product.vendor}
             />
-            <VariantList product={product} variants={product.variants}/>
+            <VariantList
+              onSelectOption={this.handleSelectOption}
+              onSelectVariant={this.handleSelectVariant}
+              product={product}
+              selectedOptionId={uiStore.pdpSelectedOptionId}
+              selectedVariantId={uiStore.pdpSelectedVariantId}
+              variants={product.variants}
+            />
           </Grid>
         </Grid>
       </div>

--- a/src/components/ProductDetail/ProductDetail.js
+++ b/src/components/ProductDetail/ProductDetail.js
@@ -44,7 +44,7 @@ class ProductDetail extends Component {
     uiStore: PropTypes.object.isRequired
   }
 
-  componentWillMount() {
+  componentDidMount() {
     const { product } = this.props;
 
     // Select first variant by default

--- a/src/components/ProductDetail/ProductDetail.test.js
+++ b/src/components/ProductDetail/ProductDetail.test.js
@@ -6,12 +6,15 @@ import theme from "lib/theme/reactionTheme";
 import ProductDetail from "./ProductDetail";
 import sampleData from "./__mocks__/productData.mock";
 
+jest.mock("next/router");
+
 const uiStore = {
   appConfig: {
     publicRuntimeConfig: {
       externalAssetsUrl: ""
     }
-  }
+  },
+  setPDPSelectedVariantId: jest.fn().mockName("uiStore.setPDPSelectedVariantId")
 };
 
 test("basic snapshot", () => {

--- a/src/components/ProductDetail/__snapshots__/ProductDetail.test.js.snap
+++ b/src/components/ProductDetail/__snapshots__/ProductDetail.test.js.snap
@@ -2,16 +2,16 @@
 
 exports[`basic snapshot 1`] = `
 <div
-  className="ProductDetail-root-1"
+  className="inject-ProductDetail-with-uiStore-root-1"
 >
   <div
-    className="MuiGrid-container-4 MuiGrid-spacing-xs-24-27 ProductDetail-pdpContainer-2"
+    className="MuiGrid-container-4 MuiGrid-spacing-xs-24-27 inject-ProductDetail-with-uiStore-pdpContainer-2"
   >
     <div
       className="MuiGrid-item-5 MuiGrid-grid-xs-12-41 MuiGrid-grid-sm-6-48"
     >
       <div
-        className="ProductDetail-section-3"
+        className="inject-ProductDetail-with-uiStore-section-3"
       >
         <div
           className="MuiGrid-container-4 inject-MediaGallery-with-uiStore-root-94"
@@ -276,7 +276,7 @@ exports[`basic snapshot 1`] = `
         </div>
       </div>
       <div
-        className="ProductDetail-section-3"
+        className="inject-ProductDetail-with-uiStore-section-3"
       >
         <section>
           <h2
@@ -382,7 +382,7 @@ Details can be added below the image for more specific product information.
           className="VariantList-variantItem-144"
         >
           <button
-            className="MuiButtonBase-root-99 VariantItem-variantButton-146 VariantItem-activeVariant-147"
+            className="MuiButtonBase-root-99 VariantItem-variantButton-146"
             disabled={undefined}
             onBlur={[Function]}
             onClick={[Function]}
@@ -450,92 +450,6 @@ Details can be added below the image for more specific product information.
               className="MuiTypography-root-111 MuiTypography-body1-120"
             />
           </button>
-        </div>
-        <div
-          className="Divider-container-157"
-        >
-          <hr
-            className="Divider-item-159"
-          />
-          <span
-            className="MuiTypography-root-111 MuiTypography-body1-120 Divider-label-158"
-          >
-            Available Options
-          </span>
-          <hr
-            className="Divider-item-159"
-          />
-        </div>
-        <div
-          className="MuiGrid-container-4 MuiGrid-spacing-xs-8-25 OptionsList-root-160"
-        >
-          <div
-            className="MuiGrid-item-5"
-          >
-            <button
-              className="MuiButtonBase-root-99 ProductDetailOption-optionButton-163"
-              disabled={undefined}
-              onBlur={[Function]}
-              onClick={[Function]}
-              onFocus={[Function]}
-              onKeyDown={[Function]}
-              onKeyUp={[Function]}
-              onMouseDown={[Function]}
-              onMouseLeave={[Function]}
-              onMouseUp={[Function]}
-              onTouchEnd={[Function]}
-              onTouchMove={[Function]}
-              onTouchStart={[Function]}
-              tabIndex="0"
-              type="button"
-            >
-              <span
-                className="MuiTypography-root-111 MuiTypography-body1-120 ProductDetailOption-optionText-164"
-              >
-                Red
-              </span>
-            </button>
-            <div
-              className="OptionsList-alert-161"
-            >
-              <div
-                className="Badge-badge-148 Badge-backorder-152 Badge-status-150 OptionsList-badge-162"
-              >
-                <span
-                  className="Badge-labelStyle-149"
-                >
-                  Backorder
-                </span>
-              </div>
-            </div>
-          </div>
-          <div
-            className="MuiGrid-item-5"
-          >
-            <button
-              className="MuiButtonBase-root-99 ProductDetailOption-optionButton-163"
-              disabled={undefined}
-              onBlur={[Function]}
-              onClick={[Function]}
-              onFocus={[Function]}
-              onKeyDown={[Function]}
-              onKeyUp={[Function]}
-              onMouseDown={[Function]}
-              onMouseLeave={[Function]}
-              onMouseUp={[Function]}
-              onTouchEnd={[Function]}
-              onTouchMove={[Function]}
-              onTouchStart={[Function]}
-              tabIndex="0"
-              type="button"
-            >
-              <span
-                className="MuiTypography-root-111 MuiTypography-body1-120 ProductDetailOption-optionText-164"
-              >
-                Green
-              </span>
-            </button>
-          </div>
         </div>
       </div>
     </div>

--- a/src/components/ProductDetailOption/ProductDetailOption.js
+++ b/src/components/ProductDetailOption/ProductDetailOption.js
@@ -10,23 +10,21 @@ import styles from "./styles";
 export default class ProductDetailOption extends Component {
   static propTypes = {
     classes: PropTypes.object,
-    onClick: PropTypes.func.isRequired,
-    option: PropTypes.object,
-    selectedOption: PropTypes.string
+    isActive: PropTypes.bool,
+    onClick: PropTypes.func,
+    option: PropTypes.object
   }
 
   handleOnClick = () => {
-    this.props.onClick(this.props.option);
+    this.props.onClick && this.props.onClick(this.props.option);
   }
 
   render() {
     const {
       classes: { optionButton, optionText, isSelected },
-      selectedOption,
+      isActive,
       option
     } = this.props;
-
-    const active = (selectedOption === option._id) || false;
 
     return (
       <ButtonBase
@@ -34,7 +32,7 @@ export default class ProductDetailOption extends Component {
         onClick={this.handleOnClick}
         className={classNames(
           optionButton,
-          { [isSelected]: active }
+          { [isSelected]: isActive || false }
         )
         }
       >

--- a/src/components/ProductDetailOptionsList/ProductDetailOptionsList.js
+++ b/src/components/ProductDetailOptionsList/ProductDetailOptionsList.js
@@ -2,9 +2,6 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import Grid from "material-ui/Grid";
 import { withStyles } from "material-ui/styles";
-import { observable, action, computed } from "mobx";
-import { observer } from "mobx-react";
-import { Router } from "routes";
 import Badge from "components/Badge";
 import { inventoryStatus } from "lib/utils";
 import ProductDetailOption from "components/ProductDetailOption";
@@ -28,34 +25,14 @@ const styles = (theme) => ({
 });
 
 @withStyles(styles, { withTheme: true })
-@observer
 export default class OptionsList extends Component {
   static propTypes = {
     classes: PropTypes.object.isRequired,
+    onSelectOption: PropTypes.func,
     options: PropTypes.arrayOf(PropTypes.object),
     productSlug: PropTypes.string,
+    selectedOptionId: PropTypes.string,
     theme: PropTypes.object
-  }
-
-  @observable _selectedOption = null;
-
-  @computed
-  get selectedOption() {
-    return this._selectedOption;
-  }
-
-  set selectedOption(value) {
-    this._selectedOption = value;
-  }
-
-  @action
-  selectOption = (option) => {
-    this.selectedOption = option._id;
-
-    Router.pushRoute("product", {
-      productSlug: this.props.productSlug,
-      variantId: option._id
-    });
   }
 
   renderInventoryStatus(option) {
@@ -72,7 +49,7 @@ export default class OptionsList extends Component {
   }
 
   render() {
-    const { classes: { root }, options, theme } = this.props;
+    const { classes: { root }, onSelectOption, options, theme, selectedOptionId } = this.props;
 
     if (!Array.isArray(options)) return null;
 
@@ -81,8 +58,8 @@ export default class OptionsList extends Component {
         {options.map((option) => (
           <Grid item key={option._id}>
             <ProductDetailOption
-              onClick={this.selectOption}
-              selectedOption={this.selectedOption}
+              isActive={selectedOptionId === option._id}
+              onClick={onSelectOption}
               option={option}
             />
             {this.renderInventoryStatus(option)}

--- a/src/components/ProductItem/ProductItem.js
+++ b/src/components/ProductItem/ProductItem.js
@@ -11,8 +11,6 @@ import Badge from "components/Badge";
 import { inventoryStatus, isProductLowQuantity, INVENTORY_STATUS } from "lib/utils";
 import { styles } from "./styles";
 
-const PRODUCT_PLACE_HOLDER = "/resources/placeholder.gif";
-
 @withStyles(styles, { withTheme: true })
 @inject("uiStore")
 @observer
@@ -21,7 +19,7 @@ class ProductItem extends Component {
     classes: PropTypes.object,
     product: PropTypes.object,
     theme: PropTypes.object,
-    uiStore: PropTypes.object
+    uiStore: PropTypes.object.isRequired
   };
 
   static defaultProps = {
@@ -51,17 +49,21 @@ class ProductItem extends Component {
   renderProductImage() {
     const {
       classes: { img, imgLoading, loadingIcon },
-      theme: { breakpoints: { values } }
+      theme: {
+        breakpoints: { values }
+      },
+      uiStore
     } = this.props;
+    const { publicRuntimeConfig } = uiStore.appConfig;
     const { hasImageLoaded } = this.state;
     let { product: { primaryImage } } = this.props;
 
     if (!primaryImage) {
       primaryImage = {
         URLs: {
-          small: PRODUCT_PLACE_HOLDER,
-          medium: PRODUCT_PLACE_HOLDER,
-          large: PRODUCT_PLACE_HOLDER
+          small: publicRuntimeConfig.placeholderImageUrls.productGrid,
+          medium: publicRuntimeConfig.placeholderImageUrls.productGrid,
+          large: publicRuntimeConfig.placeholderImageUrls.productGrid
         }
       };
     }

--- a/src/components/ProductItem/ProductItem.test.js
+++ b/src/components/ProductItem/ProductItem.test.js
@@ -6,7 +6,11 @@ import product from "./__mocks__/product.mock";
 const uiStore = {
   appConfig: {
     publicRuntimeConfig: {
-      externalAssetsUrl: "http://localhost:300"
+      externalAssetsUrl: "http://localhost:3000",
+      placeholderImageUrls: {
+        galleryFeatured: "/resources/placeholder.gif",
+        productGrid: "/resources/placeholder.gif"
+      }
     }
   }
 };

--- a/src/components/ProductItem/__snapshots__/ProductItem.test.js.snap
+++ b/src/components/ProductItem/__snapshots__/ProductItem.test.js.snap
@@ -20,21 +20,21 @@ exports[`basic snapshot 1`] = `
       >
         <source
           media="(min-width: 600px)"
-          srcSet="http://localhost:300/resources/placeholder.gif"
+          srcSet="http://localhost:3000/resources/placeholder.gif"
         />
         <source
           media="(min-width: 960px)"
-          srcSet="http://localhost:300/resources/placeholder.gif"
+          srcSet="http://localhost:3000/resources/placeholder.gif"
         />
         <source
           media="(min-width: 1280px)"
-          srcSet="http://localhost:300/resources/placeholder.gif"
+          srcSet="http://localhost:3000/resources/placeholder.gif"
         />
         <img
           alt=""
           className="inject-ProductItem-with-uiStore-img-4"
           onLoad={[Function]}
-          src="http://localhost:300/resources/placeholder.gif"
+          src="http://localhost:3000/resources/placeholder.gif"
         />
       </picture>
       <div

--- a/src/components/VariantList/VariantList.js
+++ b/src/components/VariantList/VariantList.js
@@ -1,9 +1,6 @@
 import React, { Component, Fragment } from "react";
 import PropTypes from "prop-types";
 import { withStyles } from "material-ui/styles";
-import { observable, action, computed } from "mobx";
-import { observer } from "mobx-react";
-import { Router } from "routes";
 import VariantItem from "components/VariantItem";
 import ProductDetailOptionsList from "components/ProductDetailOptionsList";
 import Badge from "components/Badge";
@@ -27,50 +24,27 @@ const styles = (theme) => ({
 });
 
 @withStyles(styles)
-@observer
 export default class VariantList extends Component {
   static propTypes = {
     classes: PropTypes.object,
+    onSelectOption: PropTypes.func,
+    onSelectVariant: PropTypes.func,
     product: PropTypes.object.isRequired,
+    selectedOptionId: PropTypes.string,
+    selectedVariantId: PropTypes.string,
     variants: PropTypes.arrayOf(PropTypes.object).isRequired
   }
 
-  constructor(props) {
-    super(props);
-    // Select first variant by default
-    this.selectedVariant = props.variants[0]._id;
-  }
-
-  @observable _selectedVariant = null;
-
-  @action
-  handleClick = (variant) => {
-    this._selectedVariant = variant._id;
-
-    Router.pushRoute("product", {
-      slugOrId: this.props.product.slug,
-      variantId: variant._id
-    });
-  }
-
-  @computed
-  get selectedVariant() {
-    return this._selectedVariant;
-  }
-
-  set selectedVariant(value) {
-    this._selectedVariant = value;
-  }
-
   renderVariant = (variant) => {
-    const { classes } = this.props;
-    const active = (this.selectedVariant === variant._id);
+    const { classes, onSelectVariant, selectedVariantId } = this.props;
+
+    const active = (selectedVariantId === variant._id);
 
     return (
       <div className={classes.variantItem} key={variant._id}>
         <VariantItem
+          handleClick={() => { onSelectVariant(variant); }}
           isActive={active}
-          handleClick={this.handleClick}
           variant={variant}
         />
         {this.renderInventoryStatus(variant)}
@@ -91,11 +65,12 @@ export default class VariantList extends Component {
     );
   }
 
-  renderOptionsList = () => {
-    const selectedVariant = this.props.variants.find((variant) => variant._id === this.selectedVariant);
+  renderOptionsList() {
+    const { onSelectOption, product, selectedOptionId, selectedVariantId, variants } = this.props;
+    const selectedVariant = variants.find((variant) => variant._id === selectedVariantId);
 
     // If currently selected variant has options, then render them.
-    const options = (Array.isArray(selectedVariant.options)) ? selectedVariant.options : null;
+    const options = (selectedVariant && Array.isArray(selectedVariant.options) && selectedVariant.options.length) ? selectedVariant.options : null;
 
     if (!options) return null;
 
@@ -103,8 +78,10 @@ export default class VariantList extends Component {
       <Fragment>
         <Divider />
         <ProductDetailOptionsList
-          productSlug={this.props.product.slug}
+          productSlug={product.slug}
+          onSelectOption={onSelectOption}
           options={options}
+          selectedOptionId={selectedOptionId}
         />
       </Fragment>
     );

--- a/src/components/VariantList/VariantList.test.js
+++ b/src/components/VariantList/VariantList.test.js
@@ -11,6 +11,8 @@ test("basic snapshot", () => {
     <MuiThemeProvider theme={theme}>
       <VariantList
         product={catalogProduct}
+        selectedOptionId="cmVhY3Rpb24vY2F0YWxvZ1Byb2R1Y3RWYXJpYW50OlNNcjRyaERGbll2Rk10RFRY"
+        selectedVariantId="cmVhY3Rpb24vY2F0YWxvZ1Byb2R1Y3RWYXJpYW50OjZxaXFQd0JrZUpkdGRRYzRH"
         variants={catalogProduct.variants}
       />
     </MuiThemeProvider>

--- a/src/components/VariantList/__snapshots__/VariantList.test.js.snap
+++ b/src/components/VariantList/__snapshots__/VariantList.test.js.snap
@@ -99,7 +99,7 @@ exports[`basic snapshot 1`] = `
       className="MuiGrid-item-49"
     >
       <button
-        className="MuiButtonBase-root-6 ProductDetailOption-optionButton-138"
+        className="MuiButtonBase-root-6 ProductDetailOption-optionButton-138 ProductDetailOption-isSelected-140"
         disabled={undefined}
         onBlur={[Function]}
         onClick={[Function]}

--- a/src/lib/apollo/initApolloServer.js
+++ b/src/lib/apollo/initApolloServer.js
@@ -30,7 +30,7 @@ const errorLink = onError(({ graphQLErrors, networkError }) => {
 const httpLink = (options) => new HttpLink({
   uri: `${graphqlUrl}`,
   headers: {
-    "meteor-login-token": `${options.meteorToken || ""}`
+    "meteor-login-token": `${options.token || ""}`
   },
   credentials: "same-origin"
 });

--- a/src/lib/apollo/withData.js
+++ b/src/lib/apollo/withData.js
@@ -6,6 +6,7 @@ import jsHttpCookie from "cookie";
 import rootMobxStores from "lib/stores";
 import initApolloServer from "./initApolloServer";
 import initApolloBrowser from "./initApolloBrowser";
+
 /**
  * Get the display name of a component
  * @name getComponentDisplayName
@@ -49,14 +50,16 @@ export default (ComposedComponent) =>
           if (typeof cookies === "string") {
             ({ token } = jsHttpCookie.parse(cookies));
           }
+
+          if (typeof token !== "string" || token.length === 0) token = undefined;
         }
 
-        rootMobxStores.routingStore.pathname = ctx.pathname;
-        rootMobxStores.routingStore.query = ctx.query;
-
-        const apollo = initApolloServer(undefined, { meteorToken: token });
         // Provide the `url` prop data in case a GraphQL query uses it
         const url = { query: ctx.query, pathname: ctx.pathname };
+
+        rootMobxStores.routingStore.updateRoute(url);
+
+        const apollo = initApolloServer(undefined, { token });
         try {
           // Run all GraphQL queries
           await getDataFromTree( // eslint-disable-line
@@ -65,7 +68,6 @@ export default (ComposedComponent) =>
             </ApolloProvider>
           ); // eslint-disable-line
         } catch (error) {
-          // errorr
           // TODO: handle the error
           console.log("apollo client error", error); // eslint-disable-line
         }
@@ -90,8 +92,7 @@ export default (ComposedComponent) =>
 
       this.apollo = initApolloBrowser(apollo.data, { token });
 
-      rootMobxStores.routingStore.pathname = props.url.pathname;
-      rootMobxStores.routingStore.query = props.url.query;
+      rootMobxStores.routingStore.updateRoute(props.url);
     }
 
     render() {

--- a/src/lib/stores/AuthStore.js
+++ b/src/lib/stores/AuthStore.js
@@ -1,4 +1,4 @@
-import { observable, computed, action } from "mobx";
+import { observable, action } from "mobx";
 import Cookies from "js-cookie";
 
 /**
@@ -12,25 +12,23 @@ class AuthStore {
   *
   * @type String
   */
-  @observable _token = "";
+  @observable token = "";
 
-  @computed get token() {
-    return this._token;
-  }
-
-  set token(value) {
-    this._token = value;
-  }
-
-  @action saveToken = () => {
-    // Save the token
-    Cookies.set("token", this.token);
-  }
-
-  fetchAuthToken() {
-    const token = Cookies.get("token");
+  @action setToken(token) {
     this.token = token || "";
-    return token;
+  }
+
+  saveTokenToCookie() {
+    if (typeof this.token === "string" && this.token.length) {
+      Cookies.set("token", this.token);
+    } else {
+      Cookies.remove("token");
+    }
+  }
+
+  setTokenFromCookie() {
+    const token = Cookies.get("token");
+    this.setToken(token);
   }
 }
 

--- a/src/lib/stores/RoutingStore.js
+++ b/src/lib/stores/RoutingStore.js
@@ -1,4 +1,4 @@
-import { action, observable, computed } from "mobx";
+import { action, observable } from "mobx";
 import { Router } from "routes";
 
 /**
@@ -12,31 +12,18 @@ export default class RoutingStore {
    *
    * @type String
    */
-  @observable _pathname = "";
+  @observable pathname = "";
 
   /**
    * The query params for the current page (i.e. `{shop: `1234', first: 24}`)
    *
    * @type Object
    */
-  @observable _query = {};
+  @observable query = {};
 
-  @computed
-  get pathname() {
-    return this._pathname;
-  }
-
-  set pathname(value) {
-    this._pathname = value;
-  }
-
-  @computed
-  get query() {
-    return this._query;
-  }
-
-  set query(value) {
-    this._query = value;
+  @action updateRoute({ pathname, query }) {
+    this.pathname = pathname;
+    this.query = query;
   }
 
   /**

--- a/src/lib/stores/UIStore.js
+++ b/src/lib/stores/UIStore.js
@@ -55,8 +55,16 @@ class UIStore {
     this.pdpSelectedOptionId = optionId;
   }
 
+  @action closeCart() {
+    this.isCartOpen = false;
+  }
+
   @action toggleCartOpen() {
     this.isCartOpen = !this.isCartOpen;
+  }
+
+  @action closeMenuDrawer() {
+    this.isMenuDrawerOpen = false;
   }
 
   @action toggleMenuDrawerOpen() {

--- a/src/lib/stores/UIStore.js
+++ b/src/lib/stores/UIStore.js
@@ -1,4 +1,4 @@
-import { observable, computed, action } from "mobx";
+import { observable, action } from "mobx";
 import getConfig from "next/config";
 
 /**
@@ -8,12 +8,19 @@ import getConfig from "next/config";
 
 class UIStore {
   /**
+   * App config data
+   *
+   * @type Object
+   */
+  @observable appConfig = getConfig();
+
+  /**
    * Is the cart drawer open or closed
    *
    * @type Boolean
    * @default false
    */
-  @observable _cartOpen = false;
+  @observable isCartOpen = false;
 
   /**
    * Is the menu drawer open or closed
@@ -21,47 +28,40 @@ class UIStore {
    * @type Boolean
    * @default false
    */
-  @observable _menuDrawerOpen = false;
+  @observable isMenuDrawerOpen = false;
 
   /**
-   * App config data
+   * The ID of the option that is selected on the product detail page. This is not
+   * tracked per product, so the assumption is that you can only view one detail page
+   * at a time. The page must reset this before initial mount.
    *
-   * @type Object
+   * @type String
    */
-  @observable _appConfig = getConfig();
+  @observable pdpSelectedOptionId = null;
 
-  @computed
-  get cartOpen() {
-    return this._cartOpen;
+  /**
+   * The ID of the variant that is selected on the product detail page. This is not
+   * tracked per product, so the assumption is that you can only view one detail page
+   * at a time. The page must reset this before initial mount.
+   *
+   * @type String
+   */
+  @observable pdpSelectedVariantId = null;
+
+  /* ACTIONS */
+
+  @action setPDPSelectedVariantId(variantId, optionId) {
+    this.pdpSelectedVariantId = variantId;
+    this.pdpSelectedOptionId = optionId;
   }
 
-  @computed
-  get appConfig() {
-    return this._appConfig;
+  @action toggleCartOpen() {
+    this.isCartOpen = !this.isCartOpen;
   }
 
-  set cartOpen(value) {
-    this._cartOpen = value;
+  @action toggleMenuDrawerOpen() {
+    this.isMenuDrawerOpen = !this.isMenuDrawerOpen;
   }
-
-  @action
-  toggleCartOpen = () => {
-    this.cartOpen = !this.cartOpen;
-  };
-
-  @computed
-  get menuDrawerOpen() {
-    return this._menuDrawerOpen;
-  }
-
-  set menuDrawerOpen(value) {
-    this._menuDrawerOpen = value;
-  }
-
-  @action
-  toggleMenuDrawerOpen = () => {
-    this.menuDrawerOpen = !this.menuDrawerOpen;
-  };
 }
 
 export default UIStore;

--- a/src/lib/theme/reactionTheme.js
+++ b/src/lib/theme/reactionTheme.js
@@ -26,7 +26,6 @@ const theme = createMuiTheme({
       bestseller: "#8CE0C9",
       borderColor: "#CCCCCC"
     }
-
   },
   spacing: {
     unithalf: 4

--- a/src/lib/theme/withRoot.js
+++ b/src/lib/theme/withRoot.js
@@ -29,7 +29,7 @@ function withRoot(Component) {
       }
 
       // Fetch and update auth token in auth store
-      rootMobxStores.authStore.fetchAuthToken();
+      rootMobxStores.authStore.setTokenFromCookie();
     }
 
     pageContext = null;

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -15,7 +15,6 @@ import ProductGrid from "components/ProductGrid";
 @withShop
 @withCatalogItems
 @inject("shop")
-@inject("uiStore")
 @observer
 class Shop extends Component {
   static propTypes = {

--- a/src/pages/product.js
+++ b/src/pages/product.js
@@ -1,6 +1,5 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
-import { observer, inject } from "mobx-react";
 import withData from "lib/apollo/withData";
 import withRoot from "lib/theme/withRoot";
 import withShop from "containers/shop/withShop";
@@ -12,8 +11,6 @@ import ProductDetail from "components/ProductDetail";
 @withRoot
 @withShop
 @withCatalogItemProduct
-@inject("uiStore")
-@observer
 class ProductDetailPage extends Component {
   static propTypes = {
     /**

--- a/src/pages/tag.js
+++ b/src/pages/tag.js
@@ -15,7 +15,6 @@ import ProductGrid from "components/ProductGrid";
 @withCatalogItems
 @inject("shop")
 @inject("routingStore")
-@inject("uiStore")
 @observer
 export default class TagShop extends Component {
   static propTypes = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5991,7 +5991,7 @@ react-apollo@^2.1.3:
     lodash "4.17.5"
     prop-types "^15.6.0"
 
-react-dom@^16.3.0:
+react-dom@16.3.2:
   version "16.3.2"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.3.2.tgz#cb90f107e09536d683d84ed5d4888e9640e0e4df"
   dependencies:
@@ -6096,7 +6096,7 @@ react-transition-group@^2.2.1:
     loose-envify "^1.3.1"
     prop-types "^15.6.1"
 
-react@^16.3.0:
+react@16.3.2:
   version "16.3.2"
   resolved "https://registry.yarnpkg.com/react/-/react-16.3.2.tgz#fdc8420398533a1e58872f59091b272ce2f91ea9"
   dependencies:


### PR DESCRIPTION
Based on our team discussions, this updates some uses of MobX to:
- Prefer callbacks that hoist state
- Pass UIState down a few more levels, to remove any mobX dependency from more of the components 
- Keep all `@action` in the stores only
- Don't use getter/setter pattern for observed props where they are simply wrapping private props and not doing anything else
- Do routing calls higher up (this will be optimized more later)

Also:
- Moved placeholder URLs to `publicRuntimeConfig`
- Pinned to latest versions of `react` and `react-dom`

### Testing
Check the following affected areas:
- Proper selection / URL updating for variant and option lists on PDP
- Setting/clearing auth token from UI dropdown
- Cart show/hide
- Placeholder images show properly on grid and PDP