### PR TITLE
Wireup sort by selector

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -16,25 +16,25 @@ ignore:
   'npm:hoek:20180212':
     - '*':
         reason: 'Possible false positive, waiting on requestjs to updated hawk version'
-        expires: 2018-05-30T00:00:00.000Z
+        expires: 2018-06-30T00:00:00.000Z
   'npm:sshpk:20180409':
     - '*':
         reason: Waiting on http-signature to update to the latest sshpk version
-        expires: 2018-05-30T00:00:00.000Z
+        expires: 2018-06-15T00:00:00.000Z
   'npm:ua-parser-js:20180227':
     - '*':
         reason: Waiting on fbjs to update to the latest ua-parser-js version
-        expires: 2018-05-30T00:00:00.000Z
+        expires: 2018-06-15T00:00:00.000Z
   'npm:tough-cookie:20170905':
     - '*':
         reason: Waiting on tough-cookie to update to the latest sshpk version
-        expires: 2018-05-30T00:00:00.000Z
+        expires: 2018-06-15T00:00:00.000Z
   'npm:stringstream:20180511':
     - '*':
         reason: Waiting on updated package
-        expires: 2018-05-30T00:00:00.000Z
+        expires: 2018-06-15T00:00:00.000Z
   'npm:braces:20180219':
     - '*':
         reason: Waiting for Next.js 6 to update to Babel 7 beta.47
-        expires: 2018-05-30T00:00:00.000Z
+        expires: 2018-06-15T00:00:00.000Z
 patch: {}

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "chalk": "^2.3.2",
     "classnames": "^2.2.5",
     "express": "^4.16.3",
-    "graphql": "^0.13.1",
+    "graphql": "^0.13.2",
     "graphql-tag": "^2.8.0",
     "isomorphic-fetch": "^2.2.1",
     "js-cookie": "^2.2.0",

--- a/src/components/NavigationDesktop/NavigationItemDesktop.js
+++ b/src/components/NavigationDesktop/NavigationItemDesktop.js
@@ -11,6 +11,7 @@ import ChevronDownIcon from "mdi-material-ui/ChevronDown";
 import ChevronUpIcon from "mdi-material-ui/ChevronUp";
 import { withStyles } from "@material-ui/core/styles";
 import { Router } from "routes";
