### PR TITLE
feat: connect quantity input in cart and mini-cart

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@material-ui/core": "^1.4.2",
-    "@reactioncommerce/components": "0.14.0",
+    "@reactioncommerce/components": "0.14.5",
     "@reactioncommerce/components-context": "^1.0.0",
     "@segment/snippet": "^4.3.1",
     "apollo-cache-inmemory": "^1.1.11",

--- a/src/components/CartItems/CartItems.js
+++ b/src/components/CartItems/CartItems.js
@@ -38,10 +38,10 @@ class CartItems extends Component {
     onRemoveItemFromCart: PropTypes.func.isRequired
   }
 
-  handleItemQuantityChange = (quantity) => {
+  handleItemQuantityChange = (quantity, _id) => {
     const { onChangeCartItemQuantity } = this.props;
 
-    onChangeCartItemQuantity(quantity);
+    onChangeCartItemQuantity(quantity, _id);
   }
 
   handleRemoveItem = (_id) => {

--- a/src/components/CartItems/CartItems.js
+++ b/src/components/CartItems/CartItems.js
@@ -4,11 +4,6 @@ import { withStyles } from "@material-ui/core/styles";
 import Button from "@reactioncommerce/components/Button/v1";
 import CartItemsList from "@reactioncommerce/components/CartItems/v1";
 
-const components = {
-  // TODO: Use QuantityInput component when MUI dependency is removed.
-  QuantityInput: "div"
-};
-
 const styles = (theme) => ({
   loadMore: {
     display: "flex",
@@ -69,7 +64,6 @@ class CartItems extends Component {
         <CartItemsList
           isMiniCart={isMiniCart}
           items={items}
-          components={components}
           onChangeCartItemQuantity={this.handleItemQuantityChange}
           onRemoveItemFromCart={this.handleRemoveItem}
         />

--- a/src/componentsContext.js
+++ b/src/componentsContext.js
@@ -12,8 +12,7 @@ import PhoneNumberInput from "@reactioncommerce/components/PhoneNumberInput/v1";
 import Price from "@reactioncommerce/components/Price/v1";
 import QuantityInput from "@reactioncommerce/components/QuantityInput/v1";
 import Select from "@reactioncommerce/components/Select/v1";
-// TODO: Re-enable the stock warning component in ticket https://github.com/reactioncommerce/reaction-next-starterkit/issues/186
-// import StockWarning from "@reactioncommerce/components/StockWarning/v1";
+import StockWarning from "@reactioncommerce/components/StockWarning/v1";
 import spinner from "@reactioncommerce/components/utils/spinner";
 import TextInput from "@reactioncommerce/components/TextInput/v1";
 
@@ -41,6 +40,6 @@ export default {
   QuantityInput,
   spinner,
   Select,
-  StockWarning: () => null,
+  StockWarning,
   TextInput
 };

--- a/src/containers/cart/updateCartItemsQuantityMutation.gql
+++ b/src/containers/cart/updateCartItemsQuantityMutation.gql
@@ -1,0 +1,9 @@
+#import "./cartPayloadFragment.gql"
+
+mutation updateCartItemsQuantity($input: UpdateCartItemsQuantityInput!) {
+  updateCartItemsQuantity(input: $input) {
+    cart {
+      ...CartPayload
+    }
+  }
+}

--- a/src/containers/cart/withCart.js
+++ b/src/containers/cart/withCart.js
@@ -164,7 +164,7 @@ export default (Component) => (
         variables: {
           input: {
             cartId: cartStore.anonymousCartId || cartStore.accountCartId,
-            cartItemIds: (Array.isArray(cartItems) && cartItems) || [cartItems],
+            items: (Array.isArray(cartItems) && cartItems) || [cartItems],
             token: cartStore.anonymousCartToken || null
           }
         },

--- a/src/containers/cart/withCart.js
+++ b/src/containers/cart/withCart.js
@@ -10,6 +10,7 @@ import createCartMutation from "./createCartMutation.gql";
 import addCartItemsMutation from "./addCartItemsMutation.gql";
 import removeCartItemsMutation from "./removeCartItemsMutation.gql";
 import reconcileCartsMutation from "./reconcileCartsMutation.gql";
+import updateCartItemsQuantityMutation from "./updateCartItemsQuantityMutation.gql";
 
 const { publicRuntimeConfig } = getConfig() || {
   publicRuntimeConfig: {
@@ -150,6 +151,41 @@ export default (Component) => (
     }
 
     /**
+     * @name handleChangeCartItemsQuantity
+     * @summary Update the quantity of one or more cart items
+     * @ignore
+     * @param {Array<Object>|Object} cartItems An array of objects or a single object of shape: { cartItemId: String, quantity: Int }
+     * @returns {undefined} No return
+     */
+    handleChangeCartItemsQuantity = (cartItems) => {
+      const { cartStore, client: apolloClient } = this.props;
+
+      apolloClient.mutate({
+        mutation: updateCartItemsQuantityMutation,
+        variables: {
+          input: {
+            cartId: cartStore.anonymousCartId || cartStore.accountCartId,
+            cartItemIds: (Array.isArray(cartItems) && cartItems) || [cartItems],
+            token: cartStore.anonymousCartToken || null
+          }
+        },
+        update: (cache, { data: mutationData }) => {
+          if (mutationData && mutationData.updateCartItemsQuantity) {
+            const { cart: cartPayload } = mutationData.updateCartItemsQuantity;
+
+            if (cartPayload) {
+              // Update Apollo cache
+              cache.writeQuery({
+                query: cartPayload.account ? accountCartQuery : anonymousCartQuery,
+                data: { cart: cartPayload }
+              });
+            }
+          }
+        }
+      });
+    }
+
+    /**
      * @name handleRemoveCartItems
      * @summary Remove items from the cart by id
      * @private
@@ -258,6 +294,7 @@ export default (Component) => (
                   <Component
                     {...this.props}
                     hasMoreCartItems={(pageInfo && pageInfo.hasNextPage) || false}
+                    onChangeCartItemsQuantity={this.handleChangeCartItemsQuantity}
                     onRemoveCartItems={this.handleRemoveCartItems}
                     loadMoreCartItems={() => {
                       fetchMore({

--- a/src/pages/cart.js
+++ b/src/pages/cart.js
@@ -51,6 +51,7 @@ class CartPage extends Component {
     classes: PropTypes.object,
     hasMoreCartItems: PropTypes.bool,
     loadMoreCartItems: PropTypes.func,
+    onChangeCartItemsQuantity: PropTypes.func,
     onRemoveCartItems: PropTypes.func,
     shop: PropTypes.shape({
       name: PropTypes.string.isRequired,
@@ -62,7 +63,11 @@ class CartPage extends Component {
     // TODO: handle checkout flow.
   }
 
-  handleItemQuantityChange = (quantity) => quantity
+  handleItemQuantityChange = (quantity, cartItemId) => {
+    const { onChangeCartItemsQuantity } = this.props;
+
+    onChangeCartItemsQuantity({ quantity, cartItemId });
+  }
 
   handleRemoveItem = (_id) => {
     const { onRemoveCartItems } = this.props;

--- a/yarn.lock
+++ b/yarn.lock
@@ -963,9 +963,9 @@
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@reactioncommerce/components-context/-/components-context-1.0.0.tgz#587764cf0d1b0312c786b8e4657379de02e13845"
 
-"@reactioncommerce/components@0.14.0":
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/@reactioncommerce/components/-/components-0.14.0.tgz#a862d8c6077dbf2a911fb64e7b8a6ade7ecfbf6d"
+"@reactioncommerce/components@0.14.5":
+  version "0.14.5"
+  resolved "https://registry.yarnpkg.com/@reactioncommerce/components/-/components-0.14.5.tgz#f28cd7ea4521667563a107e9e48c88aa52ec0934"
   dependencies:
     "@material-ui/core" "^1.4.0"
     lodash.debounce "^4.0.8"


### PR DESCRIPTION
Resolves #186
Impact: **minor**
Type: **feature**

## Issue

Connect the QuantityInput to the GraphQL mutation `UpdateCartItemsQuantity`

## Solution

Add a GQL mutation for updateCartItemsQuantity

## Testing

1. Add items to cart
2. Go to cart page
3. Increment/decrement quantities of items
4. Navigate to the homepage and back to the cart to ensure values have indeed updated

## Known issues

Cart drawer closes when you click on anything so the remove button callback never gets triggered. See #202
