### PR TITLE
[WIP] Add Empty Cart Message when there are no items in cart

### DIFF
--- a/src/pages/cart.js
+++ b/src/pages/cart.js
@@ -6,6 +6,7 @@ import Grid from "@material-ui/core/Grid";
 import Typography from "@material-ui/core/Typography";
 import { withStyles } from "@material-ui/core/styles";
 import trackProductViewed from "lib/tracking/trackProductViewed";
+import CartEmptyMessage from "@reactioncommerce/components/CartEmptyMessage/v1";
 import CartSummary from "@reactioncommerce/components/CartSummary/v1";
 import withCart from "containers/cart/withCart";
 import CartItems from "components/CartItems";
@@ -91,6 +92,7 @@ class CartPage extends Component {
     }
 
     return null;
+    return <CartEmptyMessage />;
   }
 
   render() {

--- a/src/pages/cart.js
+++ b/src/pages/cart.js
@@ -79,7 +79,7 @@ class CartPage extends Component {
   renderCartItems() {
     const { cart, hasMoreCartItems, loadMoreCartItems } = this.props;
 
-    if (cart && Array.isArray(cart.items)) {
+    if (cart && Array.isArray(cart.items) && cart.items.length) {
       return (
         <CartItems
           hasMoreCartItems={hasMoreCartItems}
@@ -91,7 +91,6 @@ class CartPage extends Component {
       );
     }
 
-    return null;
     return <CartEmptyMessage />;
   }
 


### PR DESCRIPTION
Resolves #207 
Impact: **minor**
Type: **feature**

## Issue
When there are no items in a cart, there is no message that indicates this, the screen is just blank

## Solution
Add the component libraries "Empty Cart Message" to the cart when there are 0 items in the cart.\

## Breaking changes
None.

## Testing
1. Add a few items to your cart
1. Go to the cart
1. Remove items from cart
1. See "Empty Cart Message" component

More detail for what each of these sections should include are available in our [Contributing Docs](https://docs.reactioncommerce.com/reaction-docs/master/contributing-to-reaction)