+import Link from "components/Link";
 
 const styles = (theme) => ({
   popover: {

--- a/src/components/ProductGrid/ProductGrid.test.js
+++ b/src/components/ProductGrid/ProductGrid.test.js
@@ -34,7 +34,7 @@ test("basic snapshot", () => {
           primaryShopId="123"
           setPageSize={() => true}
           setSortBy={() => true}
-          sortBy={"newest"}
+          sortBy={"updatedAt-desc"}
         />
       </Provider>
     </MuiThemeProvider>

--- a/src/components/ProductGrid/__snapshots__/ProductGrid.test.js.snap
+++ b/src/components/ProductGrid/__snapshots__/ProductGrid.test.js.snap
@@ -99,7 +99,7 @@ exports[`basic snapshot 1`] = `
             required={undefined}
             rows={undefined}
             type="hidden"
-            value="newest"
+            value="updatedAt-desc"
           />
           <svg
             aria-hidden="true"

--- a/src/components/Select/Select.js
+++ b/src/components/Select/Select.js
@@ -25,7 +25,7 @@ const styles = (theme) => ({
     backgroundColor: theme.palette.action.hover
   },
   input: {
-    width: theme.spacing.unit * 20
+    width: theme.spacing.unit * 21
   }
 });
 

--- a/src/components/SortBySelector/SortBySelector.js
+++ b/src/components/SortBySelector/SortBySelector.js
@@ -5,15 +5,15 @@ import Select from "components/Select";
 const SORT_BY = [
   {
     name: "Newest",
-    value: "newest"
+    value: "updatedAt-desc"
   },
   {
     name: "Price: low to high",
-    value: "price-low-high"
+    value: "minPrice-asc"
   },
   {
     name: "Price: high to low",
-    value: "price-high-low"
+    value: "minPrice-desc"
   }
 ];
 

--- a/src/components/SortBySelector/SortBySelector.test.js
+++ b/src/components/SortBySelector/SortBySelector.test.js
@@ -8,7 +8,7 @@ test("basic snapshot", () => {
   const component = renderer.create((
     <MuiThemeProvider theme={theme}>
       <SortBySelector
-        sortBy={"newest"}
+        sortBy={"updatedAt-desc"}
         onChange={() => true}
       />
     </MuiThemeProvider>

--- a/src/components/SortBySelector/__snapshots__/SortBySelector.test.js.snap
+++ b/src/components/SortBySelector/__snapshots__/SortBySelector.test.js.snap
@@ -36,7 +36,7 @@ exports[`basic snapshot 1`] = `
       required={undefined}
       rows={undefined}
       type="hidden"
-      value="newest"
+      value="updatedAt-desc"
     />
     <svg
       aria-hidden="true"

--- a/src/containers/catalog/catalogItems.gql
+++ b/src/containers/catalog/catalogItems.gql
@@ -1,5 +1,5 @@
-query catalogItemsQuery($shopId: ID!, $first: ConnectionLimitInt, $last:  ConnectionLimitInt, $before: ConnectionCursor, $after: ConnectionCursor) {
-  catalogItems(shopIds: [$shopId], first: $first, last: $last, before: $before, after: $after) {
+query catalogItemsQuery($shopId: ID!, $first: ConnectionLimitInt, $last:  ConnectionLimitInt, $before: ConnectionCursor, $after: ConnectionCursor, $sortBy: CatalogItemSortByField, $sortByPriceCurrencyCode: String, $sortOrder: SortOrder) {
+  catalogItems(shopIds: [$shopId], first: $first, last: $last, before: $before, after: $after, sortBy: $sortBy, sortByPriceCurrencyCode: $sortByPriceCurrencyCode, sortOrder: $sortOrder) {
     totalCount
     pageInfo {
       endCursor

--- a/src/containers/catalog/withCatalogItems.js
+++ b/src/containers/catalog/withCatalogItems.js
@@ -26,7 +26,7 @@ export default (Component) => {
     render() {
       const { primaryShopId, routingStore, uiStore } = this.props;
       const [sortBy, sortOrder] = uiStore.sortBy.split("-");
-      
+
       const variables = {
         shopId: primaryShopId,
         ...paginationVariablesFromUrlParams(routingStore.query, { defaultPageLimit: uiStore.pageSize }),

--- a/src/containers/catalog/withCatalogItems.js
+++ b/src/containers/catalog/withCatalogItems.js
@@ -24,10 +24,15 @@ export default (Component) => {
     }
 
     render() {
-      const { primaryShopId, routingStore, uiStore: { pageSize } } = this.props || {};
+      const { primaryShopId, routingStore, uiStore } = this.props;
+      const [sortBy, sortOrder] = uiStore.sortBy.split("-");
+      
       const variables = {
         shopId: primaryShopId,
-        ...paginationVariablesFromUrlParams(routingStore.query, { defaultPageLimit: pageSize })
+        ...paginationVariablesFromUrlParams(routingStore.query, { defaultPageLimit: uiStore.pageSize }),
+        sortBy,
+        sortByPriceCurrencyCode: uiStore.sortByCurrencyCode,
+        sortOrder
       };
 
       return (
@@ -45,7 +50,7 @@ export default (Component) => {
                   routingStore,
                   data,
                   queryName: "catalogItems",
-                  limit: pageSize
+                  limit: uiStore.pageSize
                 })}
                 catalogItems={catalogItems && catalogItems.edges}
               />

--- a/src/lib/helpers/pagination.js
+++ b/src/lib/helpers/pagination.js
@@ -15,7 +15,7 @@ export const loadNextPage = ({ queryName, data, limit, fetchMore, routingStore }
 
   // Set URL search params to allow for link sharing
   if (routingStore) {
-    routingStore.setSearch(`limit=${limit}&after=${cursor}`);
+    routingStore.setSearch({ limit, after: cursor });
   }
 
   fetchMore({
@@ -56,7 +56,7 @@ export const loadPreviousPage = ({ queryName, data, limit, fetchMore, routingSto
 
   // Set URL search params to allow for link sharing
   if (routingStore) {
-    routingStore.setSearch(`limit=${limit}&before=${cursor}`);
+    routingStore.setSearch({ limit, before: cursor });
   }
 
   fetchMore({

--- a/src/lib/stores/RoutingStore.js
+++ b/src/lib/stores/RoutingStore.js
@@ -1,4 +1,4 @@
-import { action, observable } from "mobx";
+import { action, toJS, observable } from "mobx";
 import { Router } from "routes";
 
 /**
@@ -33,7 +33,18 @@ export default class RoutingStore {
    * @returns {String} full url with query string
    */
   @action setSearch(search) {
-    const path = `${this.pathname}?${search}`;
+    const _query = { ...toJS(this.query), ...search };
+
+    let urlQueryString = "";
+    Object.keys(_query).forEach((key, index, arr) => {
+      urlQueryString += `${key}=${_query[key]}`;
+
+      if (index < arr.length - 1) {
+        urlQueryString += "&";
+      }
+    });
+
+    const path = `${this.pathname}?${urlQueryString}`;
     Router.pushRoute(path, path, { shallow: true });
     return path;
   }

--- a/src/lib/stores/UIStore.js
+++ b/src/lib/stores/UIStore.js
@@ -38,6 +38,20 @@ class UIStore {
   @observable pageSize = 20;
 
   /**
+   * The product grid's sorting order
+   *
+   * @type string
+   */
+  @observable sortBy = "updatedAt-desc";
+
+  /**
+   * The sort by currency code
+   *
+   * @type string
+   */
+  @observable sortByCurrencyCode = "USD";
+
+  /**
    * App config data
    * The ID of the option that is selected on the product detail page. This is not
    * tracked per product, so the assumption is that you can only view one detail page
@@ -81,6 +95,10 @@ class UIStore {
 
   @action setPageSize = (size) => {
     this.pageSize = size;
+  }
+
+  @action setSortBy = (sortBy) => {
+    this.sortBy = sortBy;
   }
 }
 

--- a/src/lib/stores/index.js
+++ b/src/lib/stores/index.js
@@ -14,6 +14,10 @@ autorun(() => {
   if (query.limit) {
     uiStore.setPageSize(parseInt(query.limit, 10));
   }
+
+  if (query.sortby) {
+    uiStore.setSortBy(query.sortby);
+  }
 });
 
 export default {

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -38,19 +38,22 @@ class Shop extends Component {
     );
   }
 
+  // TODO: move this handler to _app.js, when it becomes available.
   setPageSize = (pageSize) => {
-    this.props.routingStore.setSearch(`limit=${pageSize}`);
+    this.props.routingStore.setSearch({ limit: pageSize });
     this.props.uiStore.setPageSize(pageSize);
   }
 
+  // TODO: move this handler to _app.js, when it becomes available.
   setSortBy = (sortBy) => {
-    this.props.routingStore.setSearch(`sort=${sortBy}`);
-    // TODO: Update uiStore
+    this.props.routingStore.setSearch({ sortby: sortBy });
+    this.props.uiStore.setSortBy(sortBy);
   }
 
   render() {
     const { catalogItems, catalogItemsPageInfo, uiStore, routingStore } = this.props;
     const pageSize = parseInt(routingStore.query.limit, 10) || uiStore.pageSize;
+    const sortBy = routingStore.query.sortby || uiStore.sortBy;
 
     return (
       <Layout title="Reaction Shop">
@@ -61,7 +64,7 @@ class Shop extends Component {
           pageSize={pageSize}
           setPageSize={this.setPageSize}
           setSortBy={this.setSortBy}
-          sortBy={"newest"}
+          sortBy={sortBy}
         />
       </Layout>
     );

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -2,7 +2,6 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { observer, inject } from "mobx-react";
 import Helmet from "react-helmet";
-
 import withData from "lib/apollo/withData";
 import withCatalogItems from "containers/catalog/withCatalogItems";
 import withRoot from "lib/theme/withRoot";

--- a/src/pages/tag.js
+++ b/src/pages/tag.js
@@ -47,8 +47,22 @@ export default class TagShop extends Component {
     );
   }
 
+  // TODO: move this handler to _app.js, when it becomes available.
+  setPageSize = (pageSize) => {
+    this.props.routingStore.setSearch({ limit: pageSize });
+    this.props.uiStore.setPageSize(pageSize);
+  }
+
+  // TODO: move this handler to _app.js, when it becomes available.
+  setSortBy = (sortBy) => {
+    this.props.routingStore.setSearch({ sortby: sortBy });
+    this.props.uiStore.setSortBy(sortBy);
+  }
+
   render() {
-    const { catalogItems, catalogItemsPageInfo, tag } = this.props;
+    const { catalogItems, catalogItemsPageInfo, routingStore, uiStore, tag } = this.props;
+    const pageSize = parseInt(routingStore.query.limit, 10) || uiStore.pageSize;
+    const sortBy = routingStore.query.sortby || uiStore.sortBy;
 
     return (
       <Layout title="Reaction Shop">
@@ -57,6 +71,10 @@ export default class TagShop extends Component {
         <ProductGrid
           catalogItems={catalogItems}
           pageInfo={catalogItemsPageInfo}
+          pageSize={pageSize}
+          setPageSize={this.setPageSize}
+          setSortBy={this.setSortBy}
+          sortBy={sortBy}
         />
       </Layout>
     );

--- a/src/pages/tag.js
+++ b/src/pages/tag.js
@@ -26,8 +26,11 @@ export default class TagShop extends Component {
     catalogItemsPageInfo: PropTypes.object,
     classes: PropTypes.object,
     routingStore: PropTypes.object,
+    setPageSize: PropTypes.func,
+    setSortBy: PropTypes.func,
     shop: PropTypes.object,
-    tag: PropTypes.object
+    tag: PropTypes.object,
+    uiStore: PropTypes.object
   };
 
   static defaultProps= {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3443,7 +3443,7 @@ graphql-tag@^2.8.0:
   version "2.9.2"
   resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.9.2.tgz#2f60a5a981375f430bf1e6e95992427dc18af686"
 
-graphql@^0.13.1:
+graphql@^0.13.2:
   version "0.13.2"
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-0.13.2.tgz#4c740ae3c222823e7004096f832e7b93b2108270"
   dependencies:


### PR DESCRIPTION
This PR add functionality to sort by updatedAt, price fields.

**Testing**
1. Set sorting to all three values: newest, price: low to high and price: hight to low
2. After each selection verify products are sorted according to the set sort order
---
1. Set sorting to Price: low to high
2. Refresh page
3. Verify sorting persists
---
1. Set sorting
2. Visit PDP page
3. Navigate back to grid 
4. Verify sorting persists
