### PR TITLE
(feat): 225 nnnnat as guest / login checkout

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@material-ui/core": "^1.5.0",
-    "@reactioncommerce/components": "0.23.1",
+    "@reactioncommerce/components": "0.29",
     "@reactioncommerce/components-context": "^1.0.0",
     "@segment/snippet": "^4.3.1",
     "apollo-cache-inmemory": "^1.1.11",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@material-ui/core": "^1.5.0",
-    "@reactioncommerce/components": "0.29",
+    "@reactioncommerce/components": "0.30.3",
     "@reactioncommerce/components-context": "^1.0.0",
     "@segment/snippet": "^4.3.1",
     "apollo-cache-inmemory": "^1.1.11",

--- a/src/components/CheckoutSummary/__snapshots__/CheckoutSummary.test.js.snap
+++ b/src/components/CheckoutSummary/__snapshots__/CheckoutSummary.test.js.snap
@@ -229,7 +229,7 @@ exports[`basic snapshot 1`] = `
                   $45.00
                 </del>
                 <span
-                  className="Price__Span-cHkFMo hTtbIl"
+                  className="Price__Span-cHkFMo eGYnOf"
                 >
                   $20.00
                 </span>
@@ -443,7 +443,7 @@ exports[`basic snapshot 1`] = `
               <div>
                 
                 <span
-                  className="Price__Span-cHkFMo hTtbIl"
+                  className="Price__Span-cHkFMo eGYnOf"
                 >
                   $78.00
                 </span>

