### PR TITLE
Feat add checkout buttons component.

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -5,5 +5,5 @@ ignore:
   'npm:braces:20180219':
     - '*':
         reason: Waiting for Next.js 6 to update to Babel 7 beta.47 (https://github.com/babel/babel/issues/8034)
-        expires: 2018-06-30T00:00:00.000Z
+        expires: 2018-07-30T00:00:00.000Z
 patch: {}

--- a/src/components/CheckoutButtons/CheckoutButtons.js
+++ b/src/components/CheckoutButtons/CheckoutButtons.js
@@ -37,9 +37,9 @@ export default class CheckoutButtons extends Component {
   }
 
   render() {
-    const { 
-      isDisabled, 
-      primaryClassName, 
+    const {
+      isDisabled,
+      primaryClassName,
       primaryButtonRoute,
       primaryButtonText
     } = this.props;

--- a/src/components/CheckoutButtons/CheckoutButtons.js
+++ b/src/components/CheckoutButtons/CheckoutButtons.js
@@ -1,6 +1,7 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import Button from "@reactioncommerce/components/Button/v1";
+import Link from "components/Link";
 
 export default class CheckoutButtons extends Component {
   static propTypes = {
@@ -13,6 +14,10 @@ export default class CheckoutButtons extends Component {
      */
     onClick: PropTypes.func.isRequired,
     /**
+     * The NextJS route name for the primary checkout button.
+     */
+    primaryButtonRoute: PropTypes.string,
+    /**
      * Text to display inside the button
      */
     primaryButtonText: PropTypes.string,
@@ -23,6 +28,7 @@ export default class CheckoutButtons extends Component {
   }
 
   static defaultProps = {
+    primaryButtonRoute: "/checkout",
     primaryButtonText: "Checkout"
   };
 
@@ -31,18 +37,27 @@ export default class CheckoutButtons extends Component {
   }
 
   render() {
-    const { isDisabled, primaryClassName, primaryButtonText } = this.props;
+    const { 
+      isDisabled, 
+      primaryClassName, 
+      primaryButtonRoute,
+      primaryButtonText
+    } = this.props;
 
     return (
-      <Button
-        actionType="important"
-        className={primaryClassName}
-        isDisabled={isDisabled}
-        onClick={this.handleOnClick}
-        isFullWidth
+      <Link
+        route={primaryButtonRoute}
       >
-        {primaryButtonText}
-      </Button>
+        <Button
+          actionType="important"
+          className={primaryClassName}
+          isDisabled={isDisabled}
+          onClick={this.handleOnClick}
+          isFullWidth
+        >
+          {primaryButtonText}
+        </Button>
+      </Link>
     );
   }
 }

--- a/src/components/CheckoutButtons/CheckoutButtons.js
+++ b/src/components/CheckoutButtons/CheckoutButtons.js
@@ -1,0 +1,48 @@
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+import Button from "@reactioncommerce/components/Button/v1";
+
+export default class CheckoutButtons extends Component {
+  static propTypes = {
+    /**
+     * Set to `true` to prevent the button from calling `onClick` when clicked
+     */
+    isDisabled: PropTypes.bool,
+    /**
+     * On click function to pass to the Button component. Not handled internally, directly passed
+     */
+    onClick: PropTypes.func.isRequired,
+    /**
+     * Text to display inside the button
+     */
+    primaryButtonText: PropTypes.string,
+    /**
+     * className for primary checkout button
+     */
+    primaryClassName: PropTypes.string
+  }
+
+  static defaultProps = {
+    primaryButtonText: "Checkout"
+  };
+
+  handleOnClick = () => {
+    this.props.onClick();
+  }
+
+  render() {
+    const { isDisabled, primaryClassName, primaryButtonText } = this.props;
+
+    return (
+      <Button
+        actionType="important"
+        className={primaryClassName}
+        isDisabled={isDisabled}
+        onClick={this.handleOnClick}
+        isFullWidth
+      >
+        {primaryButtonText}
+      </Button>
+    );
+  }
+}

--- a/src/components/CheckoutButtons/CheckoutButtons.test.js
+++ b/src/components/CheckoutButtons/CheckoutButtons.test.js
@@ -1,0 +1,14 @@
+import React from "react";
+import renderer from "react-test-renderer";
+import CheckoutButtons from "./CheckoutButtons";
+
+test("basic snapshot", () => {
+  const component = renderer.create((
+    <CheckoutButtons
+      onClick={() => {}}
+    />
+  ));
+
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});

--- a/src/components/CheckoutButtons/__snapshots__/CheckoutButtons.test.js.snap
+++ b/src/components/CheckoutButtons/__snapshots__/CheckoutButtons.test.js.snap
@@ -1,56 +1,71 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`basic snapshot 1`] = `
-<div
-  className="Button__ButtonDiv-bnfrK eloVkm"
+<a
+  className="WithTracking-Link--link-1"
+  href="/checkout"
   onClick={[Function]}
-  onKeyPress={[Function]}
-  role="button"
+  onKeyDown={[Function]}
+  role="link"
   tabIndex={0}
-  title={undefined}
->
-  <div>
-    Checkout
-  </div>
-  <div
-    className="Button__SpinnerWrap-bgOcuM cCKgPo"
-    style={
-      Object {
-        "opacity": 0,
-        "paddingLeft": 0,
-        "width": 0,
-      }
+  tracking={
+    Object {
+      "getTrackingData": [Function],
+      "trackEvent": [Function],
     }
+  }
+>
+  <div
+    className="Button__ButtonDiv-bnfrK eloVkm"
+    onClick={[Function]}
+    onKeyPress={[Function]}
+    role="button"
+    tabIndex={0}
+    title={undefined}
   >
-    <svg
-      className="spinner__SpinnerSvg-iBTUvT bunzNs"
-      height="40px"
+    <div>
+      Checkout
+    </div>
+    <div
+      className="Button__SpinnerWrap-bgOcuM cCKgPo"
       style={
         Object {
-          "enableBackground": "new 0 0 50 50",
+          "opacity": 0,
+          "paddingLeft": 0,
+          "width": 0,
         }
       }
-      version="1.1"
-      viewBox="0 0 50 50"
-      width="40px"
-      x="0px"
-      y="0px"
     >
-      <path
-        d="M43.935,25.145c0-10.318-8.364-18.683-18.683-18.683c-10.318,0-18.683,8.365-18.683,18.683h4.068c0-8.071,6.543-14.615,14.615-14.615c8.072,0,14.615,6.543,14.615,14.615H43.935z"
-        fill="#000"
+      <svg
+        className="spinner__SpinnerSvg-iBTUvT bunzNs"
+        height="40px"
+        style={
+          Object {
+            "enableBackground": "new 0 0 50 50",
+          }
+        }
+        version="1.1"
+        viewBox="0 0 50 50"
+        width="40px"
+        x="0px"
+        y="0px"
       >
-        <animateTransform
-          attributeName="transform"
-          attributeType="xml"
-          dur="1s"
-          from="0 25 25"
-          repeatCount="indefinite"
-          to="360 25 25"
-          type="rotate"
-        />
-      </path>
-    </svg>
+        <path
+          d="M43.935,25.145c0-10.318-8.364-18.683-18.683-18.683c-10.318,0-18.683,8.365-18.683,18.683h4.068c0-8.071,6.543-14.615,14.615-14.615c8.072,0,14.615,6.543,14.615,14.615H43.935z"
+          fill="#000"
+        >
+          <animateTransform
+            attributeName="transform"
+            attributeType="xml"
+            dur="1s"
+            from="0 25 25"
+            repeatCount="indefinite"
+            to="360 25 25"
+            type="rotate"
+          />
+        </path>
+      </svg>
+    </div>
   </div>
-</div>
+</a>
 `;

--- a/src/components/CheckoutButtons/__snapshots__/CheckoutButtons.test.js.snap
+++ b/src/components/CheckoutButtons/__snapshots__/CheckoutButtons.test.js.snap
@@ -1,0 +1,56 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`basic snapshot 1`] = `
+<div
+  className="Button__ButtonDiv-bnfrK eloVkm"
+  onClick={[Function]}
+  onKeyPress={[Function]}
+  role="button"
+  tabIndex={0}
+  title={undefined}
+>
+  <div>
+    Checkout
+  </div>
+  <div
+    className="Button__SpinnerWrap-bgOcuM cCKgPo"
+    style={
+      Object {
+        "opacity": 0,
+        "paddingLeft": 0,
+        "width": 0,
+      }
+    }
+  >
+    <svg
+      className="spinner__SpinnerSvg-iBTUvT bunzNs"
+      height="40px"
+      style={
+        Object {
+          "enableBackground": "new 0 0 50 50",
+        }
+      }
+      version="1.1"
+      viewBox="0 0 50 50"
+      width="40px"
+      x="0px"
+      y="0px"
+    >
+      <path
+        d="M43.935,25.145c0-10.318-8.364-18.683-18.683-18.683c-10.318,0-18.683,8.365-18.683,18.683h4.068c0-8.071,6.543-14.615,14.615-14.615c8.072,0,14.615,6.543,14.615,14.615H43.935z"
+        fill="#000"
+      >
+        <animateTransform
+          attributeName="transform"
+          attributeType="xml"
+          dur="1s"
+          from="0 25 25"
+          repeatCount="indefinite"
+          to="360 25 25"
+          type="rotate"
+        />
+      </path>
+    </svg>
+  </div>
+</div>
+`;

--- a/src/components/CheckoutButtons/index.js
+++ b/src/components/CheckoutButtons/index.js
@@ -1,0 +1,1 @@
+export { default } from "./CheckoutButtons"

--- a/src/components/CheckoutButtons/index.js
+++ b/src/components/CheckoutButtons/index.js
@@ -1,1 +1,1 @@
-export { default } from "./CheckoutButtons"
+export { default } from "./CheckoutButtons";


### PR DESCRIPTION
Impact: minor
Type:  feature

## Issue
Adds a `CheckoutButtons` component that can be used anywhere checkout buttons need to be rendered. Currently there is only one button, in the future more will be added; when other payment methods are supported. For background details as to why this component was created visit: https://github.com/reactioncommerce/reaction-component-library/pull/110

## Testing
1.  Import component into desired page
2. Verify that checkout button is rendered and it fill the full width of the containing element.
3. Verify clicking on the button takes the user to the `/checkout` URL.