### PR TITLE
chore: updated snyk ignore file

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -5,9 +5,13 @@ ignore:
   'npm:braces:20180219':
     - '*':
         reason: Waiting for Next.js 6 to update to Babel 7 beta.47 (https://github.com/babel/babel/issues/8034)
-        expires: 2018-08-30T00:00:00.000Z
+        expires: 2018-09-30T00:00:00.000Z
   'npm:chownr:20180731':
     - '*':
         reason: Waiting on next-routes(https://github.com/fridays/next-routes) to fix this vulnerability
-        expires: 2018-08-30T00:00:00.000Z
+        expires: 2018-09-30T00:00:00.000Z
+  'npm:mem:20180117':
+    - '*':
+        reason: Waiting on next-routes(https://github.com/fridays/next-routes) to fix this vulnerability
+        expires: 2018-09-30T00:00:00.000Z
 patch: {}


### PR DESCRIPTION
Resolves N/A
Impact: **minor**
Type: **chore**

## Issue
Getting snyk warnings for out of date dep in CI.

## Solution
Update the .snyk ignore file since [next-routes](https://github.com/fridays/next-routes) & [nextjs](https://github.com/zeit/next.js) haven't updated.

## Testing
1. run `yarn install` followed by `synk test` to verify no security warnings. 
