### PR TITLE
fix: checkout empty state

### DIFF
--- a/src/components/CheckoutSummary/CheckoutSummary.js
+++ b/src/components/CheckoutSummary/CheckoutSummary.js
@@ -55,6 +55,7 @@ class CheckoutSummary extends Component {
         <Grid item xs={12}>
           <CartItems
             isMiniCart
+            isReadOnly
             hasMoreCartItems={hasMoreCartItems}
             onLoadMoreCartItems={loadMoreCartItems}
             items={cart.items}

--- a/src/components/CheckoutSummary/__snapshots__/CheckoutSummary.test.js.snap
+++ b/src/components/CheckoutSummary/__snapshots__/CheckoutSummary.test.js.snap
@@ -82,6 +82,12 @@ exports[`basic snapshot 1`] = `
                          
                         Medium
                       </p>
+                      <p
+                        className="CartItemDetail__Text-iQjjVf jxAYVa"
+                      >
+                        Quantity: 
+                        2
+                      </p>
                     </div>
                   </div>
                   <div
@@ -92,131 +98,7 @@ exports[`basic snapshot 1`] = `
                      in stock
                   </div>
                 </div>
-                <div
-                  className="CartItem__ItemContentQuantityInput-ifRgcr jiBlxW"
-                >
-                  <div
-                    aria-describedby={undefined}
-                    className="MuiFormControl-root-4"
-                  >
-                    <div
-                      className="MuiInput-root-8 QuantityInput-quantityContainer-2 MuiInput-formControl-9"
-                    >
-                      <div
-                        className="MuiInputAdornment-root-21"
-                      >
-                        <button
-                          className="MuiButtonBase-root-24 QuantityInput-incrementButton-1"
-                          color="default"
-                          disabled={undefined}
-                          onBlur={[Function]}
-                          onClick={[Function]}
-                          onFocus={[Function]}
-                          onKeyDown={[Function]}
-                          onKeyUp={[Function]}
-                          onMouseDown={[Function]}
-                          onMouseLeave={[Function]}
-                          onMouseUp={[Function]}
-                          onTouchEnd={[Function]}
-                          onTouchMove={[Function]}
-                          onTouchStart={[Function]}
-                          tabIndex="0"
-                          type="button"
-                          variant="outlined"
-                        >
-                          <svg
-                            aria-hidden="true"
-                            className="MuiSvgIcon-root-99"
-                            color={undefined}
-                            focusable="false"
-                            style={
-                              Object {
-                                "fontSize": "14px",
-                              }
-                            }
-                            viewBox="0 0 24 24"
-                          >
-                            <g>
-                              <path
-                                d="M19,13H5V11H19V13Z"
-                              />
-                            </g>
-                          </svg>
-                        </button>
-                      </div>
-                      <input
-                        aria-invalid={false}
-                        autoComplete={undefined}
-                        autoFocus={undefined}
-                        className="MuiInput-input-16 QuantityInput-quantityInput-3"
-                        defaultValue={undefined}
-                        disabled={false}
-                        id="addToCartQuantityInput"
-                        name={undefined}
-                        onBlur={[Function]}
-                        onChange={[Function]}
-                        onFocus={[Function]}
-                        onKeyDown={undefined}
-                        onKeyUp={undefined}
-                        placeholder={undefined}
-                        readOnly={undefined}
-                        required={undefined}
-                        rows={undefined}
-                        type="text"
-                        value={2}
-                      />
-                      <div
-                        className="MuiInputAdornment-root-21"
-                      >
-                        <button
-                          className="MuiButtonBase-root-24 QuantityInput-incrementButton-1"
-                          color="default"
-                          disabled={undefined}
-                          onBlur={[Function]}
-                          onClick={[Function]}
-                          onFocus={[Function]}
-                          onKeyDown={[Function]}
-                          onKeyUp={[Function]}
-                          onMouseDown={[Function]}
-                          onMouseLeave={[Function]}
-                          onMouseUp={[Function]}
-                          onTouchEnd={[Function]}
-                          onTouchMove={[Function]}
-                          onTouchStart={[Function]}
-                          tabIndex="0"
-                          type="button"
-                          variant="outlined"
-                        >
-                          <svg
-                            aria-hidden="true"
-                            className="MuiSvgIcon-root-99"
-                            color={undefined}
-                            focusable="false"
-                            style={
-                              Object {
-                                "fontSize": "14px",
-                              }
-                            }
-                            viewBox="0 0 24 24"
-                          >
-                            <g>
-                              <path
-                                d="M19,13H13V19H11V13H5V11H11V5H13V11H19V13Z"
-                              />
-                            </g>
-                          </svg>
-                        </button>
-                      </div>
-                    </div>
-                  </div>
-                </div>
               </div>
-              <button
-                className="CartItem__ItemRemoveButton-lnwubi glyIsk"
-                onClick={[Function]}
-              >
-                Remove
-              </button>
             </div>
             <div
               className="CartItem__ItemContentPrice-lcfJQP eaPRuH"
@@ -308,134 +190,16 @@ exports[`basic snapshot 1`] = `
                          
                         10
                       </p>
-                    </div>
-                  </div>
-                </div>
-                <div
-                  className="CartItem__ItemContentQuantityInput-ifRgcr jiBlxW"
-                >
-                  <div
-                    aria-describedby={undefined}
-                    className="MuiFormControl-root-4"
-                  >
-                    <div
-                      className="MuiInput-root-8 QuantityInput-quantityContainer-2 MuiInput-formControl-9"
-                    >
-                      <div
-                        className="MuiInputAdornment-root-21"
+                      <p
+                        className="CartItemDetail__Text-iQjjVf jxAYVa"
                       >
-                        <button
-                          className="MuiButtonBase-root-24 QuantityInput-incrementButton-1"
-                          color="default"
-                          disabled={undefined}
-                          onBlur={[Function]}
-                          onClick={[Function]}
-                          onFocus={[Function]}
-                          onKeyDown={[Function]}
-                          onKeyUp={[Function]}
-                          onMouseDown={[Function]}
-                          onMouseLeave={[Function]}
-                          onMouseUp={[Function]}
-                          onTouchEnd={[Function]}
-                          onTouchMove={[Function]}
-                          onTouchStart={[Function]}
-                          tabIndex="0"
-                          type="button"
-                          variant="outlined"
-                        >
-                          <svg
-                            aria-hidden="true"
-                            className="MuiSvgIcon-root-99"
-                            color={undefined}
-                            focusable="false"
-                            style={
-                              Object {
-                                "fontSize": "14px",
-                              }
-                            }
-                            viewBox="0 0 24 24"
-                          >
-                            <g>
-                              <path
-                                d="M19,13H5V11H19V13Z"
-                              />
-                            </g>
-                          </svg>
-                        </button>
-                      </div>
-                      <input
-                        aria-invalid={false}
-                        autoComplete={undefined}
-                        autoFocus={undefined}
-                        className="MuiInput-input-16 QuantityInput-quantityInput-3"
-                        defaultValue={undefined}
-                        disabled={false}
-                        id="addToCartQuantityInput"
-                        name={undefined}
-                        onBlur={[Function]}
-                        onChange={[Function]}
-                        onFocus={[Function]}
-                        onKeyDown={undefined}
-                        onKeyUp={undefined}
-                        placeholder={undefined}
-                        readOnly={undefined}
-                        required={undefined}
-                        rows={undefined}
-                        type="text"
-                        value={1}
-                      />
-                      <div
-                        className="MuiInputAdornment-root-21"
-                      >
-                        <button
-                          className="MuiButtonBase-root-24 QuantityInput-incrementButton-1"
-                          color="default"
-                          disabled={undefined}
-                          onBlur={[Function]}
-                          onClick={[Function]}
-                          onFocus={[Function]}
-                          onKeyDown={[Function]}
-                          onKeyUp={[Function]}
-                          onMouseDown={[Function]}
-                          onMouseLeave={[Function]}
-                          onMouseUp={[Function]}
-                          onTouchEnd={[Function]}
-                          onTouchMove={[Function]}
-                          onTouchStart={[Function]}
-                          tabIndex="0"
-                          type="button"
-                          variant="outlined"
-                        >
-                          <svg
-                            aria-hidden="true"
-                            className="MuiSvgIcon-root-99"
-                            color={undefined}
-                            focusable="false"
-                            style={
-                              Object {
-                                "fontSize": "14px",
-                              }
-                            }
-                            viewBox="0 0 24 24"
-                          >
-                            <g>
-                              <path
-                                d="M19,13H13V19H11V13H5V11H11V5H13V11H19V13Z"
-                              />
-                            </g>
-                          </svg>
-                        </button>
-                      </div>
+                        Quantity: 
+                        1
+                      </p>
                     </div>
                   </div>
                 </div>
               </div>
-              <button
-                className="CartItem__ItemRemoveButton-lnwubi glyIsk"
-                onClick={[Function]}
-              >
-                Remove
-              </button>
             </div>
             <div
               className="CartItem__ItemContentPrice-lcfJQP eaPRuH"

--- a/src/containers/cart/withCart.js
+++ b/src/containers/cart/withCart.js
@@ -358,7 +358,7 @@ export default (Component) => (
                 {(mutationFunction) => (
                   <Component
                     {...this.props}
-                    isLoading={isLoading}
+                    isLoading={skipQuery ? false : isLoading}
                     hasMoreCartItems={(pageInfo && pageInfo.hasNextPage) || false}
                     onChangeCartItemsQuantity={this.handleChangeCartItemsQuantity}
                     onRemoveCartItems={this.handleRemoveCartItems}

--- a/src/containers/cart/withCart.js
+++ b/src/containers/cart/withCart.js
@@ -316,7 +316,7 @@ export default (Component) => (
 
       return (
         <Query query={query} variables={variables} skip={skipQuery}>
-          {({ data: cartData, fetchMore, refetch: refetchCart }) => {
+          {({ loading: isLoading, data: cartData, fetchMore, refetch: refetchCart }) => {
             const { cart } = cartData || {};
             const { pageInfo } = (cart && cart.items) || {};
 
@@ -358,6 +358,7 @@ export default (Component) => (
                 {(mutationFunction) => (
                   <Component
                     {...this.props}
+                    isLoading={isLoading}
                     hasMoreCartItems={(pageInfo && pageInfo.hasNextPage) || false}
                     onChangeCartItemsQuantity={this.handleChangeCartItemsQuantity}
                     onRemoveCartItems={this.handleRemoveCartItems}

--- a/src/pages/checkout.js
+++ b/src/pages/checkout.js
@@ -6,6 +6,7 @@ import Helmet from "react-helmet";
 import { withStyles } from "@material-ui/core/styles";
 import Typography from "@material-ui/core/Typography";
 import Grid from "@material-ui/core/Grid";
+import CartEmptyMessage from "@reactioncommerce/components/CartEmptyMessage/v1";
 import CheckoutActions from "components/CheckoutActions";
 import CheckoutEmailAddress from "@reactioncommerce/components/CheckoutEmailAddress/v1";
 import CheckoutTopHat from "@reactioncommerce/components/CheckoutTopHat/v1";
@@ -63,6 +64,18 @@ const styles = (theme) => ({
     justifyContent: "space-between",
     marginBottom: "2rem"
   },
+  emptyCartContainer: {
+    display: "flex",
+    justifyContent: "center",
+    alignItems: "center"
+  },
+  emptyCart: {
+    display: "flex",
+    justifyContent: "center",
+    alignItems: "center",
+    width: 320,
+    height: 320
+  },
   logo: {
     color: theme.palette.reaction.reactionBlue,
     marginRight: theme.spacing.unit,
@@ -100,18 +113,32 @@ class Checkout extends Component {
 
   state = {}
 
+  handleCartEmptyClick = () => Router.pushRoute("/")
 
   renderCheckout() {
     const {
       classes,
       cart,
       hasMoreCartItems,
+      isLoading,
       loadMoreCartItems,
       onRemoveCartItems,
       onChangeCartItemsQuantity
     } = this.props;
 
-    if (!cart) return null;
+    if (isLoading) return null;
+
+    if (!cart || (cart && Array.isArray(cart.items) && cart.items.length === 0)) {
+      return (
+        <div className={classes.emptyCartContainer}>
+          <div className={classes.emptyCart}>
+            <div>
+              <CartEmptyMessage onClick={this.handleCartEmptyClick} />
+            </div>
+          </div>
+        </div>
+      );
+    }
 
     const hasAccount = !!cart.account;
     const displayEmail = hasAccount ? cart.account.emailRecords[0].address : cart.email;

--- a/src/pages/checkout.js
+++ b/src/pages/checkout.js
@@ -96,6 +96,7 @@ class Checkout extends Component {
     }),
     classes: PropTypes.object,
     hasMoreCartItems: PropTypes.bool,
+    isLoading: PropTypes.bool,
     loadMoreCartItems: PropTypes.func,
     onChangeCartItemsQuantity: PropTypes.func,
     onRemoveCartItems: PropTypes.func,


### PR DESCRIPTION
Resolves #238
Impact: **minor**
Type: **bugfix**

## Issue

Removing the last cart item on the checkout page leaves you with a visually broken and in an in a state where you have no option but to go back

## Solution

1. Add a cart empty message when there aren't any items in the cart to checkout with.
2. Make cart items read only in checkout so the quantity can no longer be modified at the time of checkout

## Breaking changes

none

## Testing

1. With the starter kit and using reaction `release-1.16.0` running...
1. Ensure you have no cart items
1. Navigate to http://localhost:4000/checkout
1. See the cart empty message
1. Click on the `Continue shopping` button to be redirected to the homepage
