### PR TITLE
chore: update react to fix XSS vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,9 +56,9 @@
     "next": "^6.1.1",
     "next-routes": "^1.4.2",
     "prop-types": "^15.6.2",
-    "react": "16.4.1",
+    "react": "16.4.2",
     "react-apollo": "^2.1.3",
-    "react-dom": "16.4.1",
+    "react-dom": "16.4.2",
     "react-helmet": "^5.2.0",
     "react-tracking": "^5.2.1",
     "styled-components": "^3.3.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6265,9 +6265,9 @@ react-apollo@^2.1.3:
     lodash "4.17.5"
     prop-types "^15.6.0"
 
-react-dom@16.4.1:
-  version "16.4.1"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.4.1.tgz#7f8b0223b3a5fbe205116c56deb85de32685dad6"
+react-dom@16.4.2:
+  version "16.4.2"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.4.2.tgz#4afed569689f2c561d2b8da0b819669c38a0bda4"
   dependencies:
     fbjs "^0.8.16"
     loose-envify "^1.1.0"
@@ -6375,9 +6375,9 @@ react-transition-group@^2.2.1:
     loose-envify "^1.3.1"
     prop-types "^15.6.1"
 
-react@16.4.1:
-  version "16.4.1"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.4.1.tgz#de51ba5764b5dbcd1f9079037b862bd26b82fe32"
+react@16.4.2:
+  version "16.4.2"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.4.2.tgz#2cd90154e3a9d9dd8da2991149fdca3c260e129f"
   dependencies:
     fbjs "^0.8.16"
     loose-envify "^1.1.0"


### PR DESCRIPTION
Impact: **critical**
Type: **chore**

## Issue

Update `react` and `react-dom` to 16.4.2 to fix XSS vulnerability.

```
✗ Medium severity vulnerability found on react-dom@16.4.1
- desc: Cross-site Scripting (XSS)
- info: https://snyk.io/vuln/npm:react-dom:20180802
- from: reaction-next-starterkit@1.0.0 > react-dom@16.4.1
Upgrade direct dependency react-dom@16.4.1 to react-dom@16.4.2
```

## Testing

1. Make sure the app still works