### PR TITLE
docs: add utilities docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,9 +1,5 @@
 # Reaction NextJS Starter Kit Documentation
 
-## MobX
-
-[How to use MobX correctly in this project](MOBX.md)
-
 ## Architectural Decisions Records
 
 Information around the architectural decisions made for this project should be
@@ -15,3 +11,17 @@ project and can be used to add new decisions.
 ```sh
 docker-compose run --rm web adr new "Implement the Torpedos"
 ```
+
+## MobX
+
+- [How to use MobX correctly in this project](MOBX.md)
+
+## Testing
+
+- [Testing](testing.md)
+- [Patterns](testing.md#patterns)
+
+## Tools and Utilities
+
+- [Tools to help with development](utilities.md)
+- [GraphiQL App installation and setup](utilities.md#graphiql-app)

--- a/docs/utilities.md
+++ b/docs/utilities.md
@@ -1,0 +1,11 @@
+# Tools and Utilities
+
+## GraphiQL App
+
+1. Follow the instructions to install the [GraphiQL app](https://github.com/skevy/graphiql-app).
+1. Launch the app
+1. Click the button labeled `Edit HTTP Headers`
+1. Click `+ Add Header`
+1. For `Header name` enter `meteor-login-token`
+1. For `Header value` you'll need your `Meteor.loginToken` from the [Getting Started](https://github.com/reactioncommerce/reaction-next-starterkit#getting-started) guide.
+1. TL;DR: With a Reaction App running using docker-compose, open the local storage panel in your browsers dev tools, and copy the value of the `Meteor.loginToken` into the `Header value` field.

--- a/docs/utilities.md
+++ b/docs/utilities.md
@@ -2,10 +2,21 @@
 
 ## GraphiQL App
 
+> TL;DR: With a Reaction App running using `docker-compose`, open the Local Storage panel in your browser dev tools and copy the value of `Meteor.loginToken` into the `Header value` field.
+
 1. Follow the instructions to install the [GraphiQL app](https://github.com/skevy/graphiql-app).
 1. Launch the app
 1. Click the button labeled `Edit HTTP Headers`
 1. Click `+ Add Header`
 1. For `Header name` enter `meteor-login-token`
 1. For `Header value` you'll need your `Meteor.loginToken` from the [Getting Started](https://github.com/reactioncommerce/reaction-next-starterkit#getting-started) guide.
-1. TL;DR: With a Reaction App running using docker-compose, open the local storage panel in your browsers dev tools, and copy the value of the `Meteor.loginToken` into the `Header value` field.
+1. Make your first query by setting GraphQL Endpoint to http://localhost:3030/graphql-alpha and querying for the viewer's name:
+```graphql
+{
+  viewer {
+    name
+  }
+}
+```
+
+For more on your getting started with GraphQL and Reaction: https://docs.reactioncommerce.com/reaction-docs/master/graphql-intro


### PR DESCRIPTION
- add a utilities docs with a GraphiQl app setup guide
- add a TOC for the testing doc and utils docs to `docs/readme.md`
- reorganize `docs/readme.md` to move architecture decisions doc to the first position. Seems like it's the most important so it should go first.