### PR TITLE
bug: Fix broken mini-cart when no cart is available

### DIFF
--- a/src/components/MiniCart/MiniCart.js
+++ b/src/components/MiniCart/MiniCart.js
@@ -22,9 +22,12 @@ const styles = ({ palette, zIndex }) => ({
     backgroundColor: palette.common.white
   },
   emptyCart: {
+    display: "flex",
+    justifyContent: "center",
+    alignItems: "center",
     width: 320,
     height: 320,
-    border: palette.reaction.borderColor
+    border: palette.borders.default
   }
 });
 
@@ -71,6 +74,8 @@ export default class MiniCart extends Component {
       open: true
     });
   }
+
+  handleClick = () => Router.pushRoute("/");
 
   handlePopperClose = () => {
     this.onCloseTimeout = setTimeout(() => {
@@ -127,7 +132,9 @@ export default class MiniCart extends Component {
 
     return (
       <div className={classes.emptyCart}>
-        <CartEmptyMessage onClick={this.handleClick} />
+        <div>
+          <CartEmptyMessage onClick={this.handleClick} />
+        </div>
       </div>
     );
   }

--- a/src/components/MiniCart/MiniCart.js
+++ b/src/components/MiniCart/MiniCart.js
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import { withStyles } from "@material-ui/core/styles";
 import MiniCartComponent from "@reactioncommerce/components/MiniCart/v1";
 import CartItems from "components/CartItems";
+import CartEmptyMessage from "@reactioncommerce/components/CartEmptyMessage/v1";
 import IconButton from "@material-ui/core/IconButton";
 import CartIcon from "mdi-material-ui/Cart";
 import { Router } from "routes";
@@ -19,6 +20,11 @@ const styles = ({ palette, zIndex }) => ({
   },
   cart: {
     backgroundColor: palette.common.white
+  },
+  emptyCart: {
+    width: 320,
+    height: 320,
+    border: palette.reaction.borderColor
   }
 });
 
@@ -27,7 +33,7 @@ const closePopper = {
   open: false
 };
 
-@withStyles(styles, { withTheme: true })
+@withStyles(styles)
 @withShop
 @withCart
 export default class MiniCart extends Component {
@@ -96,8 +102,38 @@ export default class MiniCart extends Component {
     }
   }
 
+  renderMiniCart() {
+    const { cart, classes, hasMoreCartItems, loadMoreCartItems, onRemoveCartItems } = this.props;
+
+    if (cart && Array.isArray(cart.items) && cart.items.length) {
+      return (
+        <MiniCartComponent
+          cart={cart}
+          components={{
+            QuantityInput: "div",
+            CartItems: (cartItemProps) => (
+              <CartItems
+                {...cartItemProps}
+                hasMoreCartItems={hasMoreCartItems}
+                onRemoveItemFromCart={onRemoveCartItems}
+                onChangeCartItemQuantity={this.handleItemQuantityChange}
+                onLoadMoreCartItems={loadMoreCartItems}
+              />
+            )
+          }}
+        />
+      );
+    }
+
+    return (
+      <div className={classes.emptyCart}>
+        <CartEmptyMessage onClick={this.handleClick} />
+      </div>
+    );
+  }
+
   render() {
-    const { classes, cart, hasMoreCartItems, loadMoreCartItems, onRemoveCartItems } = this.props;
+    const { classes } = this.props;
     const { anchorElement, open } = this.state;
     const id = open ? "simple-popper" : null;
 
@@ -123,21 +159,7 @@ export default class MiniCart extends Component {
           {({ TransitionProps }) => (
             <Fade {...TransitionProps}>
               <div className={classes.cart}>
-                <MiniCartComponent
-                  cart={cart}
-                  components={{
-                    QuantityInput: "div",
-                    CartItems: (cartItemProps) => (
-                      <CartItems
-                        {...cartItemProps}
-                        hasMoreCartItems={hasMoreCartItems}
-                        onRemoveItemFromCart={onRemoveCartItems}
-                        onChangeCartItemQuantity={this.handleItemQuantityChange}
-                        onLoadMoreCartItems={loadMoreCartItems}
-                      />
-                    )
-                  }}
-                />
+                {this.renderMiniCart()}
               </div>
             </Fade>
           )}

--- a/src/components/MiniCart/__snapshots__/MiniCart.test.js.snap
+++ b/src/components/MiniCart/__snapshots__/MiniCart.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`basic snapshot 1`] = `
 <button
-  className="MuiButtonBase-root-9 MuiIconButton-root-3 MuiIconButton-colorInherit-4"
+  className="MuiButtonBase-root-10 MuiIconButton-root-4 MuiIconButton-colorInherit-5"
   disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
@@ -20,11 +20,11 @@ exports[`basic snapshot 1`] = `
   type="button"
 >
   <span
-    className="MuiIconButton-label-8"
+    className="MuiIconButton-label-9"
   >
     <svg
       aria-hidden="true"
-      className="MuiSvgIcon-root-12"
+      className="MuiSvgIcon-root-13"
       color={undefined}
       focusable="false"
       viewBox="0 0 24 24"
@@ -37,7 +37,7 @@ exports[`basic snapshot 1`] = `
     </svg>
   </span>
   <span
-    className="MuiTouchRipple-root-19"
+    className="MuiTouchRipple-root-20"
   />
 </button>
 `;

--- a/src/lib/theme/reactionTheme.js
+++ b/src/lib/theme/reactionTheme.js
@@ -34,7 +34,7 @@ const theme = createMuiTheme({
       buttonBorderColor: "#5e7480"
     },
     borders: {
-      default: "1px solid #5e7480"
+      default: "1px solid #e6e6e6"
     },
     reaction: {
       activeElementBorderColor: "#94E8D1",


### PR DESCRIPTION
Resolves #226
Impact: **minor**
Type: **bugfix**

## Issue

When no cart is available, hovering over the cart icon produces an error in the console.

## Solution

Guard against an empty cart and display a cart empty message with actions.

## Breaking changes

none

## Testing

1. With no carts, open the mini cart to see the cart empty message
1. Add an item to the cart, and you should see items in the mini-cart
1. Remove all items from the cart, and you should see the cart empty message in the mini-cart
1. Clicking on "Continue shopping" should take you to the homepage
