### PR TITLE
Renders placeholder image when a product does not have a featured image set.

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "mobx": "^4.1.1",
     "mobx-react": "^5.0.0",
     "next": "^6.0.3",
-    "next-routes": "^1.4.1",
+    "next-routes": "^1.4.2",
     "prop-types": "^15.6.1",
     "react": "16.4.0",
     "react-apollo": "^2.1.3",

--- a/src/components/MediaGallery/MediaGallery.js
+++ b/src/components/MediaGallery/MediaGallery.js
@@ -4,6 +4,7 @@ import Grid from "@material-ui/core/Grid";
 import withStyles from "@material-ui/core/styles/withStyles";
 import MediaGalleryItem from "components/MediaGalleryItem";
 import Img from "components/Img";
+import getConfig from "next/config";
 
 const styles = (theme) => ({
   root: {
@@ -60,8 +61,26 @@ class MediaGallery extends Component {
     this.setState({ featuredMediaIndex: index });
   };
 
+  renderPlaceHolderImg = () => {
+    const { publicRuntimeConfig } = getConfig();
+    const { placeholderImageUrls } = publicRuntimeConfig;
+
+    return (
+      <Img
+        presrc={placeholderImageUrls.galleryFeatured}
+        src={placeholderImageUrls.galleryFeatured}
+      />
+    );
+  }
+
   renderFeaturedImage() {
     const { mediaItems } = this.props;
+
+    // Render placeholder, when product does not have images set.
+    if (Array.isArray(mediaItems) && mediaItems.length === 0) {
+      return this.renderPlaceHolderImg();
+    }
+
     const featuredMedia = mediaItems[this.state.featuredMediaIndex];
     const mediaUrls = featuredMedia && featuredMedia.URLs;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5352,9 +5352,9 @@ netmask@^1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/netmask/-/netmask-1.0.6.tgz#20297e89d86f6f6400f250d9f4f6b4c1945fcd35"
 
-next-routes@^1.4.1:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/next-routes/-/next-routes-1.4.1.tgz#740e3c02c4c0435ce68a5c6f877412fe8686402b"
+next-routes@^1.4.2:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/next-routes/-/next-routes-1.4.2.tgz#736a382579a792ea69f35ae70b449acdfefa7944"
   dependencies:
     path-to-regexp "^2.1.0"
 


### PR DESCRIPTION
Renders placeholder image when a product does not have a featured image set.

**Testing**
1. Add a new product in reaction, **WITH OUT** adding any images
2. Verify placeholder image is used in the PDP of the new storefront.