### PR TITLE
Add custom error page

### DIFF
--- a/src/containers/catalog/withCatalogItemProduct.js
+++ b/src/containers/catalog/withCatalogItemProduct.js
@@ -1,6 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { Query } from "react-apollo";
+import Error from "../../pages/_error";
 import catalogItemProductQuery from "./catalogItemProduct.gql";
 
 /**
@@ -12,21 +13,25 @@ import catalogItemProductQuery from "./catalogItemProduct.gql";
 export default (Component) => (
   class WithCatalogItem extends React.Component {
     static propTypes = {
-      router: PropTypes.object.isRequired
+      router: PropTypes.object.isRequired,
+      shop: PropTypes.object.isRequired
     }
 
     render() {
-      const { slugOrId } = this.props.router.query;
+      const { router: { query }, shop } = this.props;
 
       return (
-        <Query query={catalogItemProductQuery} variables={{ slugOrId }}>
+        <Query query={catalogItemProductQuery} variables={{ slugOrId: query.slugOrId }}>
           {({ loading, data }) => {
             if (loading) return null;
 
-            const { catalogItemProduct } = data || {};
+            const { catalogItemProduct } = data;
 
-            return (
+            // If no product was found, render "Not Found" page
+            return catalogItemProduct ? (
               <Component {...this.props} product={catalogItemProduct.product} />
+            ) : (
+              (<Error shop={shop} subtitle="Not Found" />)
             );
           }}
         </Query>

--- a/src/pages/_error.js
+++ b/src/pages/_error.js
@@ -30,8 +30,13 @@ export default class Error extends Component {
   }
 
   static getInitialProps({ res, err }) {
-    // eslint-disable-next-line
-    const statusCode = res ? res.statusCode : err ? err.statusCode : null;
+    let { statusCode } = res;
+
+    // Did not receive an OK response
+    if (!statusCode) {
+      statusCode = err ? err.statusCode : null;
+    }
+
     return { statusCode };
   }
 
@@ -40,15 +45,15 @@ export default class Error extends Component {
   }
 
   render() {
-    const { classes, shop, subtitle } = this.props;
+    const { classes, shop, statusCode, subtitle } = this.props;
 
     return (
       <div className={classes.root}>
         <Helmet>
           <title> {shop && shop.name} | {subtitle}</title>
         </Helmet>
-        {this.props.statusCode ? (
-          <Typography> `An error ${this.props.statusCode} occurred on server`</Typography>
+        {statusCode ? (
+          <Typography> `An error ${statusCode} occurred on server`</Typography>
         ) : (
           <Fragment>
             <Typography className={classes.errorMessage} paragraph>Sorry! We couldn't find what you're looking for.</Typography>

--- a/src/pages/_error.js
+++ b/src/pages/_error.js
@@ -1,0 +1,52 @@
+import React, { Component, Fragment } from "react";
+import PropTypes from "prop-types";
+import Helmet from "react-helmet";
+import { withStyles } from "@material-ui/core/styles";
+import Typography from "@material-ui/core/Typography";
+import Link from "components/Link";
+
+const styles = {
+  root: {
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "center",
+    marginTop: "2rem"
+  }
+};
+
+@withStyles(styles)
+export default class Error extends Component {
+  static propTypes = {
+    classes: PropTypes.object,
+    shop: PropTypes.object,
+    statusCode: PropTypes.object
+  }
+
+  static getInitialProps({ res, err }) {
+    // eslint-disable-next-line
+    const statusCode = res ? res.statusCode : err ? err.statusCode : null;
+    return { statusCode };
+  }
+
+  render() {
+    const { classes, shop } = this.props;
+
+    return (
+      <div className={classes.root}>
+        <Helmet>
+          <title>{shop && shop.name} | Error</title>
+        </Helmet>
+        {this.props.statusCode ? (
+          <Typography> `An error ${this.props.statusCode} occurred on server`</Typography>
+        ) : (
+          <Fragment>
+            <Typography paragraph>Sorry! We couldn't find what you're looking for.</Typography>
+            <Typography>
+              <Link route="/">Home</Link>
+            </Typography>
+          </Fragment>
+        )}
+      </div>
+    );
+  }
+}

--- a/src/pages/_error.js
+++ b/src/pages/_error.js
@@ -19,7 +19,8 @@ export default class Error extends Component {
   static propTypes = {
     classes: PropTypes.object,
     shop: PropTypes.object,
-    statusCode: PropTypes.object
+    statusCode: PropTypes.object,
+    subtitle: PropTypes.string
   }
 
   static getInitialProps({ res, err }) {
@@ -28,13 +29,17 @@ export default class Error extends Component {
     return { statusCode };
   }
 
+  static defaultProps = {
+    subtitle: "Error"
+  }
+
   render() {
-    const { classes, shop } = this.props;
+    const { classes, shop, subtitle } = this.props;
 
     return (
       <div className={classes.root}>
         <Helmet>
-          <title>{shop && shop.name} | Error</title>
+          <title> {shop && shop.name} | {subtitle}</title>
         </Helmet>
         {this.props.statusCode ? (
           <Typography> `An error ${this.props.statusCode} occurred on server`</Typography>

--- a/src/pages/_error.js
+++ b/src/pages/_error.js
@@ -5,14 +5,20 @@ import { withStyles } from "@material-ui/core/styles";
 import Typography from "@material-ui/core/Typography";
 import Link from "components/Link";
 
-const styles = {
+const styles = (theme) => ({
   root: {
     display: "flex",
     flexDirection: "column",
     alignItems: "center",
-    marginTop: "2rem"
+    marginTop: "4rem"
+  },
+  errorMessage: {
+    color: theme.palette.reaction.black65
+  },
+  errorLink: {
+    color: theme.palette.reaction.coolGrey400
   }
-};
+});
 
 @withStyles(styles)
 export default class Error extends Component {
@@ -45,8 +51,8 @@ export default class Error extends Component {
           <Typography> `An error ${this.props.statusCode} occurred on server`</Typography>
         ) : (
           <Fragment>
-            <Typography paragraph>Sorry! We couldn't find what you're looking for.</Typography>
-            <Typography>
+            <Typography className={classes.errorMessage} paragraph>Sorry! We couldn't find what you're looking for.</Typography>
+            <Typography className={classes.errorLink}>
               <Link route="/">Home</Link>
             </Typography>
           </Fragment>


### PR DESCRIPTION
Resolves #161 
Impact: minor
Type: feature

## Issue
Use custom error page and style it according to designs.

## Solution
Override nextjs' default error page by implementing `_error.js` in pages directory. 

**Testing**
1. Enter a URL of a non existing product or page, i.e. /product/notfound
2. Verify custom error page is rendered.
3. Enter a invalid URL, i.e. /not-found
4. Verify custom error page is rendered.
