### PR TITLE
Reaction Project Hooks

### DIFF
--- a/.reaction/project-hooks/README.md
+++ b/.reaction/project-hooks/README.md
@@ -1,0 +1,41 @@
+This directory contains project hooks for the Reaction development environment.
+They are invoked from the reaction-next build tools which operate across all
+projects to aid with orchestration.
+
+These hooks provide means for developers of an application to ensure that the
+application configure itself without higher-level coordination outside of the
+project.
+
+## Included Hooks
+
+| Name                 | Description                                          |
+| -------------------- | ---------------------------------------------------- |
+| `pre-build`          | Invoked before Docker build.                         |
+| `post-build`         | Invoked after Docker build and before project start. |
+| `post-project-start` | Invoked after project start.                         |
+| `post-system-start`  | Invoked after entire system start.                   |
+
+More information can be found in the header documentation of each script.
+
+## General Best Practices
+
+### Check that Services Are Available Before Using Them
+
+The `post-project-start` and `post-system-start` hooks are called after the
+services are started with Docker. Though they have been started, it's possible
+that they will not yet be available to perform any script actions. This depends
+on the startup time for you application.
+
+This can lead to race conditions if you try to use a service in a hook script.
+
+Always check that any service is available before using it.
+
+Tools like [await](https://github.com/betalo-sweden/await) can help.
+
+### Keep Hook Scripts Lightweight
+
+It can be tempting to add code directly to the hook script to directly perform
+a task.
+
+It is better to create a script in your project and call it from the hook. This
+keeps the scripted action reusable and available outside of the hook context.

--- a/.reaction/project-hooks/post-build
+++ b/.reaction/project-hooks/post-build
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Post Build Hook
+# Invoked by the reaction-next project bootstrapping process.
+#
+# Invoked after Docker build.
+# Perform any actions here that are required after docker-compose build but
+# before the project is started.
+#
+# Important Notes:
+#
+#  - Expect that services are NOT running at this time.
+#  - Do not assume that this hook script will run from this local directory.
+#    The $__dir var is provided for convenience and may be used to invoke other
+#    scripts.
+#  - It is good practice to keep this script lightweight and invoke setup
+#    scripts in your project.
+
+__current_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+__root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+__root_name=$(basename "${__root_dir}")
+
+echo "${__root_name} post-build script invoked." 2>&1

--- a/.reaction/project-hooks/post-project-start
+++ b/.reaction/project-hooks/post-project-start
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Post Project Start Hook
+# Invoked by the reaction-next project bootstrapping process.
+#
+# Invoked after this service is started. Can be used for project specific
+# actions that should be performed after the project is running, like database
+# setup, migrations, seeds, etc. Do not depend on other projects in this hook!
+#
+# Important Notes:
+#
+#  - The hook runs after all Docker Compose services in THIS project are
+#    started. Though started, there is no guarantee that these services are
+#    ready (i.e. that they will respond to requests.) It is your responsibility
+#    to test that services are available before using them to avoid race
+#    conditions.
+#  - Do not assume that this hook script will run from this local directory.
+#    The $__dir var is provided for convenience and may be used to invoke other
+#    scripts.
+#  - It is good practice to keep this script lightweight and invoke setup
+#    scripts in your project.
+
+__current_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+__root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+__root_name=$(basename "${__root_dir}")
+
+echo "${__root_name} post-project-start script invoked." 2>&1

--- a/.reaction/project-hooks/post-system-start
+++ b/.reaction/project-hooks/post-system-start
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Post System Start Hook
+# Invoked by the reaction-next project bootstrapping process.
+#
+# Invoked after all services in the system have been started.
+#
+# Important Notes:
+#
+#  - The hook runs after all Docker Compose services in ALL projects are
+#    started. Though started, there is no guarantee that these services are
+#    ready (i.e. that they will respond to requests.) It is your responsibility
+#    to test that services are available before using them to avoid race
+#    conditions.
+#  - Do not assume that this hook script will run from this local directory.
+#    The $__dir var is provided for convenience and may be used to invoke other
+#    scripts.
+#  - It is good practice to keep this script lightweight and invoke setup
+#    scripts in your project.
+
+__current_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+__root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+__root_name=$(basename "${__root_dir}")
+
+echo "${__root_name} post-system-start script invoked." 2>&1

--- a/.reaction/project-hooks/pre-build
+++ b/.reaction/project-hooks/pre-build
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Pre Build Hook
+# Invoked by the reaction-next project bootstrapping process.
+#
+# Invoked before Docker build.
+# Perform any actions here that are required before docker-compose build. For
+# example, copying values from .env.example to .env.
+#
+# Important Notes:
+#
+#  - Expect that services are NOT running at this time.
+#  - Do not assume that this hook script will run from this local directory.
+#    The $__dir var is provided for convenience and may be used to invoke other
+#    scripts.
+#  - It is good practice to keep this script lightweight and invoke setup
+#    scripts in your project.
+
+__current_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+__root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+__root_name=$(basename "${__root_dir}")
+
+echo "${__root_name} post-project-start script invoked." 2>&1
+
+"${__root_dir}/bin/setup"

--- a/bin/setup
+++ b/bin/setup
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+__dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+env_file=${__dir}/../.env
+env_example_file=${__dir}/../.env.example
+
+function main {
+  set -e
+
+  add_new_env_vars
+}
+
+function add_new_env_vars {
+  # create .env and set perms if it does not exist
+  [ ! -f "${env_file}" ] && { touch "${env_file}" ; chmod 0600 "${env_file}" ; }
+
+  export IFS=$'\n'
+  for var in $(cat "${env_example_file}"); do
+    key="${var%%=*}"     # get var key
+    var=$(eval echo "$var") # generate dynamic values
+
+    # If .env doesn't contain this env key, add it
+    if ! $(grep -qLE "^$key=" "${env_file}"); then
+      echo "Adding $key to .env"
+      echo "$var" >> "${env_file}"
+    fi
+  done
+}
+
+main


### PR DESCRIPTION
Issue: none
Impact: minor
Type: chore

## Issue

We have two projects, `reaction` and `reaction-next-starterkit` that must be coordinated to run together. Keycloak will add a 3rd project and another Docker network. 

Create tooling that will configure and launch the projects with a single CLI command.

## Solution

Integrate this project with multi-project orchestration.

This PR adds everything needed to hook the project into the [reaction-next](https://github.com/reactioncommerce/reaction-next) meta project. All the existing backends and frontends can be launched with the `make` command. 

After this merge, `make` command in [reaction-next](https://github.com/reactioncommerce/reaction-next) launches:

* Meteor
* Devserver
* Reaction Next Starter Kit
* Keycloak

All user defined networks are automatically created.

See the [reactioncommerce/reaction-next](https://github.com/reactioncommerce/reaction-next) project README for more details.

### What's included

* A `bin/setup` script that will copy `.env.example` to `.env` in this project directory
* A `pre-build` project hook will run the bin/setup script to ensure the required `.env` file is in place before attempting to run Docker on the project.



## Testing

You can test reaction-next in a new directory to launch everything in complete isolation.

1. Install [reaction-next prequisites](https://github.com/reactioncommerce/reaction-next#prerequisites). Ensure you have SSH enabled on Github.
2. Ensure all Docker containers are stopped to avoid port conflicts.
2. `git clone git@github.com:reactioncommerce/reaction-next.git`
3. `make`
4. Expect a failure until this PR is merged. Check out this branch in `reaction-next-starterkit` (in the reaction-next folder):  
  `cd reaction-next-starterkit && git checkout -b reaction-project-hooks origin/reaction-project-hooks && cd ..`
6. `make`

This should launch all the projects. The first launch may take some time. Meteor is in there.

You can `cd` into each child directory and control the project with Docker as usual. The `reaction-next` Makefile is using Docker, too. 

## Platform Support

📓 These scripts (and the reaction-next project) are portable bash. I doubt they'll work in Windows. We can push windows support to a future effort.

---

(I know we're moving away from `reaction-next` terminology. The project name is leftover and has not been renamed yet.)

