### PR TITLE
(feat): 87 nnnnat product grid by tag

### DIFF
--- a/src/components/NavigationDesktop/NavigationItemDesktop.js
+++ b/src/components/NavigationDesktop/NavigationItemDesktop.js
@@ -1,5 +1,6 @@
 import React, { Component, Fragment } from "react";
 import PropTypes from "prop-types";
+import { inject } from "mobx-react";
 import Button from "@material-ui/core/Button";
 import Divider from "@material-ui/core/Divider";
 import Grid from "@material-ui/core/Grid";
@@ -25,6 +26,7 @@ const styles = (theme) => ({
 });
 
 @withStyles(styles)
+@inject("routingStore")
 class NavigationItemDesktop extends Component {
   static propTypes = {
     classes: PropTypes.object,
@@ -44,11 +46,11 @@ class NavigationItemDesktop extends Component {
   }
 
   onClick = () => {
-    const { navItem } = this.props;
-
+    const { navItem, routingStore } = this.props;
     if (this.hasSubNavItems) {
       this.setState({ isSubNavOpen: !this.state.isSubNavOpen });
     } else {
+      routingStore.setTag({ _id: navItem._id, name: navItem.name, slug: navItem.slug });
       Router.pushRoute("tag", { slug: navItem.slug });
     }
   };

--- a/src/components/NavigationDesktop/NavigationItemDesktop.js
+++ b/src/components/NavigationDesktop/NavigationItemDesktop.js
@@ -1,5 +1,6 @@
 import React, { Component, Fragment } from "react";
 import PropTypes from "prop-types";
+import { inject } from "mobx-react";
 import Button from "@material-ui/core/Button";
 import Divider from "@material-ui/core/Divider";
 import Grid from "@material-ui/core/Grid";
@@ -24,19 +25,29 @@ const styles = (theme) => ({
   }
 });
 
+@inject("routingStore")
 @withStyles(styles)
 class NavigationItemDesktop extends Component {
   static propTypes = {
     classes: PropTypes.object,
-    navItem: PropTypes.object
+    navItem: PropTypes.object,
+    routingStore: PropTypes.object
   };
 
   static defaultProps = {
     classes: {},
-    navItem: {}
+    navItem: {},
+    routingStore: {}
   };
 
   state = { isSubNavOpen: false };
+
+  get linkPath() {
+    const { navItem, routingStore } = this.props;
+    return routingStore.queryString !== ""
+      ? `/tag/${navItem.slug}?${routingStore.queryString}`
+      : `/tag/${navItem.slug}`;
+  }
 
   get hasSubNavItems() {
     const { navItem: { subTags } } = this.props;
@@ -48,7 +59,8 @@ class NavigationItemDesktop extends Component {
     if (this.hasSubNavItems) {
       this.setState({ isSubNavOpen: !this.state.isSubNavOpen });
     } else {
-      Router.pushRoute("tag", { slug: navItem.slug });
+      const path = this.linkPath;
+      Router.pushRoute(path, { slug: navItem.slug });
     }
   };
 
@@ -62,7 +74,7 @@ class NavigationItemDesktop extends Component {
         <Divider />
         {navItemGroup.subTags.edges.map(({ node: navItem }, index) => (
           <MenuItem dense key={index}>
-            <Link route={`/tag/${navItem.slug}`}>
+            <Link route={`${this.linkPath}`}>
               <ListItemText primary={navItem.name} />
             </Link>
           </MenuItem>

--- a/src/components/NavigationDesktop/NavigationItemDesktop.js
+++ b/src/components/NavigationDesktop/NavigationItemDesktop.js
@@ -1,6 +1,5 @@
 import React, { Component, Fragment } from "react";
 import PropTypes from "prop-types";
-import { inject } from "mobx-react";
 import Button from "@material-ui/core/Button";
 import Divider from "@material-ui/core/Divider";
 import Grid from "@material-ui/core/Grid";

--- a/src/components/NavigationDesktop/NavigationItemDesktop.js
+++ b/src/components/NavigationDesktop/NavigationItemDesktop.js
@@ -26,7 +26,6 @@ const styles = (theme) => ({
 });
 
 @withStyles(styles)
-@inject("routingStore")
 class NavigationItemDesktop extends Component {
   static propTypes = {
     classes: PropTypes.object,
@@ -46,11 +45,10 @@ class NavigationItemDesktop extends Component {
   }
 
   onClick = () => {
-    const { navItem, routingStore } = this.props;
+    const { navItem } = this.props;
     if (this.hasSubNavItems) {
       this.setState({ isSubNavOpen: !this.state.isSubNavOpen });
     } else {
-      routingStore.setTag({ _id: navItem._id, name: navItem.name, slug: navItem.slug });
       Router.pushRoute("tag", { slug: navItem.slug });
     }
   };

--- a/src/components/NavigationDesktop/NavigationItemDesktop.test.js
+++ b/src/components/NavigationDesktop/NavigationItemDesktop.test.js
@@ -112,20 +112,24 @@ const mockTagsWithMoreSubTags = {
   }
 };
 
+const mockRoutingStore = {
+  queryString: ""
+};
+
 test("renders with 1 level of tags", () => {
-  const component = renderer.create(<NavigationItemDesktop navItems={mockTag} />);
+  const component = renderer.create(<NavigationItemDesktop navItems={mockTag} routingStore={mockRoutingStore} />);
   const tree = component.toJSON();
   expect(tree).toMatchSnapshot();
 });
 
 test("renders with 2 levels of tags", () => {
-  const component = renderer.create(<NavigationItemDesktop navItems={mockTagWithSubTags} />);
+  const component = renderer.create(<NavigationItemDesktop navItems={mockTagWithSubTags} routingStore={mockRoutingStore} />);
   const tree = component.toJSON();
   expect(tree).toMatchSnapshot();
 });
 
 test("renders with 3 levels of tags", () => {
-  const component = renderer.create(<NavigationItemDesktop navItems={mockTagsWithMoreSubTags} />);
+  const component = renderer.create(<NavigationItemDesktop navItems={mockTagsWithMoreSubTags} routingStore={mockRoutingStore} />);
   const tree = component.toJSON();
   expect(tree).toMatchSnapshot();
 });

--- a/src/components/NavigationMobile/NavigationItemMobile.js
+++ b/src/components/NavigationMobile/NavigationItemMobile.js
@@ -1,5 +1,6 @@
 import React, { Component, Fragment } from "react";
 import PropTypes from "prop-types";
+import { inject } from "mobx-react";
 import { Router } from "routes";
 import Divider from "@material-ui/core/Divider";
 import ListItemIcon from "@material-ui/core/ListItemIcon";
@@ -22,19 +23,29 @@ const styles = (theme) => ({
   }
 });
 
+@inject("routingStore")
 @withStyles(styles)
 class NavigationItemMobile extends Component {
   static propTypes = {
     classes: PropTypes.object,
-    navItem: PropTypes.object
+    navItem: PropTypes.object,
+    routingStore: PropTypes.object
   };
 
   static defaultProps = {
     classes: {},
-    navItem: {}
+    navItem: {},
+    routingStore: {}
   };
 
   state = { isSubNavOpen: false };
+
+  get linkPath() {
+    const { navItem, routingStore } = this.props;
+    return routingStore.queryString !== ""
+      ? `/tag/${navItem.slug}?${routingStore.queryString}`
+      : `/tag/${navItem.slug}`;
+  }
 
   get hasSubNavItems() {
     const { navItem: { subTags } } = this.props;

--- a/src/components/NavigationMobile/NavigationItemMobile.js
+++ b/src/components/NavigationMobile/NavigationItemMobile.js
@@ -58,7 +58,8 @@ class NavigationItemMobile extends Component {
     if (this.hasSubNavItems) {
       this.setState({ isSubNavOpen: !this.state.isSubNavOpen });
     } else {
-      Router.pushRoute("tag", { slug: navItem.slug });
+      const path = this.linkPath;
+      Router.pushRoute(path, { slug: navItem.slug });
     }
   };
 

--- a/src/components/NavigationMobile/NavigationItemMobile.test.js
+++ b/src/components/NavigationMobile/NavigationItemMobile.test.js
@@ -113,20 +113,24 @@ const mockTagsWithMoreSubTags = {
   }
 };
 
+const mockRoutingStore = {
+  queryString: ""
+};
+
 test("renders with 1 level of tags", () => {
-  const component = renderer.create(shallow(<NavigationItemMobile navItem={mockTag} />).get(3));
+  const component = renderer.create(shallow(<NavigationItemMobile navItem={mockTag} routingStore={mockRoutingStore} />).get(3));
   const tree = component.toJSON();
   expect(tree).toMatchSnapshot();
 });
 
 test("renders with 2 levels of tags", () => {
-  const component = renderer.create(<NavigationItemMobile navItem={mockTagWithSubTags} />);
+  const component = renderer.create(<NavigationItemMobile navItem={mockTagWithSubTags} routingStore={mockRoutingStore} />);
   const tree = component.toJSON();
   expect(tree).toMatchSnapshot();
 });
 
 test("renders with 3 levels of tags", () => {
-  const component = renderer.create(<NavigationItemMobile navItem={mockTagsWithMoreSubTags} />);
+  const component = renderer.create(<NavigationItemMobile navItem={mockTagsWithMoreSubTags} routingStore={mockRoutingStore} />);
   const tree = component.toJSON();
   expect(tree).toMatchSnapshot();
 });

--- a/src/components/ProductItem/ProductItem.js
+++ b/src/components/ProductItem/ProductItem.js
@@ -120,7 +120,7 @@ class ProductItem extends Component {
 
   renderProductInfo() {
     const { classes, currencyCode, product: { pricing, title, vendor } } = this.props;
-    const productPrice = priceByCurrencyCode(currencyCode, pricing);
+    const productPrice = priceByCurrencyCode(currencyCode, pricing) || {};
 
     return (
       <div >

--- a/src/containers/catalog/catalogItems.gql
+++ b/src/containers/catalog/catalogItems.gql
@@ -1,5 +1,5 @@
-query catalogItemsQuery($shopId: ID!, $first: ConnectionLimitInt, $last:  ConnectionLimitInt, $before: ConnectionCursor, $after: ConnectionCursor, $sortBy: CatalogItemSortByField, $sortByPriceCurrencyCode: String, $sortOrder: SortOrder) {
-  catalogItems(shopIds: [$shopId], first: $first, last: $last, before: $before, after: $after, sortBy: $sortBy, sortByPriceCurrencyCode: $sortByPriceCurrencyCode, sortOrder: $sortOrder) {
+query catalogItemsQuery($shopId: ID!, $tagIds: [ID] $first: ConnectionLimitInt, $last:  ConnectionLimitInt, $before: ConnectionCursor, $after: ConnectionCursor, $sortBy: CatalogItemSortByField, $sortByPriceCurrencyCode: String, $sortOrder: SortOrder) {
+  catalogItems(shopIds: [$shopId], tagIds: $tagIds, first: $first, last: $last, before: $before, after: $after, sortBy: $sortBy, sortByPriceCurrencyCode: $sortByPriceCurrencyCode, sortOrder: $sortOrder) {
     totalCount
     pageInfo {
       endCursor

--- a/src/containers/catalog/withCatalogItems.js
+++ b/src/containers/catalog/withCatalogItems.js
@@ -21,15 +21,16 @@ export default (Component) => {
       primaryShopId: PropTypes.string.isRequired,
       routingStore: PropTypes.object.isRequired,
       uiStore: PropTypes.object.isRequired
-    }
+    };
 
     render() {
       const { primaryShopId, routingStore, uiStore } = this.props;
       const [sortBy, sortOrder] = uiStore.sortBy.split("-");
-
+      const tagIds = routingStore.tag._id ? [routingStore.tag._id] : undefined;
       const variables = {
         shopId: primaryShopId,
         ...paginationVariablesFromUrlParams(routingStore.query, { defaultPageLimit: uiStore.pageSize }),
+        tagIds,
         sortBy,
         sortByPriceCurrencyCode: uiStore.sortByCurrencyCode,
         sortOrder

--- a/src/lib/stores/RoutingStore.js
+++ b/src/lib/stores/RoutingStore.js
@@ -22,7 +22,7 @@ export default class RoutingStore {
   @observable query = {};
 
   /**
-   *
+   * The query params as a URL string. (i.e. `sortby=minPrice-asc&limit=60`)
    *
    * @type String
    */
@@ -41,13 +41,6 @@ export default class RoutingStore {
   @action updateRoute({ pathname, query }) {
     this.pathname = pathname;
     this.query = query;
-
-    let path;
-    if (this.queryString !== "") {
-      path = `${pathname}/${query.slug}?${this.queryString}`;
-      console.log("route updated with queryString", path, query);
-      // Router.replaceRoute(path, path, { shallow: true });
-    }
   }
 
   /**

--- a/src/lib/stores/RoutingStore.js
+++ b/src/lib/stores/RoutingStore.js
@@ -22,6 +22,13 @@ export default class RoutingStore {
   @observable query = {};
 
   /**
+   *
+   *
+   * @type String
+   */
+  @observable queryString = "";
+
+  /**
    * The tag for the current page.
    * @type Object
    */
@@ -34,6 +41,13 @@ export default class RoutingStore {
   @action updateRoute({ pathname, query }) {
     this.pathname = pathname;
     this.query = query;
+
+    let path;
+    if (this.queryString !== "") {
+      path = `${pathname}/${query.slug}?${this.queryString}`;
+      console.log("route updated with queryString", path, query);
+      // Router.replaceRoute(path, path, { shallow: true });
+    }
   }
 
   /**
@@ -55,14 +69,16 @@ export default class RoutingStore {
       }
     });
 
+    this.queryString = urlQueryString;
+
     let path;
     if (_slug) {
-      path = `${this.pathname}/${_slug}?${urlQueryString}`;
+      path = `${this.pathname}/${_slug}?${this.queryString}`;
     } else {
-      path = `${this.pathname}?${urlQueryString}`;
+      path = `${this.pathname}?${this.queryString}`;
     }
 
-    Router.pushRoute(path, path, { shallow: true });
+    Router.replaceRoute(path, path, { shallow: true });
     return path;
   }
 }

--- a/src/lib/stores/RoutingStore.js
+++ b/src/lib/stores/RoutingStore.js
@@ -21,6 +21,16 @@ export default class RoutingStore {
    */
   @observable query = {};
 
+  /**
+   * The tag for the current page.
+   * @type Object
+   */
+  @observable tag = {};
+
+  @action setTag = (tag) => {
+    this.tag = tag;
+  }
+
   @action updateRoute({ pathname, query }) {
     this.pathname = pathname;
     this.query = query;
@@ -34,7 +44,8 @@ export default class RoutingStore {
    */
   @action setSearch(search) {
     const _query = { ...toJS(this.query), ...search };
-
+    const _slug = _query.slug;
+    delete _query.slug;
     let urlQueryString = "";
     Object.keys(_query).forEach((key, index, arr) => {
       urlQueryString += `${key}=${_query[key]}`;
@@ -44,7 +55,13 @@ export default class RoutingStore {
       }
     });
 
-    const path = `${this.pathname}?${urlQueryString}`;
+    let path;
+    if (_slug) {
+      path = `${this.pathname}/${_slug}?${urlQueryString}`;
+    } else {
+      path = `${this.pathname}?${urlQueryString}`;
+    }
+
     Router.pushRoute(path, path, { shallow: true });
     return path;
   }

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -28,6 +28,11 @@ class Shop extends Component {
     uiStore: PropTypes.object.isRequired
   };
 
+  componentDidMount() {
+    const { routingStore } = this.props;
+    routingStore.setTag({});
+  }
+
   renderHelmet() {
     const { shop } = this.props;
 
@@ -43,13 +48,13 @@ class Shop extends Component {
   setPageSize = (pageSize) => {
     this.props.routingStore.setSearch({ limit: pageSize });
     this.props.uiStore.setPageSize(pageSize);
-  }
+  };
 
   // TODO: move this handler to _app.js, when it becomes available.
   setSortBy = (sortBy) => {
     this.props.routingStore.setSearch({ sortby: sortBy });
     this.props.uiStore.setSortBy(sortBy);
-  }
+  };
 
   render() {
     const { catalogItems, catalogItemsPageInfo, uiStore, routingStore, shop } = this.props;

--- a/src/pages/tag.js
+++ b/src/pages/tag.js
@@ -38,9 +38,12 @@ export default class TagShop extends Component {
     tag: {}
   };
 
-  componentDidMount() {
-    const { routingStore, tag } = this.props;
-    routingStore.setTag(tag);
+  static getDerivedStateFromProps(props) {
+    const { routingStore, tag } = props;
+    if (routingStore.tag._id !== tag._id) {
+      console.log("routingStore", tag._id, routingStore.tag._id);
+      routingStore.setTag(tag);
+    }
   }
 
   renderHelmet() {
@@ -84,7 +87,6 @@ export default class TagShop extends Component {
           setPageSize={this.setPageSize}
           setSortBy={this.setSortBy}
           sortBy={sortBy}
-          tag={tag}
         />
       </Layout>
     );

--- a/src/pages/tag.js
+++ b/src/pages/tag.js
@@ -34,9 +34,14 @@ export default class TagShop extends Component {
     uiStore: PropTypes.object
   };
 
-  static defaultProps= {
+  static defaultProps = {
     tag: {}
   };
+
+  componentDidMount() {
+    const { routingStore, tag } = this.props;
+    routingStore.setTag(tag);
+  }
 
   renderHelmet() {
     const { shop, routingStore } = this.props;
@@ -55,13 +60,13 @@ export default class TagShop extends Component {
   setPageSize = (pageSize) => {
     this.props.routingStore.setSearch({ limit: pageSize });
     this.props.uiStore.setPageSize(pageSize);
-  }
+  };
 
   // TODO: move this handler to _app.js, when it becomes available.
   setSortBy = (sortBy) => {
     this.props.routingStore.setSearch({ sortby: sortBy });
     this.props.uiStore.setSortBy(sortBy);
-  }
+  };
 
   render() {
     const { catalogItems, catalogItemsPageInfo, routingStore, uiStore, tag } = this.props;
@@ -79,6 +84,7 @@ export default class TagShop extends Component {
           setPageSize={this.setPageSize}
           setSortBy={this.setSortBy}
           sortBy={sortBy}
+          tag={tag}
         />
       </Layout>
     );

--- a/src/pages/tag.js
+++ b/src/pages/tag.js
@@ -41,7 +41,6 @@ export default class TagShop extends Component {
   static getDerivedStateFromProps(props) {
     const { routingStore, tag } = props;
     if (routingStore.tag._id !== tag._id) {
-      console.log("routingStore", tag._id, routingStore.tag._id);
       routingStore.setTag(tag);
     }
   }

--- a/src/pages/tag.js
+++ b/src/pages/tag.js
@@ -45,6 +45,8 @@ export default class TagShop extends Component {
     return null;
   }
 
+  state = {}
+
   renderHelmet() {
     const { shop, routingStore } = this.props;
     const title = routingStore.query.slug || shop.name;

--- a/src/pages/tag.js
+++ b/src/pages/tag.js
@@ -42,6 +42,7 @@ export default class TagShop extends Component {
     if (routingStore.tag._id !== tag._id) {
       routingStore.setTag(tag);
     }
+    return null;
   }
 
   renderHelmet() {
@@ -60,12 +61,12 @@ export default class TagShop extends Component {
   setPageSize = (pageSize) => {
     this.props.routingStore.setSearch({ limit: pageSize });
     this.props.uiStore.setPageSize(pageSize);
-  };
+  }
 
   setSortBy = (sortBy) => {
     this.props.routingStore.setSearch({ sortby: sortBy });
     this.props.uiStore.setSortBy(sortBy);
-  };
+  }
 
   render() {
     const {


### PR DESCRIPTION
## Solution
Storing a `tag` inside the `routingStore` that can be used in the `catalogItems` query. 
When a nav item is clicked the `routingStore.tag` will update. 
When a `tag` page is loaded the `routingStore.tag` will be set on page load.

## Testing
1. Spin up the storefront with several products and tags loaded in RC.
2. Use the tag nav to see the product grid update based on the current tag page.
3. Hard refresh or go directly to a tag page URL to see the product grid load only the products for the active tag.
4. Update the product grid limit or sortBy, then change pages via the tag nav. The product grid should update the products by tag but retain the limit and sortBy properties.