### PR TITLE
[WIP] feat: image header component for product grid

### DIFF
--- a/src/components/ProductGrid/ProductGrid.js
+++ b/src/components/ProductGrid/ProductGrid.js
@@ -5,9 +5,9 @@ import { withStyles } from "material-ui/styles";
 import ProductItem from "components/ProductItem";
 import PageStepper from "components/PageStepper";
 
-const styles = () => ({
+const styles = (theme) => ({
   productGridContainer: {
-    maxWidth: "1440px",
+    maxWidth: theme.grid.productGridMaxWidth,
     marginLeft: "auto",
     marginRight: "auto"
   }

--- a/src/components/ProductGridHero/ProductGridHero.js
+++ b/src/components/ProductGridHero/ProductGridHero.js
@@ -1,0 +1,27 @@
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+import { withStyles } from "material-ui/styles";
+import Grid from "material-ui/Grid";
+import styles from "./styles";
+
+
+@withStyles(styles)
+export default class ProductGridHero extends Component {
+  static propTypes = {
+    classes: PropTypes.object
+  };
+
+  render() {
+    const { classes } = this.props;
+
+    return (
+      <section className={classes.productGridContainer}>
+        <Grid container spacing={24}>
+          <Grid item xs={12}>
+            <img alt="Tag Hero" className={classes.heroImg} src="https://k-lerlandworks.com/wp-content/uploads/2017/11/Custom-Water-Features-1600x325.jpg" />
+          </Grid>
+        </Grid>
+      </section>
+    );
+  }
+}

--- a/src/components/ProductGridHero/ProductGridHero.test.js
+++ b/src/components/ProductGridHero/ProductGridHero.test.js
@@ -1,0 +1,16 @@
+import React from "react";
+import renderer from "react-test-renderer";
+import { MuiThemeProvider } from "material-ui/styles";
+import theme from "lib/theme/reactionTheme";
+import ProductGridHero from "./ProductGridHero";
+
+
+test("basic snapshot", () => {
+  const component = renderer.create((
+    <MuiThemeProvider theme={theme}>
+      <ProductGridHero />
+    </MuiThemeProvider>
+  ));
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});

--- a/src/components/ProductGridHero/__snapshots__/ProductGridHero.test.js.snap
+++ b/src/components/ProductGridHero/__snapshots__/ProductGridHero.test.js.snap
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`basic snapshot 1`] = `
+<section
+  className="ProductGridHero-productGridContainer-2"
+>
+  <div
+    className="MuiGrid-container-3 MuiGrid-spacing-xs-24-26"
+  >
+    <div
+      className="MuiGrid-item-4 MuiGrid-grid-xs-12-40"
+    >
+      <img
+        alt="Tag Hero"
+        className="ProductGridHero-heroImg-1"
+        src="https://k-lerlandworks.com/wp-content/uploads/2017/11/Custom-Water-Features-1600x325.jpg"
+      />
+    </div>
+  </div>
+</section>
+`;

--- a/src/components/ProductGridHero/index.js
+++ b/src/components/ProductGridHero/index.js
@@ -1,0 +1,1 @@
+export { default } from "./ProductGridHero";

--- a/src/components/ProductGridHero/styles.js
+++ b/src/components/ProductGridHero/styles.js
@@ -1,0 +1,12 @@
+export default (theme) => ({
+  heroImg: {
+    width: "100%",
+    height: "325px",
+    objectFit: "cover"
+  },
+  productGridContainer: {
+    maxWidth: theme.grid.productGridMaxWidth,
+    marginLeft: "auto",
+    marginRight: "auto"
+  }
+});

--- a/src/lib/theme/reactionTheme.js
+++ b/src/lib/theme/reactionTheme.js
@@ -1,6 +1,10 @@
 import { createMuiTheme } from "material-ui/styles";
 
 const theme = createMuiTheme({
+  grid: {
+    productGridMaxWidth: "1440px"
+    }
+  },
   palette: {
     primary: {
       light: "#26B0F9",

--- a/src/lib/theme/reactionTheme.js
+++ b/src/lib/theme/reactionTheme.js
@@ -3,7 +3,6 @@ import { createMuiTheme } from "material-ui/styles";
 const theme = createMuiTheme({
   grid: {
     productGridMaxWidth: "1440px"
-    }
   },
   palette: {
     primary: {

--- a/src/pages/tag.js
+++ b/src/pages/tag.js
@@ -9,23 +9,13 @@ import withRoot from "lib/theme/withRoot";
 import withShop from "containers/shop/withShop";
 import Layout from "components/Layout";
 import ProductGrid from "components/ProductGrid";
-import Grid from "material-ui/Grid";
-
-const styles = (theme) => ({
-  productGridContainer: {
-    maxWidth: "1440px",
-    marginLeft: "auto",
-    marginRight: "auto"
-  }
-});
-
+import ProductGridHero from "components/ProductGridHero";
 
 
 @withData
 @withRoot
 @withShop
 @withCatalogItems
-@withStyles(styles)
 @inject("shop")
 @inject("routingStore")
 @inject("uiStore")
@@ -34,6 +24,7 @@ export default class TagShop extends Component {
   static propTypes = {
     catalogItems: PropTypes.array.isRequired,
     catalogItemsPageInfo: PropTypes.object,
+    classes: PropTypes.object,
     routingStore: PropTypes.object,
     shop: PropTypes.object
   };
@@ -57,6 +48,7 @@ export default class TagShop extends Component {
     return (
       <Layout title="Reaction Shop">
         {this.renderHelmet()}
+        <ProductGridHero />
         <ProductGrid
           catalogItems={catalogItems}
           pageInfo={catalogItemsPageInfo}

--- a/src/pages/tag.js
+++ b/src/pages/tag.js
@@ -2,17 +2,30 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { observer, inject } from "mobx-react";
 import Helmet from "react-helmet";
+import { withStyles } from "material-ui/styles";
 import withData from "lib/apollo/withData";
 import withCatalogItems from "containers/catalog/withCatalogItems";
 import withRoot from "lib/theme/withRoot";
 import withShop from "containers/shop/withShop";
 import Layout from "components/Layout";
 import ProductGrid from "components/ProductGrid";
+import Grid from "material-ui/Grid";
+
+const styles = (theme) => ({
+  productGridContainer: {
+    maxWidth: "1440px",
+    marginLeft: "auto",
+    marginRight: "auto"
+  }
+});
+
+
 
 @withData
 @withRoot
 @withShop
 @withCatalogItems
+@withStyles(styles)
 @inject("shop")
 @inject("routingStore")
 @inject("uiStore")


### PR DESCRIPTION
#### TODO

**In core reaction Repo**
- Add data to GraphQL endpoint
- Update schema to accept image url

**in this repo**
- Nothing

Create an image header (hero) component to be used on the tag grid.

This hero only shows when a tag is active, not on the default grid.

Hero image is populated from the GraphQL endpoint for the tag, which has been updated to include the image URL for the hero.

##Testing:

Use Robo3T to add an image URL to a tag
See that the image is populated on the starterkit storefront tag grid for the corresponding tag