### PR TITLE
Integrate shipping address action with GQL endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@material-ui/core": "^1.5.0",
-    "@reactioncommerce/components": "0.30.5",
+    "@reactioncommerce/components": "0.32.0",
     "@reactioncommerce/components-context": "^1.0.0",
     "@segment/snippet": "^4.3.1",
     "apollo-cache-inmemory": "^1.1.11",

--- a/src/components/CheckoutActions/CheckoutActions.js
+++ b/src/components/CheckoutActions/CheckoutActions.js
@@ -1,0 +1,97 @@
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+import { observer } from "mobx-react";
+import Actions from "@reactioncommerce/components/CheckoutActions/v1";
+import ShippingAddressCheckoutAction from "@reactioncommerce/components/ShippingAddressCheckoutAction/v1";
+import StripePaymentCheckoutAction from "@reactioncommerce/components/StripePaymentCheckoutAction/v1";
+import withCart from "containers/cart/withCart";
+import { isFulfillmentOptionSet, isPaymentMethodSet } from "lib/utils/cartUtils";
+
+// TODO: remove this mocked payment method
+const paymentMethods = [{
+  _id: 1,
+  name: "reactionstripe",
+  data: {
+    billingAddress: null,
+    displayName: null
+  }
+}];
+
+@withCart
+@observer
+export default class CheckoutActions extends Component {
+  static propTypes = {
+    cart: PropTypes.shape({
+      account: PropTypes.object,
+      checkout: PropTypes.object,
+      email: PropTypes.string,
+      items: PropTypes.array
+    }),
+    checkout: PropTypes.shape({
+      onSetFulfillmentOption: PropTypes.func.isRequired,
+      onSetShippingAddress: PropTypes.func.required
+    })
+  };
+
+  setShippingAddress = async (address) => {
+    const { checkout: { onSetShippingAddress } } = this.props;
+
+    // Omit firstName, lastName props as they are not in AddressInput type
+    // The address form and GraphQL endpoint need to be made consistent
+    const { firstName, lastName, ...rest } = address;
+    return onSetShippingAddress({
+      fullName: `${address.firstName} ${address.lastName}`,
+      ...rest
+    });
+  }
+
+  setPaymentMethod = (data) => {
+    const { billingAddress, token: { card } } = data;
+    const payment = {
+      billingAddress,
+      displayName: `${card.brand} ending in ${card.last4}`
+    };
+
+    // eslint-disable-next-line promise/avoid-new
+    return new Promise((resolve) => {
+      setTimeout(() => {
+        paymentMethods[0].data = payment;
+        // TODO: this.forceUpdate() will be removed once state is tracked by MobX
+        this.forceUpdate();
+        resolve(payment);
+      }, 1000, { payment });
+    });
+  }
+
+  render() {
+    const { checkout: { fulfillmentGroups } } = this.props.cart;
+    // console.log("props", this.props);
+
+    const shippingStatus = isFulfillmentOptionSet(fulfillmentGroups) ? "complete" : "incomplete";
+    const paymentStatus = isPaymentMethodSet(paymentMethods) ? "complete" : "incomplete";
+
+    const actions = [
+      {
+        label: "Shipping Information",
+        status: shippingStatus,
+        component: ShippingAddressCheckoutAction,
+        onSubmit: this.setShippingAddress,
+        props: {
+          fulfillmentGroup: shippingStatus === "complete" ? fulfillmentGroups[0] : null
+        }
+      },
+      {
+        label: "Payment Information",
+        status: paymentStatus,
+        component: StripePaymentCheckoutAction,
+        onSubmit: this.setPaymentMethod,
+        props: {
+          payment: paymentStatus === "complete" ? paymentMethods[0] : null
+        }
+      }
+    ];
+    return (
+      <Actions actions={actions} />
+    );
+  }
+}

--- a/src/components/CheckoutActions/index.js
+++ b/src/components/CheckoutActions/index.js
@@ -1,0 +1,1 @@
+export { default } from "./CheckoutActions";

