### PR TITLE
Update docs to reflect current Reaction development branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ _Follow steps as necessary. If you already have Reaction installed, you may be a
 0. Prerequesites
 - Install [Docker](https://docs.docker.com/install/) and [Docker Compose](https://docs.docker.com/compose/install/). Docker Compose is included when installing Docker on Mac and Windows, but will need to be installed separately on Linux.
 
-1. Clone the main [Reaction repo](https://github.com/reactioncommerce/reaction) and checkout the `release-1.12.0` branch
+1. Clone the main [Reaction repo](https://github.com/reactioncommerce/reaction) and checkout the `release-1.15.0` branch
     ```sh
     git clone git@github.com:reactioncommerce/reaction.git
     cd reaction
-    git checkout release-1.12.0
+    git checkout release-1.15.0
 
     # change directory to the parent of your reaction install
     cd ..


### PR DESCRIPTION
Update installation docs to reflect that `reaction` is currently on branch `release-1.15.0`, no longer `release-1.2.0`.