### PR TITLE
fix: add <Link> to allow nav links to be read by SSR

### DIFF
--- a/src/components/NavigationDesktop/NavigationItemDesktop.js
+++ b/src/components/NavigationDesktop/NavigationItemDesktop.js
@@ -36,7 +36,7 @@ const styles = (theme) => ({
     fontSize: "12px"
   },
   primaryNavItem: {
-    textTransform: "capitalize",
+    "textTransform": "capitalize",
     "&:first-child": {
       paddingLeft: "16px"
     }
@@ -144,7 +144,7 @@ class NavigationItemDesktop extends Component {
   }
 
   render() {
-    const { classes: { navigationShopAllLink, primaryNavItem }, navItem } = this.props;
+    const { classes: { primaryNavItem }, navItem } = this.props;
 
     return (
       <Fragment>

--- a/src/components/NavigationDesktop/NavigationItemDesktop.js
+++ b/src/components/NavigationDesktop/NavigationItemDesktop.js
@@ -75,7 +75,9 @@ class NavigationItemDesktop extends Component {
     return subTags && Array.isArray(subTags.edges) && subTags.edges.length > 0;
   }
 
-  onClick = () => {
+  onClick = (event) => {
+    event.preventDefault();
+
     const { navItem } = this.props;
     if (this.hasSubNavItems) {
       this.setState({ isSubNavOpen: !this.state.isSubNavOpen });

--- a/src/components/NavigationDesktop/NavigationItemDesktop.js
+++ b/src/components/NavigationDesktop/NavigationItemDesktop.js
@@ -91,20 +91,6 @@ class NavigationItemDesktop extends Component {
     this.setState({ isSubNavOpen: false });
   };
 
-  renderMainNav() {
-    const { classes: { primaryNavItem }, navItem } = this.props;
-
-    if (!this.hasSubNavItems) {
-      return (
-        <Link route={`${this.linkPath()}`}>
-          <ListItemText disableTypography={true} primary={navItem.name} className={primaryNavItem} />
-        </Link>
-      );
-    }
-
-    return navItem.name;
-  }
-
   renderSubNav(navItemGroup) {
     return (
       <Fragment>
@@ -163,7 +149,7 @@ class NavigationItemDesktop extends Component {
     return (
       <Fragment>
         <Button className={primaryNavItem} color="inherit" onClick={this.onClick}>
-          {this.renderMainNav()}
+          {navItem.name}
           {this.hasSubNavItems && <Fragment>{this.state.isSubNavOpen ? <ChevronUpIcon /> : <ChevronDownIcon />}</Fragment>}
         </Button>
         {this.hasSubNavItems && this.renderPopover()}

--- a/src/components/NavigationDesktop/NavigationItemDesktop.js
+++ b/src/components/NavigationDesktop/NavigationItemDesktop.js
@@ -36,7 +36,10 @@ const styles = (theme) => ({
     fontSize: "12px"
   },
   primaryNavItem: {
-    textTransform: "capitalize"
+    textTransform: "capitalize",
+    "&:first-child": {
+      paddingLeft: "16px"
+    }
   }
 });
 
@@ -87,12 +90,12 @@ class NavigationItemDesktop extends Component {
   };
 
   renderMainNav() {
-    const { navItem } = this.props;
+    const { classes: { primaryNavItem }, navItem } = this.props;
 
     if (!this.hasSubNavItems) {
       return (
         <Link route={`${this.linkPath()}`}>
-          {navItem.name}
+          <ListItemText disableTypography={true} primary={navItem.name} className={primaryNavItem} />
         </Link>
       );
     }

--- a/src/components/NavigationDesktop/NavigationItemDesktop.js
+++ b/src/components/NavigationDesktop/NavigationItemDesktop.js
@@ -36,10 +36,7 @@ const styles = (theme) => ({
     fontSize: "12px"
   },
   primaryNavItem: {
-    "textTransform": "capitalize",
-    "&:first-child": {
-      paddingLeft: "16px"
-    }
+    textTransform: "capitalize"
   }
 });
 

--- a/src/components/NavigationDesktop/NavigationItemDesktop.js
+++ b/src/components/NavigationDesktop/NavigationItemDesktop.js
@@ -86,6 +86,20 @@ class NavigationItemDesktop extends Component {
     this.setState({ isSubNavOpen: false });
   };
 
+  renderMainNav() {
+    const { navItem } = this.props;
+
+    if (!this.hasSubNavItems) {
+      return (
+        <Link route={`${this.linkPath()}`}>
+          {navItem.name}
+        </Link>
+      );
+    }
+
+    return navItem.name;
+  }
+
   renderSubNav(navItemGroup) {
     return (
       <Fragment>
@@ -139,12 +153,12 @@ class NavigationItemDesktop extends Component {
   }
 
   render() {
-    const { classes: { primaryNavItem }, navItem } = this.props;
+    const { classes: { navigationShopAllLink, primaryNavItem }, navItem } = this.props;
 
     return (
       <Fragment>
         <Button className={primaryNavItem} color="inherit" onClick={this.onClick}>
-          {navItem.name}
+          {this.renderMainNav()}
           {this.hasSubNavItems && <Fragment>{this.state.isSubNavOpen ? <ChevronUpIcon /> : <ChevronDownIcon />}</Fragment>}
         </Button>
         {this.hasSubNavItems && this.renderPopover()}

--- a/src/components/NavigationDesktop/NavigationItemDesktop.js
+++ b/src/components/NavigationDesktop/NavigationItemDesktop.js
@@ -148,7 +148,7 @@ class NavigationItemDesktop extends Component {
 
     return (
       <Fragment>
-        <Button className={primaryNavItem} color="inherit" onClick={this.onClick}>
+        <Button className={primaryNavItem} color="inherit" onClick={this.onClick} href={`${this.linkPath(navItem)}`}>
           {navItem.name}
           {this.hasSubNavItems && <Fragment>{this.state.isSubNavOpen ? <ChevronUpIcon /> : <ChevronDownIcon />}</Fragment>}
         </Button>

--- a/src/components/NavigationDesktop/NavigationItemDesktop.js
+++ b/src/components/NavigationDesktop/NavigationItemDesktop.js
@@ -145,7 +145,7 @@ class NavigationItemDesktop extends Component {
 
     return (
       <Fragment>
-        <Button className={primaryNavItem} color="inherit" onClick={this.onClick} href={`${this.linkPath(navItem)}`}>
+        <Button className={primaryNavItem} color="inherit" onClick={this.onClick} href={this.linkPath(navItem)}>
           {navItem.name}
           {this.hasSubNavItems && <Fragment>{this.state.isSubNavOpen ? <ChevronUpIcon /> : <ChevronDownIcon />}</Fragment>}
         </Button>

--- a/src/components/NavigationDesktop/__snapshots__/NavigationItemDesktop.test.js.snap
+++ b/src/components/NavigationDesktop/__snapshots__/NavigationItemDesktop.test.js.snap
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders with 1 level of tags 1`] = `
-<button
+<a
   className="MuiButtonBase-root-30 MuiButton-root-6 MuiButton-text-8 MuiButton-flat-11 MuiButton-colorInherit-25 NavigationItemDesktop-primaryNavItem-5"
-  disabled={false}
+  href="/tag/undefined"
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -15,8 +15,8 @@ exports[`renders with 1 level of tags 1`] = `
   onTouchEnd={[Function]}
   onTouchMove={[Function]}
   onTouchStart={[Function]}
+  role="button"
   tabIndex="0"
-  type="button"
 >
   <span
     className="MuiButton-label-7"
@@ -24,13 +24,13 @@ exports[`renders with 1 level of tags 1`] = `
   <span
     className="MuiTouchRipple-root-33"
   />
-</button>
+</a>
 `;
 
 exports[`renders with 2 levels of tags 1`] = `
-<button
+<a
   className="MuiButtonBase-root-30 MuiButton-root-6 MuiButton-text-8 MuiButton-flat-11 MuiButton-colorInherit-25 NavigationItemDesktop-primaryNavItem-5"
-  disabled={false}
+  href="/tag/undefined"
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -42,8 +42,8 @@ exports[`renders with 2 levels of tags 1`] = `
   onTouchEnd={[Function]}
   onTouchMove={[Function]}
   onTouchStart={[Function]}
+  role="button"
   tabIndex="0"
-  type="button"
 >
   <span
     className="MuiButton-label-7"
@@ -51,13 +51,13 @@ exports[`renders with 2 levels of tags 1`] = `
   <span
     className="MuiTouchRipple-root-33"
   />
-</button>
+</a>
 `;
 
 exports[`renders with 3 levels of tags 1`] = `
-<button
+<a
   className="MuiButtonBase-root-30 MuiButton-root-6 MuiButton-text-8 MuiButton-flat-11 MuiButton-colorInherit-25 NavigationItemDesktop-primaryNavItem-5"
-  disabled={false}
+  href="/tag/undefined"
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -69,8 +69,8 @@ exports[`renders with 3 levels of tags 1`] = `
   onTouchEnd={[Function]}
   onTouchMove={[Function]}
   onTouchStart={[Function]}
+  role="button"
   tabIndex="0"
-  type="button"
 >
   <span
     className="MuiButton-label-7"
@@ -78,5 +78,5 @@ exports[`renders with 3 levels of tags 1`] = `
   <span
     className="MuiTouchRipple-root-33"
   />
-</button>
+</a>
 `;


### PR DESCRIPTION
Resolves #196 
Impact: **minor**
Type: **bugfix**

## Issue
Top level tag navigation items are not clickable when rendering in SSR-only when Javascript is disabled.

## Solution
Wrap top level tags in a `<Link>` component so an `<a>` tag is rendered for SSR / SEO purposes.

## Breaking changes
None.


## Testing
1. In Firefox
1. type `about:config` in the address bar and hit enter
1. Search for `javascript.enabled`
1. Double click to disable
1. Launch the starter kit and navigate to the homepage
1. Inspect a top-level nav element with no children, and see that the nav item is an `<a>` tag