--- a/src/containers/cart/fragments.gql
+++ b/src/containers/cart/fragments.gql
@@ -14,6 +14,7 @@ fragment CartCommon on Cart {
   checkout {
     fulfillmentGroups {
       _id
+      type
       data {
         shippingAddress {
           _id

--- a/src/containers/cart/mutations.gql
+++ b/src/containers/cart/mutations.gql
@@ -61,6 +61,24 @@ mutation setEmailOnAnonymousCartMutation($input: SetEmailOnAnonymousCartInput!) 
   }
 }
 
+# Set Fulfillment option for items in cart
+mutation setFulfillmentOptionCartMutation($input: SelectFulfillmentOptionForGroupInput!) {
+  selectFulfillmentOptionForGroup(input: $input) {
+    cart {
+      ...CartPayloadFragment
+    }
+  }
+}
+
+# Set shipping address on cart
+mutation setShippingAddressCartMutation($input: SetShippingAddressOnCartInput!) {
+  setShippingAddressOnCart(input: $input) {
+    cart {
+      ...CartPayloadFragment
+    }
+  }
+}
+
 # Update the quantities of items in the cart
 mutation updateCartItemsQuantityMutation($input: UpdateCartItemsQuantityInput!) {
   updateCartItemsQuantity(input: $input) {

--- a/src/containers/cart/withCart.js
+++ b/src/containers/cart/withCart.js
@@ -280,10 +280,10 @@ export default (Component) => (
      * @param {Function} mutation An Apollo mutation function
      * @return {undefined} No return
      */
-    handleSetShippingAddress = async (address) => {
+    handleSetShippingAddress = (address) => {
       const { cartStore, client: apolloClient } = this.props;
 
-      const { data } = await apolloClient.mutate({
+      return apolloClient.mutate({
         mutation: setShippingAddressCartMutation,
         variables: {
           input: {
@@ -293,19 +293,6 @@ export default (Component) => (
           }
         }
       });
-
-      // Set fulfillmentOption
-      console.log("response", data);
-
-      const fulfillmentGroup = data.setShippingAddressOnCart.cart.checkout.fulfillmentGroups[0];
-      // TODO: base64 encode and namespace _ids
-      const fulfillmentOption = {
-        fulfillmentGroupId: fulfillmentGroup._id,
-        fulfillmentMethodId: fulfillmentGroup.data.shippingAddress._id
-      };
-
-      console.log("option", fulfillmentOption);
-      this.handleSetFulfillmentOption(fulfillmentOption);
     }
 
     render() {

--- a/src/containers/cart/withCart.js
+++ b/src/containers/cart/withCart.js
@@ -10,6 +10,8 @@ import {
   removeCartItemsMutation,
   reconcileCartsMutation,
   setEmailOnAnonymousCartMutation,
+  setFulfillmentOptionCartMutation,
+  setShippingAddressCartMutation,
   updateCartItemsQuantityMutation
 } from "./mutations.gql";
 import {
@@ -226,10 +228,9 @@ export default (Component) => (
     }
 
     /**
-     *
      * @name handleSetEmailOnAnonymousCart
      * @summary Call when `setEmailOnAnonymousCart` callback is called
-     * @param {Funtion} mutation An Apollo mutation function
+     * @param {Function} mutation An Apollo mutation function
      * @param {string} email An email address to be set on an anonymous cart
      * @return {undefined} No return
      */
@@ -247,6 +248,65 @@ export default (Component) => (
       });
     }
 
+    /**
+     * @name handleSetFulfillmentOption
+     * @summary Sets a fulfillment method for items in a cart
+     * @param {Object} fulfillmentOption - an object with the following props:
+     * cartId, cartToken, fulfillmentGroupId, fulfillmentMethodId
+     * @param {Function} mutation An Apollo mutation function
+     * @return {undefined} No return
+     */
+    handleSetFulfillmentOption = ({ fulfillmentGroupId, fulfillmentMethodId }) => {
+      const { cartStore, client: apolloClient } = this.props;
+
+      apolloClient.mutate({
+        mutation: setFulfillmentOptionCartMutation,
+        variables: {
+          input: {
+            cartId: cartStore.anonymousCartId,
+            cartToken: cartStore.anonymousCartToken,
+            fulfillmentGroupId,
+            fulfillmentMethodId
+          }
+        }
+      });
+    }
+
+    /**
+     * @name handleSetShippingAddress
+     * @summary Sets the shipping address for the cart
+     * @param {Object} address - an object with the following props:
+     *  address, addressId(optional), cartId, cartToken
+     * @param {Function} mutation An Apollo mutation function
+     * @return {undefined} No return
+     */
+    handleSetShippingAddress = async (address) => {
+      const { cartStore, client: apolloClient } = this.props;
+
+      const { data } = await apolloClient.mutate({
+        mutation: setShippingAddressCartMutation,
+        variables: {
+          input: {
+            cartId: cartStore.anonymousCartId,
+            cartToken: cartStore.anonymousCartToken,
+            address
+          }
+        }
+      });
+
+      // Set fulfillmentOption
+      console.log("response", data);
+
+      const fulfillmentGroup = data.setShippingAddressOnCart.cart.checkout.fulfillmentGroups[0];
+      // TODO: base64 encode and namespace _ids
+      const fulfillmentOption = {
+        fulfillmentGroupId: fulfillmentGroup._id,
+        fulfillmentMethodId: fulfillmentGroup.data.shippingAddress._id
+      };
+
+      console.log("option", fulfillmentOption);
+      this.handleSetFulfillmentOption(fulfillmentOption);
+    }
 
     render() {
       const { authStore, cartStore, shop } = this.props;
@@ -361,6 +421,10 @@ export default (Component) => (
                       });
                     }}
                     setEmailOnAnonymousCart={this.handleSetEmailOnAnonymousCart}
+                    checkout={{
+                      onSetFulfillmentOption: this.handleSetFulfillmentOption,
+                      onSetShippingAddress: this.handleSetShippingAddress
+                    }}
                     cart={processedCartData}
                   />
                 )}

--- a/src/lib/utils/cartUtils.js
+++ b/src/lib/utils/cartUtils.js
@@ -1,0 +1,28 @@
+/**
+ * Determines if at least one fulfillment method has been set for the
+ * provided fulfillment groups.
+ *
+ * @param {Array} fulfillmentGroups - An array of available fulfillment groups
+ * @returns {Boolean} - true if at least one fulfillment method has been set,
+ * false otherwise.
+ */
+export function isFulfillmentOptionSet(fulfillmentGroups) {
+  const groupWithoutAddress = fulfillmentGroups.find((group) => {
+    const shippingGroup = group.type === "shipping";
+    return shippingGroup && group.data.shippingAddress;
+  });
+
+  return groupWithoutAddress;
+}
+
+/**
+ * Determines if at least one payment method has been selected by the user
+ *
+ * @param {Array} paymentMethods - An array of available and active payment methods
+ * @returns {Boolean} true if a payment method has been selected, false otherwise.
+ */
+export function isPaymentMethodSet(paymentMethods) {
+  const setPaymentMethod = paymentMethods.find((payment) => payment.data.displayName);
+
+  return setPaymentMethod;
+}

--- a/src/lib/utils/cartUtils.js
+++ b/src/lib/utils/cartUtils.js
@@ -26,3 +26,26 @@ export function isPaymentMethodSet(paymentMethods) {
 
   return setPaymentMethod;
 }
+
+/**
+ * Filters an address object so that it only contain props that have a corresponding form field.
+ *
+ * @param {Object} address - a shipping address object
+ * @returns {Object} The filtered shipping address object
+ */
+export function adaptAddressToFormFields(address) {
+  const { fullName, address1, address2, city, country, phone, postal, region } = address;
+  const [firstName, lastName] = fullName.split(" ");
+
+  return {
+    address1,
+    address2,
+    city,
+    country,
+    firstName,
+    lastName,
+    phone,
+    postal,
+    region
+  };
+}

--- a/src/pages/checkout.js
+++ b/src/pages/checkout.js
@@ -6,11 +6,9 @@ import Helmet from "react-helmet";
 import { withStyles } from "@material-ui/core/styles";
 import Typography from "@material-ui/core/Typography";
 import Grid from "@material-ui/core/Grid";
-import CheckoutActions from "@reactioncommerce/components/CheckoutActions/v1";
+import CheckoutActions from "components/CheckoutActions";
 import CheckoutEmailAddress from "@reactioncommerce/components/CheckoutEmailAddress/v1";
 import CheckoutTopHat from "@reactioncommerce/components/CheckoutTopHat/v1";
-import ShippingAddressCheckoutAction from "@reactioncommerce/components/ShippingAddressCheckoutAction/v1";
-import StripePaymentCheckoutAction from "@reactioncommerce/components/StripePaymentCheckoutAction/v1";
 import ShopLogo from "@reactioncommerce/components/ShopLogo/v1";
 import CartIcon from "mdi-material-ui/Cart";
 import LockIcon from "mdi-material-ui/Lock";
@@ -72,52 +70,6 @@ const styles = (theme) => ({
   }
 });
 
-const fulfillmentGroups = [{
-  _id: 1,
-  type: "shipping",
-  data: {
-    shippingAddress: null
-  }
-}];
-
-const paymentMethods = [{
-  _id: 1,
-  name: "reactionstripe",
-  data: {
-    billingAddress: null,
-    displayName: null
-  }
-}];
-
-/**
- * Determines if a shipping method has been set for the "Shipping Information"
- * checkout action. The return value of either complete or incomplete will
- * be used to render status of the checkout action.
- *
- * @returns {String} complete or incomplete
- */
-function getShippingStatus() {
-  const groupWithoutAddress = fulfillmentGroups.find((group) => {
-    const shippingGroup = group.type === "shipping";
-    return shippingGroup && !group.data.shippingAddress;
-  });
-
-  return (groupWithoutAddress) ? "incomplete" : "complete";
-}
-
-/**
- * Determines if a payment method has been set for the "Payment Information"
- * checkout action. The return value of either complete or incomplete will
- * be used to render status of the checkout action.
- *
- * @returns {String} complete or incomplete
- */
-function getPaymentStatus() {
-  const paymentWithoutData = paymentMethods.find((payment) => !payment.data.displayName);
-
-  return (paymentWithoutData) ? "incomplete" : "complete";
-}
-
 @withCart
 @observer
 @withStyles(styles, { withTheme: true })
@@ -148,35 +100,6 @@ class Checkout extends Component {
 
   state = {}
 
-  setShippingAddress = (data) =>
-    // eslint-disable-next-line promise/avoid-new
-    new Promise((resolve) => {
-      setTimeout(() => {
-        fulfillmentGroups[0].data.shippingAddress = data;
-        // TODO: this.forceUpdate() will be removed once state is tracked by MobX
-        this.forceUpdate();
-        resolve(data);
-      }, 1000, { data });
-    })
-
-
-  setPaymentMethod = (data) => {
-    const { billingAddress, token: { card } } = data;
-    const payment = {
-      billingAddress,
-      displayName: `${card.brand} ending in ${card.last4}`
-    };
-
-    // eslint-disable-next-line promise/avoid-new
-    return new Promise((resolve) => {
-      setTimeout(() => {
-        paymentMethods[0].data = payment;
-        // TODO: this.forceUpdate() will be removed once state is tracked by MobX
-        this.forceUpdate();
-        resolve(payment);
-      }, 1000, { payment });
-    });
-  }
 
   renderCheckout() {
     const {
@@ -189,27 +112,6 @@ class Checkout extends Component {
     } = this.props;
 
     if (!cart) return null;
-
-    const actions = [
-      {
-        label: "Shipping Information",
-        status: getShippingStatus(),
-        component: ShippingAddressCheckoutAction,
-        onSubmit: this.setShippingAddress,
-        props: {
-          fulfillmentGroup: fulfillmentGroups[0]
-        }
-      },
-      {
-        label: "Payment Information",
-        status: getPaymentStatus(),
-        component: StripePaymentCheckoutAction,
-        onSubmit: this.setPaymentMethod,
-        props: {
-          payment: paymentMethods[0]
-        }
-      }
-    ];
 
     const hasAccount = !!cart.account;
     const displayEmail = hasAccount ? cart.account.emailRecords[0].address : cart.email;
@@ -224,7 +126,7 @@ class Checkout extends Component {
                   <CheckoutEmailAddress emailAddress={displayEmail} isAccountEmail={hasAccount} />
                   : null
               }
-              <CheckoutActions actions={actions} />
+              <CheckoutActions />
             </div>
           </div>
         </Grid>

--- a/yarn.lock
+++ b/yarn.lock
@@ -969,9 +969,9 @@
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@reactioncommerce/components-context/-/components-context-1.0.0.tgz#587764cf0d1b0312c786b8e4657379de02e13845"
 
-"@reactioncommerce/components@0.30.5":
-  version "0.30.5"
-  resolved "https://registry.yarnpkg.com/@reactioncommerce/components/-/components-0.30.5.tgz#d802423b53088a8cd2f180de3789d8a6e6c3f4d1"
+"@reactioncommerce/components@0.32.0":
+  version "0.32.0"
+  resolved "https://registry.yarnpkg.com/@reactioncommerce/components/-/components-0.32.0.tgz#177eae435a15721957a1cde35cb9b9ff136764a4"
   dependencies:
     "@material-ui/core" "^1.4.0"
     lodash.debounce "^4.0.8"


### PR DESCRIPTION
Resolves #250 
Impact: major
Type: feature

## Summary
Integrates the `ShippingInformationCheckoutAction` with it's corresponding GraphQL endpoint.

## Testing
1. Add an item to the shopping cart
2. Click on "Checkout" in the MiniCart 
3. Enter a shipping address
4. Click Save and Continue
5. Verify address was saved correctly
6. Click on "change" next to the shipping address
7. Make a change and click on "Save and Continue"
8. Verify address was updated.