--- a/src/components/ProductGrid/__snapshots__/ProductGrid.test.js.snap
+++ b/src/components/ProductGrid/__snapshots__/ProductGrid.test.js.snap
@@ -186,7 +186,7 @@ Array [
                 >
                   <div>
                     <span
-                      className="Price__Span-cHkFMo hTtbIl"
+                      className="Price__Span-cHkFMo eGYnOf"
                     >
                       $12.99 - $19.99
                     </span>
@@ -248,7 +248,7 @@ Array [
                 >
                   <div>
                     <span
-                      className="Price__Span-cHkFMo hTtbIl"
+                      className="Price__Span-cHkFMo eGYnOf"
                     >
                       $12.99 - $19.99
                     </span>

--- a/src/components/ProductItem/__snapshots__/ProductItem.test.js.snap
+++ b/src/components/ProductItem/__snapshots__/ProductItem.test.js.snap
@@ -40,7 +40,7 @@ exports[`basic snapshot 1`] = `
           >
             <div>
               <span
-                className="Price__Span-cHkFMo hTtbIl"
+                className="Price__Span-cHkFMo eGYnOf"
               >
                 $12.99 - $19.99
               </span>

--- a/src/componentsContext.js
+++ b/src/componentsContext.js
@@ -6,6 +6,7 @@ import CartItem from "@reactioncommerce/components/CartItem/v1";
 import CartItemDetail from "@reactioncommerce/components/CartItemDetail/v1";
 import CartItems from "@reactioncommerce/components/CartItems/v1";
 import CartSummary from "@reactioncommerce/components/CartSummary/v1";
+import Checkbox from "@reactioncommerce/components/Checkbox/v1";
 import CheckoutAction from "@reactioncommerce/components/CheckoutAction/v1";
 import CheckoutActionComplete from "@reactioncommerce/components/CheckoutActionComplete/v1";
 import CheckoutActionIncomplete from "@reactioncommerce/components/CheckoutActionIncomplete/v1";
@@ -25,7 +26,16 @@ const FontIcon = styled.i`
   vertical-align: middle;
 `;
 
-const iconClear = <svg version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 14 14" style={{ height: "100%", maxHeight: "100%", verticalAlign: "middle" }}><path d="M9.926 9.105l-2.105-2.105 2.105-2.105-0.82-0.82-2.105 2.105-2.105-2.105-0.82 0.82 2.105 2.105-2.105 2.105 0.82 0.82 2.105-2.105 2.105 2.105zM7 1.176c3.227 0 5.824 2.598 5.824 5.824s-2.598 5.824-5.824 5.824-5.824-2.598-5.824-5.824 2.598-5.824 5.824-5.824z" /></svg>;
+const iconClear = (
+  <svg
+    version="1.1"
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 14 14"
+    style={{ height: "100%", maxHeight: "100%", verticalAlign: "middle" }}
+  >
+    <path d="M9.926 9.105l-2.105-2.105 2.105-2.105-0.82-0.82-2.105 2.105-2.105-2.105-0.82 0.82 2.105 2.105-2.105 2.105 0.82 0.82 2.105-2.105 2.105 2.105zM7 1.176c3.227 0 5.824 2.598 5.824 5.824s-2.598 5.824-5.824 5.824-5.824-2.598-5.824-5.824 2.598-5.824 5.824-5.824z" />
+  </svg>
+);
 
 export default {
   AddressForm,
@@ -34,6 +44,7 @@ export default {
   CartItemDetail,
   CartItems,
   CartSummary,
+  Checkbox,
   CheckoutAction,
   CheckoutActionComplete,
   CheckoutActionIncomplete,
@@ -41,7 +52,7 @@ export default {
   Field,
   iconClear,
   iconError: <FontIcon className="fas fa-exclamation-triangle" />,
-  iconValid: (<FontIcon className="far fa-check-circle" />),
+  iconValid: <FontIcon className="far fa-check-circle" />,
   MiniCartSummary,
   PhoneNumberInput,
   Price,

--- a/src/componentsContext.js
+++ b/src/componentsContext.js
@@ -17,7 +17,10 @@ import PhoneNumberInput from "@reactioncommerce/components/PhoneNumberInput/v1";
 import Price from "@reactioncommerce/components/Price/v1";
 import QuantityInput from "@reactioncommerce/components/QuantityInput/v1";
 import Select from "@reactioncommerce/components/Select/v1";
+import SelectableItem from "@reactioncommerce/components/SelectableItem/v1";
+import SelectableList from "@reactioncommerce/components/SelectableList/v1";
 import StockWarning from "@reactioncommerce/components/StockWarning/v1";
+import StripeForm from "@reactioncommerce/components/StripeForm/v1";
 import spinner from "@reactioncommerce/components/utils/spinner";
 import TextInput from "@reactioncommerce/components/TextInput/v1";
 
@@ -59,6 +62,9 @@ export default {
   QuantityInput,
   spinner,
   Select,
+  SelectableItem,
+  SelectableList,
   StockWarning,
+  StripeForm,
   TextInput
 };

--- a/src/componentsContext.js
+++ b/src/componentsContext.js
@@ -21,7 +21,7 @@ import SelectableItem from "@reactioncommerce/components/SelectableItem/v1";
 import SelectableList from "@reactioncommerce/components/SelectableList/v1";
 import StockWarning from "@reactioncommerce/components/StockWarning/v1";
 import StripeForm from "@reactioncommerce/components/StripeForm/v1";
-import spinner from "@reactioncommerce/components/utils/spinner";
+import spinner from "@reactioncommerce/components/svg/spinner";
 import TextInput from "@reactioncommerce/components/TextInput/v1";
 
 const FontIcon = styled.i`

--- a/src/componentsContext.js
+++ b/src/componentsContext.js
@@ -1,5 +1,11 @@
-import React from "react";
-import styled from "styled-components";
+import iconClear from "@reactioncommerce/components/svg/iconClear";
+import iconError from "@reactioncommerce/components/svg/iconError";
+import iconValid from "@reactioncommerce/components/svg/iconValid";
+import iconAmericanExpress from "@reactioncommerce/components/svg/iconAmericanExpress";
+import iconDiscover from "@reactioncommerce/components/svg/iconDiscover";
+import iconMastercard from "@reactioncommerce/components/svg/iconMastercard";
+import iconVisa from "@reactioncommerce/components/svg/iconVisa";
+import spinner from "@reactioncommerce/components/svg/spinner";
 import AddressForm from "@reactioncommerce/components/AddressForm/v1";
 import Button from "@reactioncommerce/components/Button/v1";
 import CartItem from "@reactioncommerce/components/CartItem/v1";
@@ -21,24 +27,7 @@ import SelectableItem from "@reactioncommerce/components/SelectableItem/v1";
 import SelectableList from "@reactioncommerce/components/SelectableList/v1";
 import StockWarning from "@reactioncommerce/components/StockWarning/v1";
 import StripeForm from "@reactioncommerce/components/StripeForm/v1";
-import spinner from "@reactioncommerce/components/svg/spinner";
 import TextInput from "@reactioncommerce/components/TextInput/v1";
-
-const FontIcon = styled.i`
-  font-size: 1em;
-  vertical-align: middle;
-`;
-
-const iconClear = (
-  <svg
-    version="1.1"
-    xmlns="http://www.w3.org/2000/svg"
-    viewBox="0 0 14 14"
-    style={{ height: "100%", maxHeight: "100%", verticalAlign: "middle" }}
-  >
-    <path d="M9.926 9.105l-2.105-2.105 2.105-2.105-0.82-0.82-2.105 2.105-2.105-2.105-0.82 0.82 2.105 2.105-2.105 2.105 0.82 0.82 2.105-2.105 2.105 2.105zM7 1.176c3.227 0 5.824 2.598 5.824 5.824s-2.598 5.824-5.824 5.824-5.824-2.598-5.824-5.824 2.598-5.824 5.824-5.824z" />
-  </svg>
-);
 
 export default {
   AddressForm,
@@ -53,9 +42,13 @@ export default {
   CheckoutActionIncomplete,
   ErrorsBlock,
   Field,
+  iconAmericanExpress,
   iconClear,
-  iconError: <FontIcon className="fas fa-exclamation-triangle" />,
-  iconValid: <FontIcon className="far fa-check-circle" />,
+  iconDiscover,
+  iconError,
+  iconMastercard,
+  iconValid,
+  iconVisa,
   MiniCartSummary,
   PhoneNumberInput,
   Price,

--- a/src/containers/cart/fragments.gql
+++ b/src/containers/cart/fragments.gql
@@ -12,6 +12,39 @@ fragment CartCommon on Cart {
   updatedAt
   expiresAt
   checkout {
+    fulfillmentGroups {
+      _id
+      data {
+        shippingAddress {
+          _id
+          address1
+          address2
+          city
+          company
+          country
+          failedValidation
+          fullName
+          isBillingDefault
+          isCommercial
+          isShippingDefault
+          phone
+          postal
+          region
+        }
+      }
+      availableFulfillmentOptions {
+        price {
+          displayAmount
+        }
+        fulfillmentMethod {
+          _id
+          displayName
+        }
+      }
+    }
+    payments{
+      _id
+    }
     summary {
       fulfillmentTotal {
         displayAmount

--- a/src/containers/cart/fragments.gql
+++ b/src/containers/cart/fragments.gql
@@ -8,6 +8,7 @@ fragment CartCommon on Cart {
   shop {
     _id
   }
+  email
   updatedAt
   expiresAt
   checkout {

--- a/src/containers/cart/mutations.gql
+++ b/src/containers/cart/mutations.gql
@@ -51,6 +51,16 @@ mutation removeCartItemsMutation($input: RemoveCartItemsInput!) {
   }
 }
 
+
+# Set email on anonymous cart for guest checkout
+mutation setEmailOnAnonymousCartMutation($input: SetEmailOnAnonymousCartInput!) {
+  setEmailOnAnonymousCart(input: $input) {
+    cart {
+      ...CartPayloadFragment
+    }
+  }
+}
+
 # Update the quantities of items in the cart
 mutation updateCartItemsQuantityMutation($input: UpdateCartItemsQuantityInput!) {
   updateCartItemsQuantity(input: $input) {

--- a/src/containers/cart/withCart.js
+++ b/src/containers/cart/withCart.js
@@ -9,6 +9,7 @@ import {
   addCartItemsMutation,
   removeCartItemsMutation,
   reconcileCartsMutation,
+  setEmailOnAnonymousCartMutation,
   updateCartItemsQuantityMutation
 } from "./mutations.gql";
 import {
@@ -224,6 +225,29 @@ export default (Component) => (
       });
     }
 
+    /**
+     *
+     * @name handleSetEmailOnAnonymousCart
+     * @summary Call when `setEmailOnAnonymousCart` callback is called
+     * @param {Funtion} mutation An Apollo mutation function
+     * @param {string} email An email address to be set on an anonymous cart
+     * @return {undefined} No return
+     */
+    handleSetEmailOnAnonymousCart = ({ email }) => {
+      const { cartStore, client: apolloClient } = this.props;
+      apolloClient.mutate({
+        mutation: setEmailOnAnonymousCartMutation,
+        variables: {
+          input: {
+            cartId: cartStore.anonymousCartId,
+            email,
+            token: cartStore.anonymousCartToken
+          }
+        }
+      });
+    }
+
+
     render() {
       const { authStore, cartStore, shop } = this.props;
       let query = anonymousCartByCartIdQuery;
@@ -336,6 +360,7 @@ export default (Component) => (
                         items
                       });
                     }}
+                    setEmailOnAnonymousCart={this.handleSetEmailOnAnonymousCart}
                     cart={processedCartData}
                   />
                 )}

--- a/src/lib/theme/reactionTheme.js
+++ b/src/lib/theme/reactionTheme.js
@@ -2,7 +2,8 @@ import { createMuiTheme } from "@material-ui/core/styles";
 
 const theme = createMuiTheme({
   layout: {
-    mainContentMaxWidth: "1440px"
+    mainContentMaxWidth: "1440px",
+    mainLoginMaxWidth: "1024px"
   },
   palette: {
     primary: {

--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -72,7 +72,7 @@ export default class App extends NextApp {
               >
                 <CssBaseline />
                 {
-                  route === "/checkout" ? (
+                  (route === "/checkout" || route === "/login") ? (
                     <Component pageContext={this.pageContext} shop={shop} {...rest} />
                   ) : (
                     <Layout shop={shop}>

--- a/src/pages/checkout.js
+++ b/src/pages/checkout.js
@@ -9,7 +9,6 @@ import Grid from "@material-ui/core/Grid";
 import CheckoutActions from "@reactioncommerce/components/CheckoutActions/v1";
 import CheckoutEmailAddress from "@reactioncommerce/components/CheckoutEmailAddress/v1";
 import CheckoutTopHat from "@reactioncommerce/components/CheckoutTopHat/v1";
-import GuestForm from "@reactioncommerce/components/GuestForm/v1";
 import ShippingAddressCheckoutAction from "@reactioncommerce/components/ShippingAddressCheckoutAction/v1";
 import StripePaymentCheckoutAction from "@reactioncommerce/components/StripePaymentCheckoutAction/v1";
 import ShopLogo from "@reactioncommerce/components/ShopLogo/v1";
@@ -133,26 +132,6 @@ class Checkout extends Component {
       );
     });
 
-  renderLogin() {
-    const { classes, setEmailOnAnonymousCart } = this.props;
-    return (
-      <Grid container spacing={24}>
-        <Grid item xs={12} md={7}>
-          <div className={classes.flexContainer}>
-            <div className={classes.checkoutActions}>Login/Register</div>
-          </div>
-        </Grid>
-        <Grid item xs={12} md={5}>
-          <div className={classes.flexContainer}>
-            <div className={classes.cartSummary}>
-              <GuestForm onSubmit={setEmailOnAnonymousCart} />
-            </div>
-          </div>
-        </Grid>
-      </Grid>
-    );
-  }
-
   renderCheckout() {
     const {
       classes,
@@ -222,7 +201,7 @@ class Checkout extends Component {
   }
 
   render() {
-    const { classes, cart, shop, theme } = this.props;
+    const { classes, shop, theme } = this.props;
 
     return (
       <Fragment>
@@ -252,7 +231,7 @@ class Checkout extends Component {
                 <CartIcon />
               </Link>
             </div>
-            {cart.account === null && !cart.email ? this.renderLogin() : this.renderCheckout()}
+            {this.renderCheckout()}
           </div>
         </section>
       </Fragment>

--- a/src/pages/checkout.js
+++ b/src/pages/checkout.js
@@ -133,7 +133,7 @@ class Checkout extends Component {
       <Grid container spacing={24}>
         <Grid item xs={12} md={7}>
           <div className={classes.flexContainer}>
-            <div className={classes.checkoutActions} />
+            <div className={classes.checkoutActions}>Login/Register</div>
           </div>
         </Grid>
         <Grid item xs={12} md={5}>
@@ -210,8 +210,6 @@ class Checkout extends Component {
 
   render() {
     const { classes, cart, shop, theme } = this.props;
-
-    console.log("this is my cart!", cart);
 
     return (
       <Fragment>

--- a/src/pages/checkout.js
+++ b/src/pages/checkout.js
@@ -1,5 +1,6 @@
 import React, { Component, Fragment } from "react";
 import PropTypes from "prop-types";
+import { Router } from "routes";
 import { observer } from "mobx-react";
 import Helmet from "react-helmet";
 import { withStyles } from "@material-ui/core/styles";
@@ -99,13 +100,17 @@ class Checkout extends Component {
     loadMoreCartItems: PropTypes.func,
     onChangeCartItemsQuantity: PropTypes.func,
     onRemoveCartItems: PropTypes.func,
-    setEmailOnAnonymousCart: PropTypes.func,
     shop: PropTypes.shape({
       name: PropTypes.string.isRequired,
       description: PropTypes.string
     }),
     theme: PropTypes.object.isRequired
   };
+
+  static getDerivedStateFromProps({ cart }) {
+    if (cart.account === null && !cart.email) Router.pushRoute("login", "", { customProp: "please next" });
+    return null;
+  }
 
   // eslint-disable-next-line promise/avoid-new
   mockMutation = () =>
@@ -235,7 +240,12 @@ class Checkout extends Component {
                 </div>
               </Link>
               <div className={classes.checkoutTitleContainer}>
-                <LockIcon style={{ fontSize: 14, color: theme.palette.reaction.black35 }} />
+                <LockIcon
+                  style={{
+                    fontSize: 14,
+                    color: theme.palette.reaction.black35
+                  }}
+                />
                 <Typography className={classes.checkoutTitle}>Checkout</Typography>
               </div>
               <Link route="cart">

--- a/src/pages/checkout.js
+++ b/src/pages/checkout.js
@@ -10,6 +10,7 @@ import CheckoutEmailAddress from "@reactioncommerce/components/CheckoutEmailAddr
 import CheckoutTopHat from "@reactioncommerce/components/CheckoutTopHat/v1";
 import GuestForm from "@reactioncommerce/components/GuestForm/v1";
 import ShippingAddressCheckoutAction from "@reactioncommerce/components/ShippingAddressCheckoutAction/v1";
+import StripePaymentCheckoutAction from "@reactioncommerce/components/StripePaymentCheckoutAction/v1";
 import ShopLogo from "@reactioncommerce/components/ShopLogo/v1";
 import CartIcon from "mdi-material-ui/Cart";
 import LockIcon from "mdi-material-ui/Lock";
@@ -161,17 +162,24 @@ class Checkout extends Component {
       {
         label: "Shipping Information",
         component: ShippingAddressCheckoutAction,
-        onSubmit: this.mockMutation,
-        props: null
-      },
-      {
-        label: "Second Shipping Information",
-        component: ShippingAddressCheckoutAction,
+        status: "active",
         onSubmit: this.mockMutation,
         props: {
-          fulfillmentGroup: {
+          fulfillmentGroup: cart.checkout.fulfillmentGroups[0]
+        }
+      },
+      {
+        label: "Payment Information",
+        component: StripePaymentCheckoutAction,
+        status: "incomplete",
+        onSubmit: this.mockMutation,
+        props: {
+          payments: {
+            _id: 1,
+            name: "reactionstripe",
             data: {
-              shippingAddress: mockAddress
+              billingAddress: null,
+              displayName: null
             }
           }
         }

--- a/src/pages/login.js
+++ b/src/pages/login.js
@@ -14,26 +14,51 @@ import Link from "components/Link";
 
 import ChevronLeftIcon from "mdi-material-ui/ChevronLeft";
 
+const flexWrapper = () => ({
+  alignItems: "stretch",
+  display: "flex",
+  flexDirection: "column",
+  justifyContent: "flex-start"
+});
+
 const styles = (theme) => ({
-  // loginWrapper: {
-  //   maxWidth: "600px",
-  //   alignSelf: "flex-end",
-  //   [theme.breakpoints.up("md")]: {
-  //     paddingRight: "2rem"
-  //   }
-  // },
-  // guestWrapper: {
-  //   maxWidth: "400px",
-  //   alignSelf: "flex-start",
-  //   [theme.breakpoints.up("md")]: {
-  //     paddingRight: "2rem"
-  //   }
-  // },
-  main: {
-    flex: "1 1 auto",
-    maxWidth: theme.layout.mainContentMaxWidth,
-    margin: "0 auto",
-    padding: `0 ${theme.spacing.unit * 3}px`
+  loginWrapper: {
+    ...flexWrapper(theme),
+    paddingBottom: theme.spacing.unit * 8,
+    [theme.breakpoints.up("md")]: {
+      minHeight: "400px",
+      paddingBottom: 0,
+      paddingRight: theme.spacing.unit * 8
+    }
+  },
+  guestWrapper: {
+    ...flexWrapper(theme),
+    borderTop: `solid 1px ${theme.palette.reaction.black10}`,
+    paddingTop: theme.spacing.unit * 8,
+    [theme.breakpoints.up("md")]: {
+      borderLeft: `solid 1px ${theme.palette.reaction.black10}`,
+      borderTop: "none",
+      paddingLeft: theme.spacing.unit * 8,
+      paddingTop: 0
+    }
+  },
+  backLink: {
+    color: theme.palette.reaction.black80,
+    cursor: "pointer",
+    fontFamily: theme.typography.fontFamily,
+    fontSize: 14,
+    "&:hover": {
+      color: theme.palette.reaction.reactionBlue400
+    }
+  },
+  backLinkText: {
+    letterSpacing: "0.3px",
+    lineHeight: 1.71,
+    marginLeft: theme.spacing.unit,
+    textDecoration: "underline"
+  },
+  loginButton: {
+    marginTop: theme.spacing.unit * 3
   },
   headerCenter: {},
   headerFlex: {
@@ -48,24 +73,22 @@ const styles = (theme) => ({
     marginBottom: theme.spacing.unit * 3,
     padding: theme.spacing.unit * 3
   },
-  backLink: {
-    color: theme.palette.reaction.black80,
-    cursor: "pointer",
-    fontFamily: theme.typography.fontFamily,
-    fontSize: 14
-  },
-  backLinkText: {
-    letterSpacing: "0.3px",
-    lineHeight: 1.71,
-    marginLeft: theme.spacing.unit,
-    textDecoration: "underline"
-  },
-
   logo: {
     color: theme.palette.reaction.reactionBlue,
     margin: "auto",
     borderBottom: `solid 5px ${theme.palette.reaction.reactionBlue200}`
-  }
+  },
+  main: {
+    flex: "1 1 auto",
+    maxWidth: theme.layout.mainLoginMaxWidth,
+    minHeight: "calc(100vh - 135px)",
+    margin: "0 auto",
+    padding: `${theme.spacing.unit * 3}px ${theme.spacing.unit * 3}px 0`,
+    [theme.breakpoints.up("md")]: {
+      padding: `${theme.spacing.unit * 10}px ${theme.spacing.unit * 3}px 0`
+    }
+  },
+  root: {}
 });
 
 @withCart
@@ -93,13 +116,25 @@ export default class Login extends Component {
     Router.back();
   };
 
+  handleLoginClick = () => {
+    // TODO: Redirect to Auth solution
+    // eslint-disable-next-line
+    console.log("login buttton clicked!");
+  };
+
+  handleRegisterClick = () => {
+    // TODO: Redirect to Auth solution
+    // eslint-disable-next-line
+    console.log("register buttton clicked!");
+  };
+
   renderHeader() {
-    const { classes, shop, theme } = this.props;
+    const { classes, shop } = this.props;
     return (
       <div className={classes.header}>
         <div className={classes.headerFlex}>
           <Link className={classes.backLink} onClick={this.handleBackClick}>
-            <ChevronLeftIcon style={{ fontSize: 18, color: theme.palette.reaction.black80, verticalAlign: "sub" }} />
+            <ChevronLeftIcon style={{ fontSize: 18, color: "inherit", verticalAlign: "sub", transition: "none" }} />
             <span className={classes.backLinkText}>Back</span>
           </Link>
         </div>
@@ -118,19 +153,31 @@ export default class Login extends Component {
   renderCheckoutLogin() {
     const { classes, setEmailOnAnonymousCart } = this.props;
     return (
-      <Grid container spacing={24}>
+      <Grid container>
         <Grid item xs={12} md={7}>
-          <div className={classes.flexContainer}>
-            <div className={classes.loginWrapper}>
-              <Button onClick={() => Router.back()}>Back!</Button>
-            </div>
+          <div className={classes.loginWrapper}>
+            <Typography variant="title" gutterBottom>
+              Returning Customer
+            </Typography>
+            <Button onClick={this.handleLoginClick} actionType="important" isFullWidth className={classes.loginButton}>
+              Login
+            </Button>
+            <Button
+              onClick={this.handleRegisterClick}
+              actionType="secondary"
+              isFullWidth
+              className={classes.loginButton}
+            >
+              Create a new account
+            </Button>
           </div>
         </Grid>
         <Grid item xs={12} md={5}>
-          <div className={classes.flexContainer}>
-            <div className={classes.guestWrapper}>
-              <GuestForm onSubmit={setEmailOnAnonymousCart} />
-            </div>
+          <div className={classes.guestWrapper}>
+            <Typography variant="title" gutterBottom>
+              Guest Checkout
+            </Typography>
+            <GuestForm onSubmit={setEmailOnAnonymousCart} />
           </div>
         </Grid>
       </Grid>

--- a/src/pages/login.js
+++ b/src/pages/login.js
@@ -1,0 +1,151 @@
+import React, { Component, Fragment } from "react";
+import PropTypes from "prop-types";
+import { Router } from "routes";
+import Helmet from "react-helmet";
+import { withStyles } from "@material-ui/core/styles";
+import Typography from "@material-ui/core/Typography";
+import Grid from "@material-ui/core/Grid";
+import Button from "@reactioncommerce/components/Button/v1";
+import CheckoutTopHat from "@reactioncommerce/components/CheckoutTopHat/v1";
+import GuestForm from "@reactioncommerce/components/GuestForm/v1";
+import ShopLogo from "@reactioncommerce/components/ShopLogo/v1";
+import withCart from "containers/cart/withCart";
+import Link from "components/Link";
+
+import ChevronLeftIcon from "mdi-material-ui/ChevronLeft";
+
+const styles = (theme) => ({
+  // loginWrapper: {
+  //   maxWidth: "600px",
+  //   alignSelf: "flex-end",
+  //   [theme.breakpoints.up("md")]: {
+  //     paddingRight: "2rem"
+  //   }
+  // },
+  // guestWrapper: {
+  //   maxWidth: "400px",
+  //   alignSelf: "flex-start",
+  //   [theme.breakpoints.up("md")]: {
+  //     paddingRight: "2rem"
+  //   }
+  // },
+  main: {
+    flex: "1 1 auto",
+    maxWidth: theme.layout.mainContentMaxWidth,
+    margin: "0 auto",
+    padding: `0 ${theme.spacing.unit * 3}px`
+  },
+  headerCenter: {},
+  headerFlex: {
+    alignSelf: "center",
+    flex: "1 1 1%"
+  },
+  header: {
+    alignContent: "center",
+    borderBottom: `solid 1px ${theme.palette.reaction.black10}`,
+    display: "flex",
+    justifyContent: "center",
+    marginBottom: theme.spacing.unit * 3,
+    padding: theme.spacing.unit * 3
+  },
+  backLink: {
+    color: theme.palette.reaction.black80,
+    cursor: "pointer",
+    fontFamily: theme.typography.fontFamily,
+    fontSize: 14
+  },
+  backLinkText: {
+    letterSpacing: "0.3px",
+    lineHeight: 1.71,
+    marginLeft: theme.spacing.unit,
+    textDecoration: "underline"
+  },
+
+  logo: {
+    color: theme.palette.reaction.reactionBlue,
+    margin: "auto",
+    borderBottom: `solid 5px ${theme.palette.reaction.reactionBlue200}`
+  }
+});
+
+@withCart
+@withStyles(styles, { withTheme: true })
+export default class Login extends Component {
+  static propTypes = {
+    cart: PropTypes.shape({
+      account: PropTypes.object,
+      email: PropTypes.string
+    }),
+    classes: PropTypes.object,
+    setEmailOnAnonymousCart: PropTypes.func,
+    shop: PropTypes.shape({
+      name: PropTypes.string.isRequired,
+      description: PropTypes.string
+    })
+  };
+
+  handleBackClick = (event) => {
+    Router.back();
+  };
+
+  renderHeader() {
+    const { classes, shop, theme } = this.props;
+    return (
+      <div className={classes.header}>
+        <div className={classes.headerFlex}>
+          <Link className={classes.backLink} onClick={this.handleBackClick}>
+            <ChevronLeftIcon style={{ fontSize: 18, color: theme.palette.reaction.black80, verticalAlign: "sub" }} />
+            <span className={classes.backLinkText}>Back</span>
+          </Link>
+        </div>
+
+        <Link route="home">
+          <div className={classes.logo}>
+            <ShopLogo shopName={shop.name} />
+          </div>
+        </Link>
+
+        <div className={classes.headerFlex} />
+      </div>
+    );
+  }
+
+  renderCheckoutLogin() {
+    const { classes, setEmailOnAnonymousCart } = this.props;
+    return (
+      <Grid container spacing={24}>
+        <Grid item xs={12} md={7}>
+          <div className={classes.flexContainer}>
+            <div className={classes.loginWrapper}>
+              <Button onClick={() => Router.back()}>Back!</Button>
+            </div>
+          </div>
+        </Grid>
+        <Grid item xs={12} md={5}>
+          <div className={classes.flexContainer}>
+            <div className={classes.guestWrapper}>
+              <GuestForm onSubmit={setEmailOnAnonymousCart} />
+            </div>
+          </div>
+        </Grid>
+      </Grid>
+    );
+  }
+
+  render() {
+    const { classes, shop } = this.props;
+    return (
+      <Fragment>
+        <Helmet>
+          <title>{shop && shop.name} | Login</title>
+          <meta name="description" content={shop && shop.description} />
+        </Helmet>
+        <CheckoutTopHat checkoutMessage="Free Shipping + Free Returns" />
+        <div className={classes.root}>
+          {this.renderHeader()}
+          <main className={classes.main}>{this.renderCheckoutLogin()}</main>
+        </div>
+      </Fragment>
+    );
+  }
+}

--- a/src/pages/login.js
+++ b/src/pages/login.js
@@ -84,7 +84,12 @@ export default class Login extends Component {
     })
   };
 
-  handleBackClick = (event) => {
+  static getDerivedStateFromProps({ cart }) {
+    if (cart.account !== null || cart.email) Router.back();
+    return null;
+  }
+
+  handleBackClick = () => {
     Router.back();
   };
 

--- a/src/pages/login.js
+++ b/src/pages/login.js
@@ -43,10 +43,10 @@ const styles = (theme) => ({
     }
   },
   backLink: {
-    color: theme.palette.reaction.black80,
-    cursor: "pointer",
-    fontFamily: theme.typography.fontFamily,
-    fontSize: 14,
+    "color": theme.palette.reaction.black80,
+    "cursor": "pointer",
+    "fontFamily": theme.typography.fontFamily,
+    "fontSize": 14,
     "&:hover": {
       color: theme.palette.reaction.reactionBlue400
     }
@@ -104,7 +104,8 @@ export default class Login extends Component {
     shop: PropTypes.shape({
       name: PropTypes.string.isRequired,
       description: PropTypes.string
-    })
+    }),
+    theme: PropTypes.object.isRequired
   };
 
   static getDerivedStateFromProps({ cart }) {

--- a/src/routes.js
+++ b/src/routes.js
@@ -4,6 +4,7 @@ routes
   .add("home", "/", "index")
   .add("cart", "/cart", "cart")
   .add("checkout", "/cart/checkout", "checkout")
+  .add("login", "/login", "login")
   .add("shopProduct", "/shop/:shopSlug/product/:slugOrId", "product")
   .add("product", "/product/:slugOrId/:variantId?", "product")
   .add("shop", "/shop/:shopId/:tag", "index")

--- a/yarn.lock
+++ b/yarn.lock
@@ -969,9 +969,9 @@
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@reactioncommerce/components-context/-/components-context-1.0.0.tgz#587764cf0d1b0312c786b8e4657379de02e13845"
 
-"@reactioncommerce/components@0.23.1":
-  version "0.23.1"
-  resolved "https://registry.yarnpkg.com/@reactioncommerce/components/-/components-0.23.1.tgz#9b9d3ecfcbb73f68986f29904c71cb1e2290d5cc"
+"@reactioncommerce/components@0.29":
+  version "0.29.0"
+  resolved "https://registry.yarnpkg.com/@reactioncommerce/components/-/components-0.29.0.tgz#dfcc83791a66372d3524c7f61d6b641e859e8896"
   dependencies:
     "@material-ui/core" "^1.4.0"
     lodash.debounce "^4.0.8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -969,9 +969,9 @@
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@reactioncommerce/components-context/-/components-context-1.0.0.tgz#587764cf0d1b0312c786b8e4657379de02e13845"
 
-"@reactioncommerce/components@0.29":
-  version "0.29.0"
-  resolved "https://registry.yarnpkg.com/@reactioncommerce/components/-/components-0.29.0.tgz#dfcc83791a66372d3524c7f61d6b641e859e8896"
+"@reactioncommerce/components@0.30.3":
+  version "0.30.3"
+  resolved "https://registry.yarnpkg.com/@reactioncommerce/components/-/components-0.30.3.tgz#ded2306273d18e8a8e02ae4c6e486c54e23e1481"
   dependencies:
     "@material-ui/core" "^1.4.0"
     lodash.debounce "^4.0.8"


### PR DESCRIPTION
Resolves #225 
Impact: **minor**
Type: **feature**

## Solution
  *  Updated the `checkout` page to now show a "login/register/checkout as a guest" view if `cart.account === null || !cart.email`.
  *  Added the `setEmailOnAnonymousCart` mutation and created a handler for the `withCart` HOC.
  *  Added the `GuestForm` component to the login view of the `checkout` page that captures an users email address and sends it to the `setEmailOnAnonymousCart` mutation.
  * Added the `CheckoutEmailAddress` component to the `checkout` page  to display the guest/account email once it's avalible.
 * Updated cart `fragment` GQL query to include `fulfillmentGroups` and `payments` data.
 * Started adding new checkout actions to checkout page.

## Breaking changes
N/A

## Testing
### Continue as guest checkout.
1. In the storefront, as an anonymous user add a few items to your cart and click the "checkout" button.
2. When the checkout page loads you should see the "login" view with the `GuestForm`. 
4. Enter an email address and click the "Continue as guest" button.
3. The "checkout" view should now display with the newly added email address at the top of the `CheckoutActions`.
