### PR TITLE
fix: added ie11 to babelrc browser target

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -6,7 +6,8 @@
         "targets": {
           "node": "current",
           "browsers": [
-            "last 2 versions"
+            "last 2 versions",
+            "ie 11"
           ]
         }
       }


### PR DESCRIPTION
Resolves #153 
Impact: **minor**
Type: **bugfix**

## Issue
The storefront wasn't loading in IE11 even though we have ES6 feature polyfills our babelrc config was only targeting the "laster 2 versions" and not IE11.

## Solution
Updated the babelrc to also target IE11.

## Testing
1. Startup RC and the storefront.
2. Using a VM visit the storefront app in IE11. (http://10.0.2.2:4000 for VirtualBox)
3. Storefront should now load and navigable

## Notes
This PR only fixes the issue of the storefront not loading in IE11, as you test you'll see several layout issues that still need to be captured.
