### PR TITLE
bug: Mini-cart quantity hookup

### DIFF
--- a/src/components/MiniCart/MiniCart.js
+++ b/src/components/MiniCart/MiniCart.js
@@ -7,7 +7,6 @@ import IconButton from "@material-ui/core/IconButton";
 import CartIcon from "mdi-material-ui/Cart";
 import { Router } from "routes";
 import Popper from "@material-ui/core/Popper";
-import ClickAwayListener from "@material-ui/core/ClickAwayListener";
 import Fade from "@material-ui/core/Fade";
 import withCart from "containers/cart/withCart";
 import withShop from "containers/shop/withShop";
@@ -64,12 +63,14 @@ export default class MiniCart extends Component {
 
   state = {
     open: false,
-    anchorElement: null,
-    enteredPopper: false
+    anchorElement: null
   };
 
   handlePopperOpen = (event) => {
     const { currentTarget } = event;
+
+    this.clearOnCloseTimeout();
+
     this.setState({
       anchorElement: currentTarget,
       open: true
@@ -77,17 +78,13 @@ export default class MiniCart extends Component {
   }
 
   handlePopperClose = () => {
-    const { enteredPopper } = this.state;
-
-    setTimeout(() => {
-      if (!enteredPopper) {
-        this.setState(closePopper);
-      }
+    this.onCloseTimeout = setTimeout(() => {
+      this.setState(closePopper);
     }, 500);
   }
 
   handleEnterPopper = () => {
-    this.setState({ enteredPopper: true });
+    this.clearOnCloseTimeout();
   }
 
   handleLeavePopper = () => {
@@ -102,6 +99,12 @@ export default class MiniCart extends Component {
     this.setState(closePopper, () => Router.pushRoute("cart"));
   }
 
+  clearOnCloseTimeout() {
+    if (this.onCloseTimeout) {
+      window && window.clearTimeout(this.onCloseTimeout);
+    }
+  }
+
   render() {
     const { classes, cart, hasMoreCartItems, loadMoreCartItems, onRemoveCartItems } = this.props;
     const { anchorElement, open } = this.state;
@@ -109,15 +112,13 @@ export default class MiniCart extends Component {
 
     return (
       <Fragment>
-        <ClickAwayListener onClickAway={this.handleClickAway}>
-          <IconButton color="inherit"
-            onMouseEnter={this.handlePopperOpen}
-            onMouseLeave={this.handlePopperClose}
-            onClick={this.handleOnClick}
-          >
-            <CartIcon />
-          </IconButton>
-        </ClickAwayListener>
+        <IconButton color="inherit"
+          onMouseEnter={this.handlePopperOpen}
+          onMouseLeave={this.handlePopperClose}
+          onClick={this.handleOnClick}
+        >
+          <CartIcon />
+        </IconButton>
 
         <Popper
           className={classes.popper}

--- a/src/components/MiniCart/MiniCart.js
+++ b/src/components/MiniCart/MiniCart.js
@@ -58,6 +58,7 @@ export default class MiniCart extends Component {
     classes: PropTypes.object.isRequired,
     hasMoreCartItems: PropTypes.bool,
     loadMoreCartItems: PropTypes.func,
+    onChangeCartItemsQuantity: PropTypes.func,
     onRemoveCartItems: PropTypes.func
   }
 
@@ -97,6 +98,12 @@ export default class MiniCart extends Component {
 
   handleOnClick = () => {
     this.setState(closePopper, () => Router.pushRoute("cart"));
+  }
+
+  handleItemQuantityChange = (quantity, cartItemId) => {
+    const { onChangeCartItemsQuantity } = this.props;
+
+    onChangeCartItemsQuantity({ quantity, cartItemId });
   }
 
   clearOnCloseTimeout() {
@@ -141,6 +148,7 @@ export default class MiniCart extends Component {
                         {...cartItemProps}
                         hasMoreCartItems={hasMoreCartItems}
                         onRemoveItemFromCart={onRemoveCartItems}
+                        onChangeCartItemQuantity={this.handleItemQuantityChange}
                         onLoadMoreCartItems={loadMoreCartItems}
                       />
                     )


### PR DESCRIPTION
Resolves #211
Impact: **minor**
Type: **feature/bugfix**

## Issue

The quantity input in the cart drawer was not hooked up to the `withCart` decorator. This issue revealed itself when the I fixed the issue where the popover would close on click here: https://github.com/reactioncommerce/reaction-next-starterkit/pull/212

## Solution

- Add event handlers to adjust cart item quantity

## Testing

**test using reaction 1.15.0**

1. Add an item to the cart
2. Hover over the cart icon to open the mini-cart drawer
3. Adjust the quantity in of the item
4. Hover off of the cart drawer, and back unto it to ensure the changes to the quantity did indeed happen.

## Known issue

It seems as though the quantity input is not reactive for some reason. If you're on the cart page and open the mini-cart drawer and increment the quantity, then the input doesn't change. This may be related to how the quantity input handles local state.