### PR TITLE
feat: integrate stripe payment checkout action

### DIFF
--- a/src/lib/stores/CartStore.js
+++ b/src/lib/stores/CartStore.js
@@ -38,10 +38,10 @@ class CartStore {
   @observable isReconcilingCarts = false;
 
   /**
- * The Stripe token that stores encrypted user payment data
- *
- * @type Object
- */
+   * The Stripe token that stores encrypted user payment data
+   *
+   * @type Object
+   */
   @observable stripeToken = null;
 
   /**

--- a/src/lib/stores/CartStore.js
+++ b/src/lib/stores/CartStore.js
@@ -38,6 +38,13 @@ class CartStore {
   @observable isReconcilingCarts = false;
 
   /**
+ * The Stripe token that stores encrypted user payment data
+ *
+ * @type Object
+ */
+  @observable stripeToken = null;
+
+  /**
    * @name setAnonymousCartCredentials
    * @summary Set anonymousCartID and anonymousCartToken to local storage and cookies
    * @param {String} anonymousCartId Cart Id from "createCart" mutation
@@ -115,6 +122,14 @@ class CartStore {
 
   @action setAccountCartId(value) {
     this.accountCartId = value;
+  }
+
+  get stripeToken() {
+    return this.stripeToken;
+  }
+
+  @action setStripeToken(value) {
+    this.stripeToken = value;
   }
 }
 

--- a/src/lib/utils/cartUtils.js
+++ b/src/lib/utils/cartUtils.js
@@ -15,18 +15,6 @@ export function isShippingAddressSet(fulfillmentGroups) {
 }
 
 /**
- * Determines if at least one payment method has been selected by the user
- *
- * @param {Array} paymentMethods - An array of available and active payment methods
- * @returns {Boolean} true if a payment method has been selected, false otherwise.
- */
-export function isPaymentMethodSet(paymentMethods) {
-  const setPaymentMethod = paymentMethods.find((payment) => payment.data.displayName);
-
-  return setPaymentMethod;
-}
-
-/**
  * Filters an address object so that it only contain props that have a corresponding form field.
  *
  * @param {Object} address - a shipping address object


### PR DESCRIPTION
Resolves #266 
Impact: Minor
Type: feature

## Summary
Integrates the `StripePaymentCheckoutAction` with MobX, the stripe token + billing address is stored in the `CartStore` for use with the review order checkout action.

## Testing
NOTE: To see the user data, add a console log in the checkout page's render method to output the `paymentData` values.

1. Add item to cart,
2. Fill out steps 1-2 in the checkout page
3. Enter 4111 1111 1111 1111 for the credit card number + any valid data + CVC
4. Enter a billing address
5. click "Save and Continue"
6. Verify payment data was outputted in the browser's console.  