### PR TITLE
Fix invalid page size set via URL param

### DIFF
--- a/src/components/PageSizeSelector/PageSizeSelector.js
+++ b/src/components/PageSizeSelector/PageSizeSelector.js
@@ -1,19 +1,20 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import Select from "components/Select";
+import { PAGE_SIZES } from "lib/utils/pageSizes";
 
-const PAGE_SIZES = [
+const SELECTOR_OPTIONS = [
   {
     name: "20 Products",
-    value: 20
+    value: PAGE_SIZES._20
   },
   {
     name: "60 Products",
-    value: 60
+    value: PAGE_SIZES._60
   },
   {
     name: "100 Products",
-    value: 100
+    value: PAGE_SIZES._100
   }
 ];
 
@@ -33,7 +34,7 @@ class PageSizeSelector extends Component {
     return (
       <Select
         value={pageSize}
-        options={PAGE_SIZES}
+        options={SELECTOR_OPTIONS}
         inputProps={{
           name: "pageSize",
           id: "page-size"

--- a/src/components/ProductGrid/__snapshots__/ProductGrid.test.js.snap
+++ b/src/components/ProductGrid/__snapshots__/ProductGrid.test.js.snap
@@ -171,7 +171,7 @@ exports[`basic snapshot 1`] = `
                 >
                   Men's Lightweigth Synchilla
                 </aside>
-                <p
+                <div
                   className="MuiTypography-root-152 MuiTypography-body1-161"
                 >
                   <div>
@@ -181,7 +181,7 @@ exports[`basic snapshot 1`] = `
                       $12.99 - $19.99
                     </span>
                   </div>
-                </p>
+                </div>
               </div>
               <div>
                 <p
@@ -238,7 +238,7 @@ exports[`basic snapshot 1`] = `
                 >
                   Basic Reaction Product
                 </aside>
-                <p
+                <div
                   className="MuiTypography-root-152 MuiTypography-body1-161"
                 >
                   <div>
@@ -248,7 +248,7 @@ exports[`basic snapshot 1`] = `
                       $12.99 - $19.99
                     </span>
                   </div>
-                </p>
+                </div>
               </div>
               <div>
                 <p

--- a/src/components/ProductItem/__snapshots__/ProductItem.test.js.snap
+++ b/src/components/ProductItem/__snapshots__/ProductItem.test.js.snap
@@ -41,7 +41,7 @@ exports[`basic snapshot 1`] = `
           >
             Reaction Sample Product
           </aside>
-          <p
+          <div
             className="MuiTypography-root-23 MuiTypography-body1-32"
           >
             <div>
@@ -51,7 +51,7 @@ exports[`basic snapshot 1`] = `
                 $12.99 - $19.99
               </span>
             </div>
-          </p>
+          </div>
         </div>
         <div>
           <p

--- a/src/lib/stores/RoutingStore.js
+++ b/src/lib/stores/RoutingStore.js
@@ -1,5 +1,6 @@
 import { action, toJS, observable } from "mobx";
 import { Router } from "routes";
+import { inPageSizes, PAGE_SIZES } from "lib/utils/pageSizes";
 
 /**
  * A mobx store for routing data
@@ -53,6 +54,10 @@ export default class RoutingStore {
     const _query = { ...toJS(this.query), ...search };
     const _slug = _query.slug;
     delete _query.slug;
+
+    // Validate limit
+    _query.limit = inPageSizes(_query.limit) ? _query.limit : PAGE_SIZES._20;
+
     let urlQueryString = "";
     Object.keys(_query).forEach((key, index, arr) => {
       urlQueryString += `${key}=${_query[key]}`;

--- a/src/lib/stores/UIStore.js
+++ b/src/lib/stores/UIStore.js
@@ -1,5 +1,6 @@
 import { observable, action } from "mobx";
 import getConfig from "next/config";
+import { PAGE_SIZES, inPageSizes } from "lib/utils/pageSizes";
 
 /**
  * A mobx store for UI data
@@ -35,7 +36,7 @@ class UIStore {
    *
    * @type Number
    */
-  @observable pageSize = 20;
+  @observable pageSize = PAGE_SIZES._20;
 
   /**
    * The product grid's sorting order
@@ -94,7 +95,8 @@ class UIStore {
   }
 
   @action setPageSize = (size) => {
-    this.pageSize = size;
+    // Validate page size
+    this.pageSize = inPageSizes(size) ? size : PAGE_SIZES._20;
   }
 
   @action setSortBy = (sortBy) => {

--- a/src/lib/stores/index.js
+++ b/src/lib/stores/index.js
@@ -1,4 +1,5 @@
 import { autorun, configure } from "mobx";
+import { ExecutionEnv } from "lib/utils/executionEnv";
 import AuthStore from "./AuthStore";
 import RoutingStore from "./RoutingStore";
 import UIStore from "./UIStore";
@@ -11,13 +12,16 @@ const routingStore = new RoutingStore();
 const uiStore = new UIStore();
 
 autorun(() => {
-  const { query } = routingStore;
-  if (query && query.limit) {
-    uiStore.setPageSize(parseInt(query.limit, 10));
-  }
+  // Execute only in browser.
+  if (ExecutionEnv.canUseDOM) {
+    const { query } = routingStore;
+    if (query && query.limit) {
+      uiStore.setPageSize(parseInt(query.limit, 10));
+    }
 
-  if (query && query.sortby) {
-    uiStore.setSortBy(query.sortby);
+    if (query && query.sortby) {
+      uiStore.setSortBy(query.sortby);
+    }
   }
 });
 

--- a/src/lib/utils/executionEnv.js
+++ b/src/lib/utils/executionEnv.js
@@ -1,0 +1,19 @@
+const canUseDOM = !!(
+  typeof window !== "undefined" &&
+  window.document &&
+  window.document.createElement
+);
+
+/**
+ * The ExecutionEnv object provides properties that should be used
+ * to determine if the current execution environment is either client or server.
+ * Further, other properties are available to determine if a browser
+ * supports certain features.
+ */
+export const ExecutionEnv = {
+  canUseDOM,
+  canUseWorkers: typeof Worker !== "undefined",
+  canUseEventListeners:
+    canUseDOM && !!(window.addEventListener || window.attachEvent),
+  canUseViewport: canUseDOM && !!window.screen
+};

--- a/src/lib/utils/pageSizes.js
+++ b/src/lib/utils/pageSizes.js
@@ -1,0 +1,21 @@
+export const PAGE_SIZES = {
+  _20: 20,
+  _60: 60,
+  _100: 100
+};
+
+/**
+ * Determines whether a given pages is in the predefined enumeration
+ *
+ * @param {Number} size - The size to check against
+ * @returns {Boolean} -  True if size is valid, false otherwise.
+ */
+export function inPageSizes(size) {
+  for (const value in PAGE_SIZES) {
+    if (PAGE_SIZES[value] === size) {
+      return true;
+    }
+  }
+  return false;
+}
+

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -5,6 +5,7 @@ import Helmet from "react-helmet";
 import withCatalogItems from "containers/catalog/withCatalogItems";
 import ProductGrid from "components/ProductGrid";
 import trackProductListViewed from "lib/tracking/trackProductListViewed";
+import { inPageSizes } from "lib/utils/pageSizes";
 
 @withCatalogItems
 @inject("routingStore", "uiStore")
@@ -49,7 +50,7 @@ class Shop extends Component {
 
   render() {
     const { catalogItems, catalogItemsPageInfo, uiStore, routingStore: { query }, shop } = this.props;
-    const pageSize = query && query.limit ? parseInt(query.limit, 10) : uiStore.pageSize;
+    const pageSize = query && inPageSizes(query.limit) ? parseInt(query.limit, 10) : uiStore.pageSize;
     const sortBy = query && query.sortby ? query.sortby : uiStore.sortBy;
 
     return (


### PR DESCRIPTION
Resolves #157 
Impact: minor
Type: refactor

## Issue
Changing the `limit` url query param manually to a number that is not one of the default page sizes leads to a broken UI state. I attempted to fix that by changing the URL query `limit` param on startup, however it lead to an infinite loop. After some thought, I believe that the we should not be changing the URL query params entered by the user.

## Solution
A have added validation so that even if an invalid page size is set the URL, the UI will render to using the default page size of 20. 

## Testing
1. Set page size to any value using the dropdown.
2. Verify URL updates correctly.
3. Change the URL param `limit` and set it to an invalid page size, i.e. 25
4. Verify UI renders with default page size of 20

