### PR TITLE
feat: remove cart items

### DIFF
--- a/src/components/MiniCart/MiniCart.js
+++ b/src/components/MiniCart/MiniCart.js
@@ -58,7 +58,8 @@ export default class MiniCart extends Component {
     }),
     classes: PropTypes.object.isRequired,
     hasMoreCartItems: PropTypes.bool,
-    loadMoreCartItems: PropTypes.func
+    loadMoreCartItems: PropTypes.func,
+    onRemoveCartItems: PropTypes.func
   }
 
   state = {
@@ -102,7 +103,7 @@ export default class MiniCart extends Component {
   }
 
   render() {
-    const { classes, cart, hasMoreCartItems, loadMoreCartItems } = this.props;
+    const { classes, cart, hasMoreCartItems, loadMoreCartItems, onRemoveCartItems } = this.props;
     const { anchorElement, open } = this.state;
     const id = open ? "simple-popper" : null;
 
@@ -138,6 +139,7 @@ export default class MiniCart extends Component {
                       <CartItems
                         {...cartItemProps}
                         hasMoreCartItems={hasMoreCartItems}
+                        onRemoveItemFromCart={onRemoveCartItems}
                         onLoadMoreCartItems={loadMoreCartItems}
                       />
                     )

--- a/src/containers/cart/cartPayloadFragment.gql
+++ b/src/containers/cart/cartPayloadFragment.gql
@@ -1,0 +1,97 @@
+fragment CartPayload on Cart {
+  _id
+  account {
+    _id
+  }
+  createdAt
+  shop {
+    _id
+  }
+  updatedAt
+  expiresAt
+  checkout {
+    summary {
+      itemTotal {
+        displayAmount
+      }
+      fulfillmentTotal {
+        displayAmount
+      }
+      itemTotal {
+        displayAmount
+      }
+      taxTotal {
+        displayAmount
+      }
+      total {
+        displayAmount
+      }
+    }
+  }
+  items {
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+    edges {
+      node {
+        _id
+        productConfiguration {
+          productId
+          productVariantId
+        }
+        addedAt
+        attributes {
+          label
+          value
+        }
+        createdAt
+        isBackorder
+        isLowQuantity
+        isSoldOut
+        imageURLs {
+          large
+          small
+          original
+          medium
+          thumbnail
+        }
+        metafields {
+          value
+          key
+        }
+        parcel {
+          length
+          width
+          weight
+          height
+        }
+        price {
+          amount
+          displayAmount
+          currency {
+            code
+          }
+        }
+        priceWhenAdded {
+          amount
+          displayAmount
+          currency {
+            code
+          }
+        }
+        productSlug
+        productType
+        quantity
+        shop {
+          _id
+        }
+        title
+        variantTitle
+        optionTitle
+        updatedAt
+        currentQuantity
+      }
+    }
+  }
+}

--- a/src/containers/cart/removeCartItemsMutation.gql
+++ b/src/containers/cart/removeCartItemsMutation.gql
@@ -1,0 +1,9 @@
+#import "./cartPayloadFragment.gql"
+
+mutation removeCartItems($input: RemoveCartItemsInput!) {
+  removeCartItems(input: $input) {
+    cart {
+      ...CartPayload
+    }
+  }
+}

--- a/src/pages/cart.js
+++ b/src/pages/cart.js
@@ -51,6 +51,7 @@ class CartPage extends Component {
     classes: PropTypes.object,
     hasMoreCartItems: PropTypes.bool,
     loadMoreCartItems: PropTypes.func,
+    onRemoveCartItems: PropTypes.func,
     shop: PropTypes.shape({
       name: PropTypes.string.isRequired,
       description: PropTypes.string
@@ -63,7 +64,11 @@ class CartPage extends Component {
 
   handleItemQuantityChange = (quantity) => quantity
 
-  handleRemoveItem = (_id) => _id
+  handleRemoveItem = (_id) => {
+    const { onRemoveCartItems } = this.props;
+
+    onRemoveCartItems(_id);
+  }
 
   renderCartItems() {
     const { cart, hasMoreCartItems, loadMoreCartItems } = this.props;


### PR DESCRIPTION
Resolves #187 
Impact: **minor**
Type: **feature**

## Issue

Connect the `remove` button on the cart items to a GraphQL mutation to remove cart items.

## Solution

- Add a GraphQL mutation to remove cart items
- Add a callback function to remove cart items
- Connect the CartItems component in the cart page and mini-cart to that callback

## Breaking changes

none

## Testing
1. Add items to cart
1. Open the cart page
1. Remove an item from the cart

## Known issues

- Cart drawer closes when you click on anything so the remove button callback never gets triggered. See #202 