### PR TITLE
bug: minicart checkout button onClick hookup

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@material-ui/core": "^1.4.2",
-    "@reactioncommerce/components": "0.19.0",
+    "@reactioncommerce/components": "0.22.0",
     "@reactioncommerce/components-context": "^1.0.0",
     "@segment/snippet": "^4.3.1",
     "apollo-cache-inmemory": "^1.1.11",

--- a/src/components/MiniCart/MiniCart.js
+++ b/src/components/MiniCart/MiniCart.js
@@ -76,6 +76,7 @@ export default class MiniCart extends Component {
   }
 
   handleClick = () => Router.pushRoute("/");
+  handleCheckoutButtonClick = () => Router.pushRoute("checkout");
 
   handlePopperClose = () => {
     this.onCloseTimeout = setTimeout(() => {
@@ -114,6 +115,7 @@ export default class MiniCart extends Component {
       return (
         <MiniCartComponent
           cart={cart}
+          onCheckoutButtonClick={this.handleCheckoutButtonClick}
           components={{
             QuantityInput: "div",
             CartItems: (cartItemProps) => (

--- a/yarn.lock
+++ b/yarn.lock
@@ -963,9 +963,9 @@
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@reactioncommerce/components-context/-/components-context-1.0.0.tgz#587764cf0d1b0312c786b8e4657379de02e13845"
 
-"@reactioncommerce/components@0.19.0":
-  version "0.19.0"
-  resolved "https://registry.yarnpkg.com/@reactioncommerce/components/-/components-0.19.0.tgz#5f9a014c6ac380b91b9d7a2809576a432c8196a2"
+"@reactioncommerce/components@0.22.0":
+  version "0.22.0"
+  resolved "https://registry.yarnpkg.com/@reactioncommerce/components/-/components-0.22.0.tgz#4209840a5eb7ce8410a90af3cf8bd5e7d6eaf631"
   dependencies:
     "@material-ui/core" "^1.4.0"
     lodash.debounce "^4.0.8"


### PR DESCRIPTION
Resolves #233 
Impact: **minor**
Type: **bugfix**

## Issue

When the checkout button in the mini cart was clicked, no event was fired to take you to the checkout page.

## Solution

- Made an update in the [reaction component library](https://github.com/reactioncommerce/reaction-component-library) to add `onCheckoutButtonClick` to the mini cart checkout button component.
- Hooked up the event callback to a Router.pushRoute in the starter-kit

**Why didn't I use the Link component**

I didn't use the link component because wrapping an anchor tag around a button caused onClick event bubbling issues. I would have to double click the checkout button in order for it to take me to the checkout page.

## Testing

1. Add items to the cart
2. Open the mini-cart
3. Click the checkout button
4. Arrive at the checkout page
