### PR TITLE
fix: Segment receives incorrect Product List Viewed data

### DIFF
--- a/src/containers/catalog/withCatalogItems.js
+++ b/src/containers/catalog/withCatalogItems.js
@@ -38,10 +38,8 @@ export default (Component) => {
 
       return (
         <Query query={catalogItemsQuery} variables={variables}>
-          {({ loading, data, fetchMore }) => {
-            if (loading) return null;
-
-            const { catalogItems } = data;
+          {({ data, fetchMore }) => {
+            const { catalogItems } = data || {};
 
             return (
               <Component

--- a/src/containers/tags/withTag.js
+++ b/src/containers/tags/withTag.js
@@ -23,14 +23,14 @@ export default (Component) => (
 
       return (
         <Query query={tagQuery} variables={{ slugOrId: tag }}>
-          {({ loading, error, data }) => {
-            if (loading || error) return null;
-            if (!data || !data.tag) return null;
+          {({ error, data }) => {
+            if (error) return null;
+            const tagData = data || {};
 
             return (
               <Component
                 {...this.props}
-                tag={data.tag}
+                tag={tagData && tagData.tag}
               />
             );
           }}

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -35,8 +35,14 @@ class Shop extends Component {
     routingStore.setTag({});
   }
 
+  componentDidUpdate(prevProps) {
+    if (this.props.catalogItems !== prevProps.catalogItems) {
+      this.trackEvent(this.props);
+    }
+  }
+
   @trackProductListViewed()
-  componentDidUpdate() {}
+  trackEvent() {}
 
   setPageSize = (pageSize) => {
     this.props.routingStore.setSearch({ limit: pageSize });

--- a/src/pages/tag.js
+++ b/src/pages/tag.js
@@ -50,11 +50,14 @@ export default class TagShop extends Component {
 
   state = {}
 
-  @trackProductListViewed()
-  componentDidMount() {}
+  componentDidUpdate(prevProps) {
+    if (this.props.catalogItems !== prevProps.catalogItems) {
+      this.trackEvent(this.props);
+    }
+  }
 
   @trackProductListViewed()
-  componentDidUpdate() {}
+  trackEvent() {}
 
   renderHelmet() {
     const { shop, routingStore } = this.props;


### PR DESCRIPTION
Resolves #179 
Impact: **minor**
Type: **bugfix**

## Issue
Data sent to segment was always one click behind, and sometimes it was being sent multiple times with the same or different data.

This was due to two things:
1. The product grid was being remounted every time the page was changed. This was due to the `withCatalogItems` decorator, which was returning `null` while the decorator was loading. This would unmount the grid, which would then remount when the data was ready, which would call `componentDidMount` again.
1. `trackProductListView` was being called as a decorator of `componentDidUpdate`, so it would be called no matter if the data was different or the same, as long as the component did update.

## Solution
Two issues were occuring here.
1. Don't have `loading` return `null` when data is being loaded. This fixes the re-mounting, which will in turn only call the trackProductListViewed` decorator one time on the first load. In the future, if we want to use the loading component for anything other than just returning `null` if it's `true`, we should pass it a level further into the next component and do the logic there.

1. Move the decorator into a `trackEvent` function, and check `prevProps` vs `this.props` to make sure data has been udpated before calling the tracking event after the initial mount.



## Breaking changes
None

## Testing
1. Create a segment account and get the API key. Add the key to the .env (see .env.example)
1. Start the app
1. Add enough products to allow for filters to change the products displayed
1. In the segment dashboard under sources > javascript > debugger see the events being tracked
1. Change pages and filters on the Product grid and see that the correct data is being sent to segment