### PR TITLE
feat: Empty Product Grid "No products" message

### DIFF
--- a/src/components/ProductGrid/ProductGrid.js
+++ b/src/components/ProductGrid/ProductGrid.js
@@ -6,6 +6,7 @@ import ProductItem from "components/ProductItem";
 import PageStepper from "components/PageStepper";
 import PageSizeSelector from "components/PageSizeSelector";
 import SortBySelector from "components/SortBySelector";
+import ProductGridEmptyMessage from "./ProductGridEmptyMessage";
 
 const styles = (theme) => ({
   root: {
@@ -75,7 +76,7 @@ export default class ProductGrid extends Component {
   render() {
     const { catalogItems, classes, pageInfo } = this.props;
 
-    if (!catalogItems) return null;
+    if (!catalogItems) return <ProductGridEmptyMessage />;
 
     return (
       <section className={classes.root}>

--- a/src/components/ProductGrid/ProductGrid.js
+++ b/src/components/ProductGrid/ProductGrid.js
@@ -76,7 +76,7 @@ export default class ProductGrid extends Component {
   render() {
     const { catalogItems, classes, pageInfo } = this.props;
 
-    if (!catalogItems) return <ProductGridEmptyMessage />;
+    if (!catalogItems || !catalogItems.length) return <ProductGridEmptyMessage />;
 
     return (
       <section className={classes.root}>

--- a/src/components/ProductGrid/ProductGrid.test.js
+++ b/src/components/ProductGrid/ProductGrid.test.js
@@ -14,6 +14,14 @@ const uiStore = {
   }
 };
 
+const routingStore = {
+  pathname: "tag",
+  query: {
+    slug: "test-tag",
+    querystring: "?this&that"
+  }
+};
+
 test("basic snapshot", () => {
   const pageInfo = {
     hasNextPage: false,
@@ -26,7 +34,7 @@ test("basic snapshot", () => {
 
   const component = renderer.create((
     <MuiThemeProvider theme={theme}>
-      <Provider uiStore={uiStore}>
+      <Provider routingStore={routingStore} uiStore={uiStore}>
         <ProductGrid
           catalogItems={products}
           currencyCode="USD"
@@ -56,7 +64,7 @@ test("Empty product grid message", () => {
 
   const component = renderer.create((
     <MuiThemeProvider theme={theme}>
-      <Provider uiStore={uiStore}>
+      <Provider routingStore={routingStore} uiStore={uiStore}>
         <ProductGrid
           catalogItems={null}
           currencyCode="USD"

--- a/src/components/ProductGrid/ProductGrid.test.js
+++ b/src/components/ProductGrid/ProductGrid.test.js
@@ -43,3 +43,33 @@ test("basic snapshot", () => {
   const tree = component.toJSON();
   expect(tree).toMatchSnapshot();
 });
+
+test("Empty product grid message", () => {
+  const pageInfo = {
+    hasNextPage: false,
+    hasPreviousPage: true,
+    loadNextPage: () => {},
+    loadPreviousPage: () => {},
+    startCursor: "",
+    endCursor: ""
+  };
+
+  const component = renderer.create((
+    <MuiThemeProvider theme={theme}>
+      <Provider uiStore={uiStore}>
+        <ProductGrid
+          catalogItems={null}
+          currencyCode="USD"
+          pageInfo={pageInfo}
+          pageSize={20}
+          primaryShopId="123"
+          setPageSize={() => true}
+          setSortBy={() => true}
+          sortBy={"updatedAt-desc"}
+        />
+      </Provider>
+    </MuiThemeProvider>
+  ));
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});

--- a/src/components/ProductGrid/ProductGridEmptyMessage.js
+++ b/src/components/ProductGrid/ProductGridEmptyMessage.js
@@ -27,6 +27,7 @@ export default class ProductGridEmptyMessage extends Component {
     actionMessage: PropTypes.string,
     classes: PropTypes.object,
     notFoundMessage: PropTypes.string,
+    resetLink: PropTypes.string,
     routingStore: PropTypes.object
   }
 
@@ -36,10 +37,10 @@ export default class ProductGridEmptyMessage extends Component {
   }
 
   render() {
-    const { classes, actionMessage, notFoundMessage, routingStore } = this.props;
+    const { classes, actionMessage, notFoundMessage, resetLink: providedResetLink, routingStore } = this.props;
 
-    let resetLink = routingStore.pathname;
-    if (routingStore && routingStore.query && routingStore.query.slug) {
+    let resetLink = providedResetLink || routingStore.pathname;
+    if (!providedResetLink && routingStore && routingStore.query && routingStore.query.slug) {
       resetLink = `${routingStore.pathname}/${routingStore.query.slug}`;
     }
 

--- a/src/components/ProductGrid/ProductGridEmptyMessage.js
+++ b/src/components/ProductGrid/ProductGridEmptyMessage.js
@@ -1,0 +1,55 @@
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+import { inject } from "mobx-react";
+import { withStyles } from "@material-ui/core/styles";
+import Typography from "@material-ui/core/Typography";
+import Link from "components/Link";
+
+const styles = (theme) => ({
+  root: {
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "center",
+    marginTop: "4rem"
+  },
+  actionMessage: {
+    color: theme.palette.reaction.coolGrey400
+  },
+  notFoundMessage: {
+    color: theme.palette.reaction.black65
+  }
+});
+
+@withStyles(styles)
+@inject("routingStore")
+export default class ProductGridEmptyMessage extends Component {
+  static propTypes = {
+    actionMessage: PropTypes.string,
+    classes: PropTypes.object,
+    notFoundMessage: PropTypes.string,
+    routingStore: PropTypes.object
+  }
+
+  static defaultProps = {
+    actionMessage: "Clear filters",
+    notFoundMessage: "Sorry! We couldn't find what you're looking for."
+  }
+
+  render() {
+    const { classes, actionMessage, notFoundMessage, routingStore } = this.props;
+
+    let resetLink = routingStore.pathname;
+    if (routingStore && routingStore.query && routingStore.query.slug) {
+      resetLink = `${routingStore.pathname}/${routingStore.query.slug}`;
+    }
+
+    return (
+      <div className={classes.root}>
+        <Typography className={classes.notFoundMessage} paragraph>{notFoundMessage}</Typography>
+        <Typography className={classes.actionMessage}>
+          <Link route={resetLink}>{actionMessage}</Link>
+        </Typography>
+      </div>
+    );
+  }
+}

--- a/src/components/ProductGrid/__snapshots__/ProductGrid.test.js.snap
+++ b/src/components/ProductGrid/__snapshots__/ProductGrid.test.js.snap
@@ -1,5 +1,37 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Empty product grid message 1`] = `
+<div
+  className="inject-ProductGridEmptyMessage-with-routingStore-root-203"
+>
+  <p
+    className="MuiTypography-root-152 MuiTypography-body1-161 MuiTypography-paragraph-170 inject-ProductGridEmptyMessage-with-routingStore-notFoundMessage-205"
+  >
+    Sorry! We couldn't find what you're looking for.
+  </p>
+  <p
+    className="MuiTypography-root-152 MuiTypography-body1-161 inject-ProductGridEmptyMessage-with-routingStore-actionMessage-204"
+  >
+    <a
+      className="WithTracking-Link--link-131"
+      href="tag/test-tag"
+      onClick={[Function]}
+      onKeyDown={[Function]}
+      role="link"
+      tabIndex={0}
+      tracking={
+        Object {
+          "getTrackingData": [Function],
+          "trackEvent": [Function],
+        }
+      }
+    >
+      Clear filters
+    </a>
+  </p>
+</div>
+`;
+
 exports[`basic snapshot 1`] = `
 <section
   className="ProductGrid-root-1"

--- a/src/containers/catalog/withCatalogItems.js
+++ b/src/containers/catalog/withCatalogItems.js
@@ -41,7 +41,7 @@ export default (Component) => {
           {({ loading, data, fetchMore }) => {
             if (loading) return null;
 
-            const { catalogItems } = data || {};
+            const { catalogItems } = data;
 
             return (
               <Component


### PR DESCRIPTION
Resolves #issueNumber
Impact: **minor**
Type: **feature**

## Issue
Add message/link to the grid component, when loading is complete but there are no items.

## Solution
Created a new component, `ProductGridEmptyMessage`, that will display when no products are available on the grid.

## Breaking changes
None

## Testing
1. Start up the app
1. Use the Admin to create a tag that has no products attached to it
1. In the starterkit, Go to the tag page which has no products on it
1. See the empty grid message
1. Click the `Clear filters`
1. See that page is routed to where it should go (clear the `querystring`)