### PR TITLE
ref: filter media gallery images by selected option / variant

### DIFF
--- a/src/components/ProductDetail/ProductDetail.js
+++ b/src/components/ProductDetail/ProductDetail.js
@@ -157,7 +157,7 @@ class ProductDetail extends Component {
       }
 
       // If we have a selected option, do the same check
-      // Will revert to variant check if no option mdia is available
+      // Will revert to variant check if no option media is available
       if (Array.isArray(selectedVariant.options) && selectedVariant.options.length) {
         const selectedOption = selectedVariant.options.find((option) => option._id === pdpSelectedOptionId);
         if (selectedOption) {

--- a/src/components/ProductDetail/ProductDetail.js
+++ b/src/components/ProductDetail/ProductDetail.js
@@ -143,6 +143,31 @@ class ProductDetail extends Component {
       pdpProductToAddToCart = pdpSelectedOptionId;
     }
 
+    // Set the default media as the top-level product's media
+    // (all media on all variants and objects)
+    let pdpMediaItems = product.media;
+
+    // If we have a selected variant (we always should)
+    // check to see if media is available, and use this media instead
+    // Revert to original media if variant doesn't have specific media
+    const selectedVariant = product.variants.find((variant) => variant._id === pdpSelectedVariantId);
+    if (selectedVariant) {
+      if (selectedVariant.media && selectedVariant.media.length) {
+        pdpMediaItems = selectedVariant.media;
+      }
+
+      // If we have a selected option, do the same check
+      // Will revert to variant check if no option mdia is available
+      if (Array.isArray(selectedVariant.options) && selectedVariant.options.length) {
+        const selectedOption = selectedVariant.options.find((option) => option._id === pdpSelectedOptionId);
+        if (selectedOption) {
+          if (selectedOption.media && selectedOption.media.length) {
+            pdpMediaItems = selectedOption.media;
+          }
+        }
+      }
+    }
+
     const productPrice = this.determineProductPrice();
 
     return (
@@ -157,7 +182,7 @@ class ProductDetail extends Component {
           </Grid>
           <Grid item xs={12} sm={6}>
             <div className={classes.section}>
-              <MediaGallery mediaItems={product.media} />
+              <MediaGallery mediaItems={pdpMediaItems} />
             </div>
             <div className={classes.section}>
               <TagGrid tags={product.tags.nodes} />

--- a/src/containers/catalog/catalogItemProduct.gql
+++ b/src/containers/catalog/catalogItemProduct.gql
@@ -81,6 +81,58 @@ query catalogItemProductQuery($slugOrId: String!) {
           optionTitle
           isSoldOut
           isLowQuantity
+          media {
+            toGrid
+            priority
+            productId
+            variantId
+            URLs {
+              thumbnail
+              small
+              medium
+              large
+              original
+            }
+          }
+          primaryImage {
+            URLs {
+              large
+              medium
+              original
+              small
+              thumbnail
+            }
+            toGrid
+            priority
+            productId
+            variantId
+          }
+        }
+        media {
+          toGrid
+          priority
+          productId
+          variantId
+          URLs {
+            thumbnail
+            small
+            medium
+            large
+            original
+          }
+        }
+        primaryImage {
+          URLs {
+            large
+            medium
+            original
+            small
+            thumbnail
+          }
+          toGrid
+          priority
+          productId
+          variantId
         }
       }
     }


### PR DESCRIPTION
Resolves #165 
Impact: **minor**
Type: **refactor**

## Issue
Product images aren't displayed based on which variant / option is selected. All images always show, not matter what.

## Solution
Use the new data available - `media` and `primaryImage` information specific to each option / variant ([PR #4468 in the core repo](https://github.com/reactioncommerce/reaction/pull/4468)) to show only media directly related to the selected option / variant, if available. If no media is available, show the media for the parent of the current selected option / variant.

## Breaking changes
None

## Testing
1. Add multiple variants and options to a product
1. Add images to some of these options and variants, and leave some of the options and variants with no images
1. See that when selecting an option / variant, you only see the media that was uploaded for that specific option / variant. If no media is available, see that the media shown is that of the current selected variants parent.
