### PR TITLE
Checkout complete page

### DIFF
--- a/src/components/OrderFulfillmentGroup/OrderFulfillmentGroup.js
+++ b/src/components/OrderFulfillmentGroup/OrderFulfillmentGroup.js
@@ -29,7 +29,9 @@ class OrderFulfillmentGroup extends Component {
   static propTypes = {
     classes: PropTypes.object,
     fulfillmentGroup: PropTypes.shape({
-      items: PropTypes.arrayOf(PropTypes.object),
+      items: PropTypes.shape({
+        nodes: PropTypes.arrayOf(PropTypes.object)
+      }),
       data: PropTypes.shape({
         shippingAddress: PropTypes.object
       })

--- a/src/components/OrderFulfillmentGroup/OrderFulfillmentGroup.js
+++ b/src/components/OrderFulfillmentGroup/OrderFulfillmentGroup.js
@@ -13,6 +13,12 @@ const styles = (theme) => ({
   fulfillmentDetails: {
     padding: theme.spacing.unit * 2
   },
+  header: {
+    padding: `${theme.spacing.unit}px ${theme.spacing.unit * 2}px`
+  },
+  headerRightColumn: {
+    textAlign: "right"
+  },
   summary: {
     paddingTop: theme.spacing.unit * 2
   }
@@ -123,10 +129,20 @@ class OrderFulfillmentGroup extends Component {
 
   render() {
     const { classes, fulfillmentGroup } = this.props;
-
+    const { fulfillmentMethod } = fulfillmentGroup.selectedFulfillmentOption;
     return (
       <Fragment>
         <section className={classes.fulfillmentGroup}>
+          <header className={classes.header}>
+            <Grid container spacing={24}>
+              <Grid item xs={6}>
+                <Typography variant="subheading">{fulfillmentMethod.displayName}</Typography>
+              </Grid>
+              <Grid item xs={6} className={classes.headerRightColumn}>
+                <Typography variant="body2">{fulfillmentMethod.group}</Typography>
+              </Grid>
+            </Grid>
+          </header>
           {this.renderItems()}
           {this.renderFulfillmentInfo()}
         </section>

--- a/src/components/OrderFulfillmentGroup/OrderFulfillmentGroup.js
+++ b/src/components/OrderFulfillmentGroup/OrderFulfillmentGroup.js
@@ -1,0 +1,109 @@
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+import Grid from "@material-ui/core/Grid";
+import CheckoutActionComplete from "@reactioncommerce/components/CheckoutActionComplete/v1";
+import ShippingAddressCheckoutAction from "@reactioncommerce/components/ShippingAddressCheckoutAction/v1";
+import CartItems from "components/CartItems";
+
+class OrderFulfillmentGroup extends Component {
+  static propTypes = {
+    cart: PropTypes.shape({
+      items: PropTypes.arrayOf(PropTypes.object),
+      checkout: PropTypes.shape({
+        itemTotal: PropTypes.shape({
+          displayAmount: PropTypes.string
+        }),
+        taxTotal: PropTypes.shape({
+          displayAmount: PropTypes.string
+        })
+      })
+    }),
+    classes: PropTypes.object,
+    fulfillmentGroup: PropTypes.object,
+    hasMoreCartItems: PropTypes.bool,
+    loadMoreCartItems: PropTypes.func,
+    onChangeCartItemsQuantity: PropTypes.func,
+    onRemoveCartItems: PropTypes.func,
+    shop: PropTypes.shape({
+      name: PropTypes.string.isRequired,
+      description: PropTypes.string
+    })
+  }
+
+  static defaultProps = {
+    hasMoreCartItems: false,
+    loadMoreCartItems() {},
+    onChangeCartItemsQuantity() {},
+    onRemoveCartItems() {}
+  }
+
+  handleItemQuantityChange = (quantity, cartItemId) => {
+    const { onChangeCartItemsQuantity } = this.props;
+
+    onChangeCartItemsQuantity({ quantity, cartItemId });
+  }
+
+  handleRemoveItem = (_id) => {
+    const { onRemoveCartItems } = this.props;
+
+    onRemoveCartItems(_id);
+  }
+
+  renderItems() {
+    const { cart, hasMoreCartItems, loadMoreCartItems } = this.props;
+
+    if (cart && Array.isArray(cart.items)) {
+      return (
+        <Grid item xs={12}>
+          <CartItems
+            isMiniCart
+            isReadOnly
+            hasMoreCartItems={hasMoreCartItems}
+            onLoadMoreCartItems={loadMoreCartItems}
+            items={cart.items}
+            onChangeCartItemQuantity={this.handleItemQuantityChange}
+            onRemoveItemFromCart={this.handleRemoveItem}
+          />
+        </Grid>
+      );
+    }
+
+    return null;
+  }
+
+  renderFulfillmentInfo() {
+    const { cart, fulfillmentGroup } = this.props;
+
+    if (cart && cart.checkout && cart.checkout.summary) {
+      let address;
+
+      if (cart.checkout && cart.checkout.fulfillmentGroup) {
+        address = ShippingAddressCheckoutAction.renderComplete({ fulfillmentGroup });
+      }
+
+      return (
+        <Grid item xs={12}>
+          <CheckoutActionComplete
+            content={address}
+            label="Shipping Address"
+          />
+        </Grid>
+      );
+    }
+
+    return null;
+  }
+
+  render() {
+    return (
+      <aside>
+        <Grid container spacing={24}>
+          {this.renderItems()}
+          {this.renderFulfillmentInfo()}
+        </Grid>
+      </aside>
+    );
+  }
+}
+
+export default OrderFulfillmentGroup;

--- a/src/components/OrderFulfillmentGroup/OrderFulfillmentGroup.js
+++ b/src/components/OrderFulfillmentGroup/OrderFulfillmentGroup.js
@@ -17,19 +17,13 @@ const styles = (theme) => ({
 @withStyles(styles)
 class OrderFulfillmentGroup extends Component {
   static propTypes = {
-    cart: PropTypes.shape({
+    classes: PropTypes.object,
+    fulfillmentGroup: PropTypes.shape({
       items: PropTypes.arrayOf(PropTypes.object),
-      checkout: PropTypes.shape({
-        itemTotal: PropTypes.shape({
-          displayAmount: PropTypes.string
-        }),
-        taxTotal: PropTypes.shape({
-          displayAmount: PropTypes.string
-        })
+      data: PropTypes.shape({
+        shippingAddress: PropTypes.object
       })
     }),
-    classes: PropTypes.object,
-    fulfillmentGroup: PropTypes.object,
     hasMoreCartItems: PropTypes.bool,
     loadMoreCartItems: PropTypes.func,
     onChangeCartItemsQuantity: PropTypes.func,
@@ -60,9 +54,9 @@ class OrderFulfillmentGroup extends Component {
   }
 
   renderItems() {
-    const { cart, hasMoreCartItems, loadMoreCartItems } = this.props;
+    const { fulfillmentGroup, hasMoreCartItems, loadMoreCartItems } = this.props;
 
-    if (cart && Array.isArray(cart.items)) {
+    if (fulfillmentGroup && Array.isArray(fulfillmentGroup.items.nodes)) {
       return (
         <Grid item xs={12}>
           <CartItems
@@ -70,7 +64,7 @@ class OrderFulfillmentGroup extends Component {
             isReadOnly
             hasMoreCartItems={hasMoreCartItems}
             onLoadMoreCartItems={loadMoreCartItems}
-            items={cart.items}
+            items={fulfillmentGroup.items.nodes}
             onChangeCartItemQuantity={this.handleItemQuantityChange}
             onRemoveItemFromCart={this.handleRemoveItem}
           />
@@ -82,34 +76,29 @@ class OrderFulfillmentGroup extends Component {
   }
 
   renderFulfillmentInfo() {
-    const { cart, classes, fulfillmentGroup } = this.props;
+    const { classes, fulfillmentGroup } = this.props;
 
-    if (cart && cart.checkout && cart.checkout.summary) {
-      let address;
-
-      if (fulfillmentGroup) {
-        const { data: { shippingAddress } } = fulfillmentGroup;
-
-        address = (
-          <Typography variant="body2">
-            {(shippingAddress.firstName || shippingAddress.lastName) && (
-              <span>
-                {shippingAddress.firstName} {shippingAddress.lastName}
-                <br />
-              </span>
-            )}
-            {shippingAddress.address1}
-            <br />
-            {(shippingAddress.address2 && shippingAddress.address2 !== "") && (
-              <span>
-                {shippingAddress.address2} <br />
-              </span>
-            )}
-            {shippingAddress.city}, {shippingAddress.region} {shippingAddress.postal} <br />
-            {shippingAddress.country}
-          </Typography>
-        );
-      }
+    if (fulfillmentGroup.data && fulfillmentGroup.data.shippingAddress) {
+      const { data: { shippingAddress } } = fulfillmentGroup;
+      const address = (
+        <Typography variant="body2">
+          {(shippingAddress.firstName || shippingAddress.lastName) && (
+            <span>
+              {shippingAddress.firstName} {shippingAddress.lastName}
+              <br />
+            </span>
+          )}
+          {shippingAddress.address1}
+          <br />
+          {(shippingAddress.address2 && shippingAddress.address2 !== "") && (
+            <span>
+              {shippingAddress.address2} <br />
+            </span>
+          )}
+          {shippingAddress.city}, {shippingAddress.region} {shippingAddress.postal} <br />
+          {shippingAddress.country}
+        </Typography>
+      );
 
       return (
         <div className={classes.fulfillmentDetails}>

--- a/src/components/OrderFulfillmentGroup/OrderFulfillmentGroup.js
+++ b/src/components/OrderFulfillmentGroup/OrderFulfillmentGroup.js
@@ -1,9 +1,10 @@
-import React, { Component } from "react";
+import React, { Component, Fragment } from "react";
 import PropTypes from "prop-types";
 import Grid from "@material-ui/core/Grid";
 import Typography from "@material-ui/core/Typography";
 import { withStyles } from "@material-ui/core/styles";
 import CartItems from "components/CartItems";
+import OrderSummary from "components/OrderSummary";
 
 const styles = (theme) => ({
   fulfillmentGroup: {
@@ -11,6 +12,9 @@ const styles = (theme) => ({
   },
   fulfillmentDetails: {
     padding: theme.spacing.unit * 2
+  },
+  summary: {
+    paddingTop: theme.spacing.unit * 2
   }
 });
 
@@ -118,13 +122,18 @@ class OrderFulfillmentGroup extends Component {
   }
 
   render() {
-    const { classes } = this.props;
+    const { classes, fulfillmentGroup } = this.props;
 
     return (
-      <section className={classes.fulfillmentGroup}>
-        {this.renderItems()}
-        {this.renderFulfillmentInfo()}
-      </section>
+      <Fragment>
+        <section className={classes.fulfillmentGroup}>
+          {this.renderItems()}
+          {this.renderFulfillmentInfo()}
+        </section>
+        <section className={classes.summary}>
+          <OrderSummary fulfillmentGroup={fulfillmentGroup} />
+        </section>
+      </Fragment>
     );
   }
 }

--- a/src/components/OrderFulfillmentGroup/OrderFulfillmentGroup.js
+++ b/src/components/OrderFulfillmentGroup/OrderFulfillmentGroup.js
@@ -1,10 +1,20 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import Grid from "@material-ui/core/Grid";
-import CheckoutActionComplete from "@reactioncommerce/components/CheckoutActionComplete/v1";
-import ShippingAddressCheckoutAction from "@reactioncommerce/components/ShippingAddressCheckoutAction/v1";
+import Typography from "@material-ui/core/Typography";
+import { withStyles } from "@material-ui/core/styles";
 import CartItems from "components/CartItems";
 
+const styles = (theme) => ({
+  fulfillmentGroup: {
+    border: theme.palette.borders.default
+  },
+  fulfillmentDetails: {
+    padding: theme.spacing.unit * 2
+  }
+});
+
+@withStyles(styles)
 class OrderFulfillmentGroup extends Component {
   static propTypes = {
     cart: PropTypes.shape({
@@ -72,22 +82,46 @@ class OrderFulfillmentGroup extends Component {
   }
 
   renderFulfillmentInfo() {
-    const { cart, fulfillmentGroup } = this.props;
+    const { cart, classes, fulfillmentGroup } = this.props;
 
     if (cart && cart.checkout && cart.checkout.summary) {
       let address;
 
-      if (cart.checkout && cart.checkout.fulfillmentGroup) {
-        address = ShippingAddressCheckoutAction.renderComplete({ fulfillmentGroup });
+      if (fulfillmentGroup) {
+        const { data: { shippingAddress } } = fulfillmentGroup;
+
+        address = (
+          <Typography variant="body2">
+            {(shippingAddress.firstName || shippingAddress.lastName) && (
+              <span>
+                {shippingAddress.firstName} {shippingAddress.lastName}
+                <br />
+              </span>
+            )}
+            {shippingAddress.address1}
+            <br />
+            {(shippingAddress.address2 && shippingAddress.address2 !== "") && (
+              <span>
+                {shippingAddress.address2} <br />
+              </span>
+            )}
+            {shippingAddress.city}, {shippingAddress.region} {shippingAddress.postal} <br />
+            {shippingAddress.country}
+          </Typography>
+        );
       }
 
       return (
-        <Grid item xs={12}>
-          <CheckoutActionComplete
-            content={address}
-            label="Shipping Address"
-          />
-        </Grid>
+        <div className={classes.fulfillmentDetails}>
+          <Grid container spacing={24}>
+            <Grid item xs={3}>
+              <Typography variant="subheading">{"Shipping Address"}</Typography>
+            </Grid>
+            <Grid item xs={9}>
+              {address}
+            </Grid>
+          </Grid>
+        </div>
       );
     }
 
@@ -95,13 +129,13 @@ class OrderFulfillmentGroup extends Component {
   }
 
   render() {
+    const { classes } = this.props;
+
     return (
-      <aside>
-        <Grid container spacing={24}>
-          {this.renderItems()}
-          {this.renderFulfillmentInfo()}
-        </Grid>
-      </aside>
+      <section className={classes.fulfillmentGroup}>
+        {this.renderItems()}
+        {this.renderFulfillmentInfo()}
+      </section>
     );
   }
 }

--- a/src/components/OrderFulfillmentGroup/OrderFulfillmentGroup.test.js
+++ b/src/components/OrderFulfillmentGroup/OrderFulfillmentGroup.test.js
@@ -1,23 +1,22 @@
 import React from "react";
 import renderer from "react-test-renderer";
+import { MuiThemeProvider } from "@material-ui/core/styles";
+import theme from "lib/theme/reactionTheme";
 import { ComponentsProvider } from "@reactioncommerce/components-context";
 import componentsContext from "componentsContext";
 import OrderFulfillmentGroup from "./OrderFulfillmentGroup";
 
-const testOrder = {
-  checkout: {
-    summary: {
-      itemTotal: {
-        displayAmount: "$118"
-      },
-      total: {
-        displayAmount: "$118"
-      }
+const testFulfillmentGroup = {
+  summary: {
+    itemTotal: {
+      displayAmount: "$118"
+    },
+    total: {
+      displayAmount: "$118"
     }
   },
-  totalItemQuantity: 3,
-  items: [
-    {
+  items: {
+    nodes: [{
       _id: "123",
       attributes: [
         { label: "Color", value: "Red" },
@@ -59,16 +58,27 @@ const testOrder = {
       productSlug: "/product-slug",
       title: "Another Great Product",
       quantity: 1
+    }]
+  },
+  payment: {
+    displayName: "Example Payment"
+  },
+  selectedFulfillmentOption: {
+    fulfillmentMethod: {
+      displayName: "Free Shipping",
+      group: "Ground"
     }
-  ]
+  }
 };
 
 test("basic snapshot", () => {
   const component = renderer.create((
     <ComponentsProvider value={componentsContext}>
-      <OrderFulfillmentGroup
-        order={testOrder}
-      />
+      <MuiThemeProvider theme={theme}>
+        <OrderFulfillmentGroup
+          fulfillmentGroup={testFulfillmentGroup}
+        />
+      </MuiThemeProvider>
     </ComponentsProvider>
   ));
 

--- a/src/components/OrderFulfillmentGroup/OrderFulfillmentGroup.test.js
+++ b/src/components/OrderFulfillmentGroup/OrderFulfillmentGroup.test.js
@@ -1,0 +1,77 @@
+import React from "react";
+import renderer from "react-test-renderer";
+import { ComponentsProvider } from "@reactioncommerce/components-context";
+import componentsContext from "componentsContext";
+import OrderFulfillmentGroup from "./OrderFulfillmentGroup";
+
+const testOrder = {
+  checkout: {
+    summary: {
+      itemTotal: {
+        displayAmount: "$118"
+      },
+      total: {
+        displayAmount: "$118"
+      }
+    }
+  },
+  totalItemQuantity: 3,
+  items: [
+    {
+      _id: "123",
+      attributes: [
+        { label: "Color", value: "Red" },
+        { label: "Size", value: "Medium" }
+      ],
+      compareAtPrice: {
+        displayAmount: "$45.00"
+      },
+      currentQuantity: 3,
+      imageURLs: {
+        small: "//placehold.it/150",
+        thumbnail: "//placehold.it/100"
+      },
+      isLowQuantity: true,
+      price: {
+        displayAmount: "$20.00"
+      },
+      productSlug: "/product-slug",
+      productVendor: "Patagonia",
+      title: "A Great Product",
+      quantity: 2
+    },
+    {
+      _id: "456",
+      attributes: [
+        { label: "Color", value: "Black" },
+        { label: "Size", value: "10" }
+      ],
+      currentQuantity: 500,
+      imageURLs: {
+        small: "//placehold.it/150",
+        thumbnail: "//placehold.it/100"
+      },
+      isLowQuantity: false,
+      price: {
+        displayAmount: "$78.00"
+      },
+      productVendor: "Nike",
+      productSlug: "/product-slug",
+      title: "Another Great Product",
+      quantity: 1
+    }
+  ]
+};
+
+test("basic snapshot", () => {
+  const component = renderer.create((
+    <ComponentsProvider value={componentsContext}>
+      <OrderFulfillmentGroup
+        order={testOrder}
+      />
+    </ComponentsProvider>
+  ));
+
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});

--- a/src/components/OrderFulfillmentGroup/__snapshots__/OrderFulfillmentGroup.test.js.snap
+++ b/src/components/OrderFulfillmentGroup/__snapshots__/OrderFulfillmentGroup.test.js.snap
@@ -1,0 +1,345 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`basic snapshot 1`] = `
+Array [
+  <section
+    className="OrderFulfillmentGroup-fulfillmentGroup-1"
+  >
+    <header
+      className="OrderFulfillmentGroup-header-3"
+    >
+      <div
+        className="MuiGrid-container-6 MuiGrid-spacing-xs-24-30"
+      >
+        <div
+          className="MuiGrid-item-7 MuiGrid-grid-xs-6-40"
+        >
+          <h3
+            className="MuiTypography-root-103 MuiTypography-subheading-110"
+          >
+            Free Shipping
+          </h3>
+        </div>
+        <div
+          className="MuiGrid-item-7 MuiGrid-grid-xs-6-40 OrderFulfillmentGroup-headerRightColumn-4"
+        >
+          <aside
+            className="MuiTypography-root-103 MuiTypography-body2-111"
+          >
+            Ground
+          </aside>
+        </div>
+      </div>
+    </header>
+    <div
+      className="MuiGrid-item-7 MuiGrid-grid-xs-12-46"
+    >
+      <div
+        className="CartItems__Items-gEXRwN gdnVAG"
+      >
+        <div
+          className="CartItem__Item-ghDCXl cfXPgA"
+        >
+          <a
+            href="/product-slug"
+          >
+            <picture>
+              
+              <img
+                alt=""
+                src="//placehold.it/100"
+                style={
+                  Object {
+                    "display": "block",
+                  }
+                }
+              />
+            </picture>
+          </a>
+          <div
+            className="CartItem__ItemContent-fAfWVu iOkAew"
+          >
+            <div
+              className="CartItem__ItemContentDetail-huMIJe gVwWKq"
+            >
+              <div
+                className="CartItem__ItemContentDetailInner-eKJgRu cjjvqv"
+              >
+                <div
+                  className="CartItem__ItemContentDetailInfo-kmZYEG epAHLA"
+                >
+                  <div
+                    className="CartItemDetail__Detail-xugoC bPXJMk"
+                  >
+                    <h3
+                      className="CartItemDetail__Title-iDNyNA ckBsQI"
+                    >
+                      <a
+                        href="/product-slug"
+                      >
+                        A Great Product
+                      </a>
+                    </h3>
+                    <div
+                      className="CartItemDetail__Attributes-Jfttp dEgfNx"
+                    >
+                      <p
+                        className="CartItemDetail__Text-iQjjVf jxAYVa"
+                      >
+                        Patagonia
+                      </p>
+                      <p
+                        className="CartItemDetail__Attr-cEjNLZ gFtQDZ"
+                      >
+                        <span>
+                          Color
+                          :
+                        </span>
+                         
+                        Red
+                      </p>
+                      <p
+                        className="CartItemDetail__Attr-cEjNLZ gFtQDZ"
+                      >
+                        <span>
+                          Size
+                          :
+                        </span>
+                         
+                        Medium
+                      </p>
+                      <p
+                        className="CartItemDetail__Text-iQjjVf jxAYVa"
+                      >
+                        Quantity: 
+                        2
+                      </p>
+                    </div>
+                  </div>
+                  <div
+                    className="StockWarning__Span-niCBr hrChZc"
+                  >
+                    Only 
+                    3
+                     in stock
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              className="CartItem__ItemContentPrice-lcfJQP eaPRuH"
+            >
+              <div>
+                
+                <del
+                  className="Price__Del-bTXnTw juwrQs"
+                >
+                  $45.00
+                </del>
+                <span
+                  className="Price__Span-cHkFMo eGYnOf"
+                >
+                  $20.00
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className="CartItem__Item-ghDCXl cfXPgA"
+        >
+          <a
+            href="/product-slug"
+          >
+            <picture>
+              
+              <img
+                alt=""
+                src="//placehold.it/100"
+                style={
+                  Object {
+                    "display": "block",
+                  }
+                }
+              />
+            </picture>
+          </a>
+          <div
+            className="CartItem__ItemContent-fAfWVu iOkAew"
+          >
+            <div
+              className="CartItem__ItemContentDetail-huMIJe gVwWKq"
+            >
+              <div
+                className="CartItem__ItemContentDetailInner-eKJgRu cjjvqv"
+              >
+                <div
+                  className="CartItem__ItemContentDetailInfo-kmZYEG epAHLA"
+                >
+                  <div
+                    className="CartItemDetail__Detail-xugoC bPXJMk"
+                  >
+                    <h3
+                      className="CartItemDetail__Title-iDNyNA ckBsQI"
+                    >
+                      <a
+                        href="/product-slug"
+                      >
+                        Another Great Product
+                      </a>
+                    </h3>
+                    <div
+                      className="CartItemDetail__Attributes-Jfttp dEgfNx"
+                    >
+                      <p
+                        className="CartItemDetail__Text-iQjjVf jxAYVa"
+                      >
+                        Nike
+                      </p>
+                      <p
+                        className="CartItemDetail__Attr-cEjNLZ gFtQDZ"
+                      >
+                        <span>
+                          Color
+                          :
+                        </span>
+                         
+                        Black
+                      </p>
+                      <p
+                        className="CartItemDetail__Attr-cEjNLZ gFtQDZ"
+                      >
+                        <span>
+                          Size
+                          :
+                        </span>
+                         
+                        10
+                      </p>
+                      <p
+                        className="CartItemDetail__Text-iQjjVf jxAYVa"
+                      >
+                        Quantity: 
+                        1
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              className="CartItem__ItemContentPrice-lcfJQP eaPRuH"
+            >
+              <div>
+                
+                <span
+                  className="Price__Span-cHkFMo eGYnOf"
+                >
+                  $78.00
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>,
+  <section
+    className="OrderFulfillmentGroup-summary-5"
+  >
+    <div
+      className="OrderSummary-summary-129"
+    >
+      <div
+        className="OrderSummary-header-130"
+      >
+        <div
+          className="MuiGrid-container-6 MuiGrid-spacing-xs-24-30"
+        >
+          <div
+            className="MuiGrid-item-7 MuiGrid-grid-xs-3-37"
+          >
+            <h3
+              className="MuiTypography-root-103 MuiTypography-subheading-110"
+            >
+              Payment Method
+            </h3>
+          </div>
+          <div
+            className="MuiGrid-item-7 MuiGrid-grid-xs-3-37"
+          >
+            <aside
+              className="MuiTypography-root-103 MuiTypography-body2-111"
+            >
+              Example Payment
+            </aside>
+          </div>
+        </div>
+      </div>
+      <hr
+        className="MuiDivider-root-133"
+      />
+      <div
+        className="sc-bdVaJa iXzmsn"
+      >
+        <table
+          className="CartSummary__Table-cWcArh gWGRvE"
+        >
+          <tbody>
+            <tr>
+              <td
+                className="CartSummary__Td-jXBgKC bUBGM"
+              >
+                Item total
+              </td>
+              <td
+                className="CartSummary__Td-boDvWU sYgOn"
+              >
+                $118
+              </td>
+            </tr>
+            <tr>
+              <td
+                className="CartSummary__Td-jXBgKC bUBGM"
+              >
+                Shipping
+              </td>
+              <td
+                className="CartSummary__Td-boDvWU sYgOn"
+              />
+            </tr>
+            <tr>
+              <td
+                className="CartSummary__Td-jXBgKC bUBGM"
+              >
+                Tax
+              </td>
+              <td
+                className="CartSummary__Td-boDvWU sYgOn"
+              >
+                -
+              </td>
+            </tr>
+            <tr>
+              <td
+                className="CartSummary__Td-jXBgKC isuVSE"
+              >
+                Order total
+              </td>
+              <td
+                className="CartSummary__Td-boDvWU FDHoo"
+              >
+                <span
+                  className="CartSummary__Total-BZUQP bdUKHv"
+                >
+                  $118
+                </span>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </section>,
+]
+`;

--- a/src/components/OrderFulfillmentGroup/index.js
+++ b/src/components/OrderFulfillmentGroup/index.js
@@ -1,0 +1,1 @@
+export { default } from "./OrderFulfillmentGroup";

--- a/src/components/OrderFulfillmentGroups/OrderFulfillmentGroups.js
+++ b/src/components/OrderFulfillmentGroups/OrderFulfillmentGroups.js
@@ -16,6 +16,9 @@ class OrderFulfillmentGroups extends Component {
       })
     }),
     classes: PropTypes.object,
+    order: PropTypes.shape({
+      fulfillmentGroups: PropTypes.arrayOf(PropTypes.object)
+    }),
     shop: PropTypes.shape({
       name: PropTypes.string.isRequired,
       description: PropTypes.string

--- a/src/components/OrderFulfillmentGroups/OrderFulfillmentGroups.js
+++ b/src/components/OrderFulfillmentGroups/OrderFulfillmentGroups.js
@@ -1,6 +1,5 @@
-import React, { Component } from "react";
+import React, { Component, Fragment } from "react";
 import PropTypes from "prop-types";
-import Grid from "@material-ui/core/Grid";
 import OrderFulfillmentGroup from "components/OrderFulfillmentGroup";
 
 class OrderFulfillmentGroups extends Component {
@@ -40,11 +39,9 @@ class OrderFulfillmentGroups extends Component {
 
   render() {
     return (
-      <aside>
-        <Grid container spacing={24}>
-          {this.renderFulfillmentGroups()}
-        </Grid>
-      </aside>
+      <Fragment>
+        {this.renderFulfillmentGroups()}
+      </Fragment>
     );
   }
 }

--- a/src/components/OrderFulfillmentGroups/OrderFulfillmentGroups.js
+++ b/src/components/OrderFulfillmentGroups/OrderFulfillmentGroups.js
@@ -4,17 +4,6 @@ import OrderFulfillmentGroup from "components/OrderFulfillmentGroup";
 
 class OrderFulfillmentGroups extends Component {
   static propTypes = {
-    cart: PropTypes.shape({
-      items: PropTypes.arrayOf(PropTypes.object),
-      checkout: PropTypes.shape({
-        itemTotal: PropTypes.shape({
-          displayAmount: PropTypes.string
-        }),
-        taxTotal: PropTypes.shape({
-          displayAmount: PropTypes.string
-        })
-      })
-    }),
     classes: PropTypes.object,
     order: PropTypes.shape({
       fulfillmentGroups: PropTypes.arrayOf(PropTypes.object)

--- a/src/components/OrderFulfillmentGroups/OrderFulfillmentGroups.js
+++ b/src/components/OrderFulfillmentGroups/OrderFulfillmentGroups.js
@@ -18,8 +18,9 @@ class OrderFulfillmentGroups extends Component {
     const { order } = this.props;
 
     if (order && Array.isArray(order.fulfillmentGroups)) {
-      return order.fulfillmentGroups.map((fulfillmentGroup) => (
+      return order.fulfillmentGroups.map((fulfillmentGroup, index) => (
         <OrderFulfillmentGroup
+          key={index}
           fulfillmentGroup={fulfillmentGroup}
         />
       ));

--- a/src/components/OrderFulfillmentGroups/OrderFulfillmentGroups.js
+++ b/src/components/OrderFulfillmentGroups/OrderFulfillmentGroups.js
@@ -23,12 +23,12 @@ class OrderFulfillmentGroups extends Component {
   }
 
   renderFulfillmentGroups() {
-    const { cart } = this.props;
+    const { order } = this.props;
 
-    if (cart.checkout && Array.isArray(cart.checkout.fulfillmentGroups)) {
-      return cart.checkout.fulfillmentGroups.map((fulfillmentGroup) => (
+    if (order && Array.isArray(order.fulfillmentGroups)) {
+      return order.fulfillmentGroups.map((fulfillmentGroup) => (
         <OrderFulfillmentGroup
-          cart={cart}
+          order={order}
           fulfillmentGroup={fulfillmentGroup}
         />
       ));

--- a/src/components/OrderFulfillmentGroups/OrderFulfillmentGroups.js
+++ b/src/components/OrderFulfillmentGroups/OrderFulfillmentGroups.js
@@ -28,7 +28,6 @@ class OrderFulfillmentGroups extends Component {
     if (order && Array.isArray(order.fulfillmentGroups)) {
       return order.fulfillmentGroups.map((fulfillmentGroup) => (
         <OrderFulfillmentGroup
-          order={order}
           fulfillmentGroup={fulfillmentGroup}
         />
       ));

--- a/src/components/OrderFulfillmentGroups/OrderFulfillmentGroups.js
+++ b/src/components/OrderFulfillmentGroups/OrderFulfillmentGroups.js
@@ -1,0 +1,52 @@
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+import Grid from "@material-ui/core/Grid";
+import OrderFulfillmentGroup from "components/OrderFulfillmentGroup";
+
+class OrderFulfillmentGroups extends Component {
+  static propTypes = {
+    cart: PropTypes.shape({
+      items: PropTypes.arrayOf(PropTypes.object),
+      checkout: PropTypes.shape({
+        itemTotal: PropTypes.shape({
+          displayAmount: PropTypes.string
+        }),
+        taxTotal: PropTypes.shape({
+          displayAmount: PropTypes.string
+        })
+      })
+    }),
+    classes: PropTypes.object,
+    shop: PropTypes.shape({
+      name: PropTypes.string.isRequired,
+      description: PropTypes.string
+    })
+  }
+
+  renderFulfillmentGroups() {
+    const { cart } = this.props;
+
+    if (cart.checkout && Array.isArray(cart.checkout.fulfillmentGroups)) {
+      return cart.checkout.fulfillmentGroups.map((fulfillmentGroup) => (
+        <OrderFulfillmentGroup
+          cart={cart}
+          fulfillmentGroup={fulfillmentGroup}
+        />
+      ));
+    }
+
+    return null;
+  }
+
+  render() {
+    return (
+      <aside>
+        <Grid container spacing={24}>
+          {this.renderFulfillmentGroups()}
+        </Grid>
+      </aside>
+    );
+  }
+}
+
+export default OrderFulfillmentGroups;

--- a/src/components/OrderFulfillmentGroups/OrderFulfillmentGroups.test.js
+++ b/src/components/OrderFulfillmentGroups/OrderFulfillmentGroups.test.js
@@ -1,11 +1,13 @@
 import React from "react";
 import renderer from "react-test-renderer";
+import { MuiThemeProvider } from "@material-ui/core/styles";
+import theme from "lib/theme/reactionTheme";
 import { ComponentsProvider } from "@reactioncommerce/components-context";
 import componentsContext from "componentsContext";
 import OrderFulfillmentGroups from "./OrderFulfillmentGroups";
 
-const testCart = {
-  checkout: {
+const testOrder = {
+  fulfillmentGroups: [{
     summary: {
       itemTotal: {
         displayAmount: "$118"
@@ -13,62 +15,72 @@ const testCart = {
       total: {
         displayAmount: "$118"
       }
-    }
-  },
-  totalItemQuantity: 3,
-  items: [
-    {
-      _id: "123",
-      attributes: [
-        { label: "Color", value: "Red" },
-        { label: "Size", value: "Medium" }
-      ],
-      compareAtPrice: {
-        displayAmount: "$45.00"
-      },
-      currentQuantity: 3,
-      imageURLs: {
-        small: "//placehold.it/150",
-        thumbnail: "//placehold.it/100"
-      },
-      isLowQuantity: true,
-      price: {
-        displayAmount: "$20.00"
-      },
-      productSlug: "/product-slug",
-      productVendor: "Patagonia",
-      title: "A Great Product",
-      quantity: 2
     },
-    {
-      _id: "456",
-      attributes: [
-        { label: "Color", value: "Black" },
-        { label: "Size", value: "10" }
-      ],
-      currentQuantity: 500,
-      imageURLs: {
-        small: "//placehold.it/150",
-        thumbnail: "//placehold.it/100"
+    items: {
+      nodes: [{
+        _id: "123",
+        attributes: [
+          { label: "Color", value: "Red" },
+          { label: "Size", value: "Medium" }
+        ],
+        compareAtPrice: {
+          displayAmount: "$45.00"
+        },
+        currentQuantity: 3,
+        imageURLs: {
+          small: "//placehold.it/150",
+          thumbnail: "//placehold.it/100"
+        },
+        isLowQuantity: true,
+        price: {
+          displayAmount: "$20.00"
+        },
+        productSlug: "/product-slug",
+        productVendor: "Patagonia",
+        title: "A Great Product",
+        quantity: 2
       },
-      isLowQuantity: false,
-      price: {
-        displayAmount: "$78.00"
-      },
-      productVendor: "Nike",
-      productSlug: "/product-slug",
-      title: "Another Great Product",
-      quantity: 1
+      {
+        _id: "456",
+        attributes: [
+          { label: "Color", value: "Black" },
+          { label: "Size", value: "10" }
+        ],
+        currentQuantity: 500,
+        imageURLs: {
+          small: "//placehold.it/150",
+          thumbnail: "//placehold.it/100"
+        },
+        isLowQuantity: false,
+        price: {
+          displayAmount: "$78.00"
+        },
+        productVendor: "Nike",
+        productSlug: "/product-slug",
+        title: "Another Great Product",
+        quantity: 1
+      }]
+    },
+    payment: {
+      displayName: "Example Payment"
+    },
+    selectedFulfillmentOption: {
+      fulfillmentMethod: {
+        displayName: "Free Shipping",
+        group: "Ground"
+      }
     }
-  ]
+  }]
 };
 
 test("basic snapshot", () => {
   const component = renderer.create((
     <ComponentsProvider value={componentsContext}>
-      <OrderFulfillmentGroups
-        cart={testCart}
-      />
+      <MuiThemeProvider theme={theme}>
+        <OrderFulfillmentGroups
+          order={testOrder}
+        />
+      </MuiThemeProvider>
     </ComponentsProvider>
   ));
 

--- a/src/components/OrderFulfillmentGroups/OrderFulfillmentGroups.test.js
+++ b/src/components/OrderFulfillmentGroups/OrderFulfillmentGroups.test.js
@@ -1,0 +1,77 @@
+import React from "react";
+import renderer from "react-test-renderer";
+import { ComponentsProvider } from "@reactioncommerce/components-context";
+import componentsContext from "componentsContext";
+import OrderFulfillmentGroups from "./OrderFulfillmentGroups";
+
+const testCart = {
+  checkout: {
+    summary: {
+      itemTotal: {
+        displayAmount: "$118"
+      },
+      total: {
+        displayAmount: "$118"
+      }
+    }
+  },
+  totalItemQuantity: 3,
+  items: [
+    {
+      _id: "123",
+      attributes: [
+        { label: "Color", value: "Red" },
+        { label: "Size", value: "Medium" }
+      ],
+      compareAtPrice: {
+        displayAmount: "$45.00"
+      },
+      currentQuantity: 3,
+      imageURLs: {
+        small: "//placehold.it/150",
+        thumbnail: "//placehold.it/100"
+      },
+      isLowQuantity: true,
+      price: {
+        displayAmount: "$20.00"
+      },
+      productSlug: "/product-slug",
+      productVendor: "Patagonia",
+      title: "A Great Product",
+      quantity: 2
+    },
+    {
+      _id: "456",
+      attributes: [
+        { label: "Color", value: "Black" },
+        { label: "Size", value: "10" }
+      ],
+      currentQuantity: 500,
+      imageURLs: {
+        small: "//placehold.it/150",
+        thumbnail: "//placehold.it/100"
+      },
+      isLowQuantity: false,
+      price: {
+        displayAmount: "$78.00"
+      },
+      productVendor: "Nike",
+      productSlug: "/product-slug",
+      title: "Another Great Product",
+      quantity: 1
+    }
+  ]
+};
+
+test("basic snapshot", () => {
+  const component = renderer.create((
+    <ComponentsProvider value={componentsContext}>
+      <OrderFulfillmentGroups
+        cart={testCart}
+      />
+    </ComponentsProvider>
+  ));
+
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});

--- a/src/components/OrderFulfillmentGroups/__snapshots__/OrderFulfillmentGroups.test.js.snap
+++ b/src/components/OrderFulfillmentGroups/__snapshots__/OrderFulfillmentGroups.test.js.snap
@@ -1,0 +1,345 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`basic snapshot 1`] = `
+Array [
+  <section
+    className="OrderFulfillmentGroup-fulfillmentGroup-1"
+  >
+    <header
+      className="OrderFulfillmentGroup-header-3"
+    >
+      <div
+        className="MuiGrid-container-6 MuiGrid-spacing-xs-24-30"
+      >
+        <div
+          className="MuiGrid-item-7 MuiGrid-grid-xs-6-40"
+        >
+          <h3
+            className="MuiTypography-root-103 MuiTypography-subheading-110"
+          >
+            Free Shipping
+          </h3>
+        </div>
+        <div
+          className="MuiGrid-item-7 MuiGrid-grid-xs-6-40 OrderFulfillmentGroup-headerRightColumn-4"
+        >
+          <aside
+            className="MuiTypography-root-103 MuiTypography-body2-111"
+          >
+            Ground
+          </aside>
+        </div>
+      </div>
+    </header>
+    <div
+      className="MuiGrid-item-7 MuiGrid-grid-xs-12-46"
+    >
+      <div
+        className="CartItems__Items-gEXRwN gdnVAG"
+      >
+        <div
+          className="CartItem__Item-ghDCXl cfXPgA"
+        >
+          <a
+            href="/product-slug"
+          >
+            <picture>
+              
+              <img
+                alt=""
+                src="//placehold.it/100"
+                style={
+                  Object {
+                    "display": "block",
+                  }
+                }
+              />
+            </picture>
+          </a>
+          <div
+            className="CartItem__ItemContent-fAfWVu iOkAew"
+          >
+            <div
+              className="CartItem__ItemContentDetail-huMIJe gVwWKq"
+            >
+              <div
+                className="CartItem__ItemContentDetailInner-eKJgRu cjjvqv"
+              >
+                <div
+                  className="CartItem__ItemContentDetailInfo-kmZYEG epAHLA"
+                >
+                  <div
+                    className="CartItemDetail__Detail-xugoC bPXJMk"
+                  >
+                    <h3
+                      className="CartItemDetail__Title-iDNyNA ckBsQI"
+                    >
+                      <a
+                        href="/product-slug"
+                      >
+                        A Great Product
+                      </a>
+                    </h3>
+                    <div
+                      className="CartItemDetail__Attributes-Jfttp dEgfNx"
+                    >
+                      <p
+                        className="CartItemDetail__Text-iQjjVf jxAYVa"
+                      >
+                        Patagonia
+                      </p>
+                      <p
+                        className="CartItemDetail__Attr-cEjNLZ gFtQDZ"
+                      >
+                        <span>
+                          Color
+                          :
+                        </span>
+                         
+                        Red
+                      </p>
+                      <p
+                        className="CartItemDetail__Attr-cEjNLZ gFtQDZ"
+                      >
+                        <span>
+                          Size
+                          :
+                        </span>
+                         
+                        Medium
+                      </p>
+                      <p
+                        className="CartItemDetail__Text-iQjjVf jxAYVa"
+                      >
+                        Quantity: 
+                        2
+                      </p>
+                    </div>
+                  </div>
+                  <div
+                    className="StockWarning__Span-niCBr hrChZc"
+                  >
+                    Only 
+                    3
+                     in stock
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              className="CartItem__ItemContentPrice-lcfJQP eaPRuH"
+            >
+              <div>
+                
+                <del
+                  className="Price__Del-bTXnTw juwrQs"
+                >
+                  $45.00
+                </del>
+                <span
+                  className="Price__Span-cHkFMo eGYnOf"
+                >
+                  $20.00
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className="CartItem__Item-ghDCXl cfXPgA"
+        >
+          <a
+            href="/product-slug"
+          >
+            <picture>
+              
+              <img
+                alt=""
+                src="//placehold.it/100"
+                style={
+                  Object {
+                    "display": "block",
+                  }
+                }
+              />
+            </picture>
+          </a>
+          <div
+            className="CartItem__ItemContent-fAfWVu iOkAew"
+          >
+            <div
+              className="CartItem__ItemContentDetail-huMIJe gVwWKq"
+            >
+              <div
+                className="CartItem__ItemContentDetailInner-eKJgRu cjjvqv"
+              >
+                <div
+                  className="CartItem__ItemContentDetailInfo-kmZYEG epAHLA"
+                >
+                  <div
+                    className="CartItemDetail__Detail-xugoC bPXJMk"
+                  >
+                    <h3
+                      className="CartItemDetail__Title-iDNyNA ckBsQI"
+                    >
+                      <a
+                        href="/product-slug"
+                      >
+                        Another Great Product
+                      </a>
+                    </h3>
+                    <div
+                      className="CartItemDetail__Attributes-Jfttp dEgfNx"
+                    >
+                      <p
+                        className="CartItemDetail__Text-iQjjVf jxAYVa"
+                      >
+                        Nike
+                      </p>
+                      <p
+                        className="CartItemDetail__Attr-cEjNLZ gFtQDZ"
+                      >
+                        <span>
+                          Color
+                          :
+                        </span>
+                         
+                        Black
+                      </p>
+                      <p
+                        className="CartItemDetail__Attr-cEjNLZ gFtQDZ"
+                      >
+                        <span>
+                          Size
+                          :
+                        </span>
+                         
+                        10
+                      </p>
+                      <p
+                        className="CartItemDetail__Text-iQjjVf jxAYVa"
+                      >
+                        Quantity: 
+                        1
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              className="CartItem__ItemContentPrice-lcfJQP eaPRuH"
+            >
+              <div>
+                
+                <span
+                  className="Price__Span-cHkFMo eGYnOf"
+                >
+                  $78.00
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>,
+  <section
+    className="OrderFulfillmentGroup-summary-5"
+  >
+    <div
+      className="OrderSummary-summary-129"
+    >
+      <div
+        className="OrderSummary-header-130"
+      >
+        <div
+          className="MuiGrid-container-6 MuiGrid-spacing-xs-24-30"
+        >
+          <div
+            className="MuiGrid-item-7 MuiGrid-grid-xs-3-37"
+          >
+            <h3
+              className="MuiTypography-root-103 MuiTypography-subheading-110"
+            >
+              Payment Method
+            </h3>
+          </div>
+          <div
+            className="MuiGrid-item-7 MuiGrid-grid-xs-3-37"
+          >
+            <aside
+              className="MuiTypography-root-103 MuiTypography-body2-111"
+            >
+              Example Payment
+            </aside>
+          </div>
+        </div>
+      </div>
+      <hr
+        className="MuiDivider-root-133"
+      />
+      <div
+        className="sc-bdVaJa iXzmsn"
+      >
+        <table
+          className="CartSummary__Table-cWcArh gWGRvE"
+        >
+          <tbody>
+            <tr>
+              <td
+                className="CartSummary__Td-jXBgKC bUBGM"
+              >
+                Item total
+              </td>
+              <td
+                className="CartSummary__Td-boDvWU sYgOn"
+              >
+                $118
+              </td>
+            </tr>
+            <tr>
+              <td
+                className="CartSummary__Td-jXBgKC bUBGM"
+              >
+                Shipping
+              </td>
+              <td
+                className="CartSummary__Td-boDvWU sYgOn"
+              />
+            </tr>
+            <tr>
+              <td
+                className="CartSummary__Td-jXBgKC bUBGM"
+              >
+                Tax
+              </td>
+              <td
+                className="CartSummary__Td-boDvWU sYgOn"
+              >
+                -
+              </td>
+            </tr>
+            <tr>
+              <td
+                className="CartSummary__Td-jXBgKC isuVSE"
+              >
+                Order total
+              </td>
+              <td
+                className="CartSummary__Td-boDvWU FDHoo"
+              >
+                <span
+                  className="CartSummary__Total-BZUQP bdUKHv"
+                >
+                  $118
+                </span>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </section>,
+]
+`;

--- a/src/components/OrderFulfillmentGroups/index.js
+++ b/src/components/OrderFulfillmentGroups/index.js
@@ -1,0 +1,1 @@
+export { default } from "./OrderFulfillmentGroups";

--- a/src/components/OrderSummary/OrderSummary.js
+++ b/src/components/OrderSummary/OrderSummary.js
@@ -69,7 +69,6 @@ class OrderSummary extends Component {
             displayShipping={fulfillmentTotal && fulfillmentTotal.displayAmount}
             displaySubtotal={itemTotal && itemTotal.displayAmount}
             displayTotal={total && total.displayAmount}
-            itemsQuantity={cart.totalItemQuantity}
           />
         </OrderSummaryContainer>
       );

--- a/src/components/OrderSummary/OrderSummary.js
+++ b/src/components/OrderSummary/OrderSummary.js
@@ -79,7 +79,7 @@ class OrderSummary extends Component {
   }
 
   render() {
-    const { classes } = this.props;
+    const { classes, fulfillmentGroup } = this.props;
 
     return (
       <div className={classes.summary}>
@@ -89,7 +89,7 @@ class OrderSummary extends Component {
               <Typography variant="subheading">{"Payment Method"}</Typography>
             </Grid>
             <Grid item xs={3}>
-              <Typography variant="body2">{"Visa ending in 1111"}</Typography>
+              <Typography variant="body2">{fulfillmentGroup.payment && fulfillmentGroup.payment.displayName}</Typography>
             </Grid>
           </Grid>
         </div>

--- a/src/components/OrderSummary/OrderSummary.js
+++ b/src/components/OrderSummary/OrderSummary.js
@@ -5,6 +5,17 @@ import Divider from "@material-ui/core/Divider";
 import Typography from "@material-ui/core/Typography";
 import { withStyles } from "@material-ui/core/styles";
 import CartSummary from "@reactioncommerce/components/CartSummary/v1";
+import styled from "styled-components";
+
+// Use styled components to adjust the styling of the
+// cart summary component to fit inside a bordered box
+const OrderSummaryContainer = styled.div`
+  table td {
+    padding-left: 1rem;
+    padding-right: 1rem;
+    border-bottom: none;
+  }
+`;
 
 const styles = (theme) => ({
   summary: {
@@ -53,7 +64,7 @@ class OrderSummary extends Component {
       } = cart.checkout.summary;
 
       return (
-        <Grid item xs={12}>
+        <OrderSummaryContainer>
           <CartSummary
             isDense
             displayShipping={fulfillmentTotal && fulfillmentTotal.displayAmount}
@@ -61,7 +72,7 @@ class OrderSummary extends Component {
             displayTotal={total && total.displayAmount}
             itemsQuantity={cart.totalItemQuantity}
           />
-        </Grid>
+        </OrderSummaryContainer>
       );
     }
 

--- a/src/components/OrderSummary/OrderSummary.js
+++ b/src/components/OrderSummary/OrderSummary.js
@@ -1,0 +1,93 @@
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+import Grid from "@material-ui/core/Grid";
+import Divider from "@material-ui/core/Divider";
+import Typography from "@material-ui/core/Typography";
+import { withStyles } from "@material-ui/core/styles";
+import CartSummary from "@reactioncommerce/components/CartSummary/v1";
+
+const styles = (theme) => ({
+  summary: {
+    border: theme.palette.borders.default
+  },
+  header: {
+    padding: `${theme.spacing.unit}px ${theme.spacing.unit * 2}px`
+  },
+  title: {
+    flex: "1 0 auto"
+  },
+  paymentMethod: {
+    flex: "2 0 auto"
+  }
+});
+
+@withStyles(styles)
+class OrderSummary extends Component {
+  static propTypes = {
+    classes: PropTypes.object,
+    order: PropTypes.shape({
+      items: PropTypes.arrayOf(PropTypes.object),
+      checkout: PropTypes.shape({
+        itemTotal: PropTypes.shape({
+          displayAmount: PropTypes.string
+        }),
+        taxTotal: PropTypes.shape({
+          displayAmount: PropTypes.string
+        })
+      })
+    }),
+    shop: PropTypes.shape({
+      name: PropTypes.string.isRequired,
+      description: PropTypes.string
+    })
+  }
+
+  renderSummary() {
+    const { order: cart } = this.props;
+
+    if (cart && cart.checkout && cart.checkout.summary) {
+      const {
+        fulfillmentTotal,
+        itemTotal,
+        total
+      } = cart.checkout.summary;
+
+      return (
+        <Grid item xs={12}>
+          <CartSummary
+            isDense
+            displayShipping={fulfillmentTotal && fulfillmentTotal.displayAmount}
+            displaySubtotal={itemTotal && itemTotal.displayAmount}
+            displayTotal={total && total.displayAmount}
+            itemsQuantity={cart.totalItemQuantity}
+          />
+        </Grid>
+      );
+    }
+
+    return null;
+  }
+
+  render() {
+    const { classes } = this.props;
+
+    return (
+      <div className={classes.summary}>
+        <div className={classes.header}>
+          <Grid container spacing={24}>
+            <Grid item xs={3}>
+              <Typography variant="subheading">{"Payment Method"}</Typography>
+            </Grid>
+            <Grid item xs={3}>
+              <Typography variant="body2">{"Visa ending in 1111"}</Typography>
+            </Grid>
+          </Grid>
+        </div>
+        <Divider />
+        {this.renderSummary()}
+      </div>
+    );
+  }
+}
+
+export default OrderSummary;

--- a/src/components/OrderSummary/OrderSummary.js
+++ b/src/components/OrderSummary/OrderSummary.js
@@ -36,9 +36,8 @@ const styles = (theme) => ({
 class OrderSummary extends Component {
   static propTypes = {
     classes: PropTypes.object,
-    order: PropTypes.shape({
-      items: PropTypes.arrayOf(PropTypes.object),
-      checkout: PropTypes.shape({
+    fulfillmentGroup: PropTypes.shape({
+      summary: PropTypes.shape({
         itemTotal: PropTypes.shape({
           displayAmount: PropTypes.string
         }),
@@ -54,14 +53,14 @@ class OrderSummary extends Component {
   }
 
   renderSummary() {
-    const { order: cart } = this.props;
+    const { fulfillmentGroup } = this.props;
 
-    if (cart && cart.checkout && cart.checkout.summary) {
+    if (fulfillmentGroup && fulfillmentGroup.summary) {
       const {
         fulfillmentTotal,
         itemTotal,
         total
-      } = cart.checkout.summary;
+      } = fulfillmentGroup.summary;
 
       return (
         <OrderSummaryContainer>

--- a/src/components/OrderSummary/OrderSummary.test.js
+++ b/src/components/OrderSummary/OrderSummary.test.js
@@ -1,0 +1,77 @@
+import React from "react";
+import renderer from "react-test-renderer";
+import { ComponentsProvider } from "@reactioncommerce/components-context";
+import componentsContext from "componentsContext";
+import OrderSummary from "./OrderSummary";
+
+const testOrder = {
+  checkout: {
+    summary: {
+      itemTotal: {
+        displayAmount: "$118"
+      },
+      total: {
+        displayAmount: "$118"
+      }
+    }
+  },
+  totalItemQuantity: 3,
+  items: [
+    {
+      _id: "123",
+      attributes: [
+        { label: "Color", value: "Red" },
+        { label: "Size", value: "Medium" }
+      ],
+      compareAtPrice: {
+        displayAmount: "$45.00"
+      },
+      currentQuantity: 3,
+      imageURLs: {
+        small: "//placehold.it/150",
+        thumbnail: "//placehold.it/100"
+      },
+      isLowQuantity: true,
+      price: {
+        displayAmount: "$20.00"
+      },
+      productSlug: "/product-slug",
+      productVendor: "Patagonia",
+      title: "A Great Product",
+      quantity: 2
+    },
+    {
+      _id: "456",
+      attributes: [
+        { label: "Color", value: "Black" },
+        { label: "Size", value: "10" }
+      ],
+      currentQuantity: 500,
+      imageURLs: {
+        small: "//placehold.it/150",
+        thumbnail: "//placehold.it/100"
+      },
+      isLowQuantity: false,
+      price: {
+        displayAmount: "$78.00"
+      },
+      productVendor: "Nike",
+      productSlug: "/product-slug",
+      title: "Another Great Product",
+      quantity: 1
+    }
+  ]
+};
+
+test("basic snapshot", () => {
+  const component = renderer.create((
+    <ComponentsProvider value={componentsContext}>
+      <OrderSummary
+        order={testOrder}
+      />
+    </ComponentsProvider>
+  ));
+
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});

--- a/src/components/OrderSummary/OrderSummary.test.js
+++ b/src/components/OrderSummary/OrderSummary.test.js
@@ -1,23 +1,22 @@
 import React from "react";
 import renderer from "react-test-renderer";
+import { MuiThemeProvider } from "@material-ui/core/styles";
+import theme from "lib/theme/reactionTheme";
 import { ComponentsProvider } from "@reactioncommerce/components-context";
 import componentsContext from "componentsContext";
 import OrderSummary from "./OrderSummary";
 
-const testOrder = {
-  checkout: {
-    summary: {
-      itemTotal: {
-        displayAmount: "$118"
-      },
-      total: {
-        displayAmount: "$118"
-      }
+const testFulfillmentGroup = {
+  summary: {
+    itemTotal: {
+      displayAmount: "$118"
+    },
+    total: {
+      displayAmount: "$118"
     }
   },
-  totalItemQuantity: 3,
-  items: [
-    {
+  items: {
+    nodes: [{
       _id: "123",
       attributes: [
         { label: "Color", value: "Red" },
@@ -59,16 +58,27 @@ const testOrder = {
       productSlug: "/product-slug",
       title: "Another Great Product",
       quantity: 1
+    }]
+  },
+  payment: {
+    displayName: "Example Payment"
+  },
+  selectedFulfillmentOption: {
+    fulfillmentMethod: {
+      displayName: "Free Shipping",
+      group: "Ground"
     }
-  ]
+  }
 };
 
 test("basic snapshot", () => {
   const component = renderer.create((
     <ComponentsProvider value={componentsContext}>
-      <OrderSummary
-        order={testOrder}
-      />
+      <MuiThemeProvider theme={theme}>
+        <OrderSummary
+          fulfillmentGroup={testFulfillmentGroup}
+        />
+      </MuiThemeProvider>
     </ComponentsProvider>
   ));
 

--- a/src/components/OrderSummary/__snapshots__/OrderSummary.test.js.snap
+++ b/src/components/OrderSummary/__snapshots__/OrderSummary.test.js.snap
@@ -1,0 +1,97 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`basic snapshot 1`] = `
+<div
+  className="OrderSummary-summary-1"
+>
+  <div
+    className="OrderSummary-header-2"
+  >
+    <div
+      className="MuiGrid-container-5 MuiGrid-spacing-xs-24-29"
+    >
+      <div
+        className="MuiGrid-item-6 MuiGrid-grid-xs-3-36"
+      >
+        <h3
+          className="MuiTypography-root-102 MuiTypography-subheading-109"
+        >
+          Payment Method
+        </h3>
+      </div>
+      <div
+        className="MuiGrid-item-6 MuiGrid-grid-xs-3-36"
+      >
+        <aside
+          className="MuiTypography-root-102 MuiTypography-body2-110"
+        >
+          Example Payment
+        </aside>
+      </div>
+    </div>
+  </div>
+  <hr
+    className="MuiDivider-root-127"
+  />
+  <div
+    className="sc-bdVaJa iXzmsn"
+  >
+    <table
+      className="CartSummary__Table-cWcArh gWGRvE"
+    >
+      <tbody>
+        <tr>
+          <td
+            className="CartSummary__Td-jXBgKC bUBGM"
+          >
+            Item total
+          </td>
+          <td
+            className="CartSummary__Td-boDvWU sYgOn"
+          >
+            $118
+          </td>
+        </tr>
+        <tr>
+          <td
+            className="CartSummary__Td-jXBgKC bUBGM"
+          >
+            Shipping
+          </td>
+          <td
+            className="CartSummary__Td-boDvWU sYgOn"
+          />
+        </tr>
+        <tr>
+          <td
+            className="CartSummary__Td-jXBgKC bUBGM"
+          >
+            Tax
+          </td>
+          <td
+            className="CartSummary__Td-boDvWU sYgOn"
+          >
+            -
+          </td>
+        </tr>
+        <tr>
+          <td
+            className="CartSummary__Td-jXBgKC isuVSE"
+          >
+            Order total
+          </td>
+          <td
+            className="CartSummary__Td-boDvWU FDHoo"
+          >
+            <span
+              className="CartSummary__Total-BZUQP bdUKHv"
+            >
+              $118
+            </span>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+`;

--- a/src/components/OrderSummary/index.js
+++ b/src/components/OrderSummary/index.js
@@ -1,0 +1,1 @@
+export { default } from "./OrderSummary";

--- a/src/containers/order/fragments.gql
+++ b/src/containers/order/fragments.gql
@@ -142,6 +142,20 @@ fragment OrderCommon on Order {
     shop {
       _id
     }
+    summary {
+      fulfillmentTotal {
+        displayAmount
+      }
+      itemTotal {
+        displayAmount
+      }
+      taxTotal {
+        displayAmount
+      }
+      total {
+        displayAmount
+      }
+    }
     type
   }
   shop {

--- a/src/containers/order/fragments.gql
+++ b/src/containers/order/fragments.gql
@@ -1,6 +1,108 @@
 # Common fields for order for queries
 fragment OrderCommon on Order {
-  # ...fields
+  _id
+  account {
+    _id
+  }
+  cartId
+  createdAt
+  currencyCode
+  email
+  fulfillmentGroups {
+    _id
+    data {
+      shippingAddress
+    }
+    items {
+      _id
+      addedAt
+      createdAt
+      imageURLs {
+        large
+        medium
+        original
+        small
+        thumbnail
+      }
+      isTaxable
+      optionTitle
+      parcel {
+        containers
+        distanceUnit
+        height
+        length
+        massUnit
+        weight
+        width
+      }
+      price {
+        amount,
+        currency {
+          code
+        }
+        displayAmount
+      }
+      productConfiguration {
+        productId
+        productVariantId
+      }
+      productSlug
+      productType
+      productVendor
+      quantity
+      shop {
+        _id
+      }
+      subtotal
+      taxCode
+      title
+      updatedAt
+      variantTitle
+    }
+    payment {
+      _id
+      amount
+      createdAt
+      data
+      displayName
+      method {
+        name
+      }
+    }
+    selectedFulfillmentOption {
+      fulfillmentMethod {
+        _id
+        carrier
+        displayName
+        fulfillmentTypes
+        group
+        name
+      }
+      handlingPrice {
+        amount,
+        currency {
+          code
+        }
+        displayAmount
+      }
+      price {
+        amount,
+        currency {
+          code
+        }
+        displayAmount
+      }
+    }
+    shop {
+      _id
+    }
+    type
+  }
+  shop {
+    _id
+  }
+  totalItemQuantity
+  updatedAt
 }
 
 # Fragment for order query

--- a/src/containers/order/fragments.gql
+++ b/src/containers/order/fragments.gql
@@ -1,0 +1,9 @@
+# Common fields for order for queries
+fragment OrderCommon on Order {
+  # ...fields
+}
+
+# Fragment for order query
+fragment OrderQueryFragment on Cart {
+  ...OrderCommon
+}

--- a/src/containers/order/fragments.gql
+++ b/src/containers/order/fragments.gql
@@ -6,64 +6,110 @@ fragment OrderCommon on Order {
   }
   cartId
   createdAt
-  currencyCode
   email
   fulfillmentGroups {
     _id
     data {
-      shippingAddress
+      ... on ShippingOrderFulfillmentGroupData {
+        shippingAddress {
+          _id
+          address1
+          address2
+          city
+          company
+          country
+          fullName
+          isCommercial
+          isShippingDefault
+          phone
+          postal
+          region
+        }
+      }
     }
     items {
+      nodes {
+        _id
+        addedAt
+        createdAt
+        imageURLs {
+          large
+          medium
+          original
+          small
+          thumbnail
+        }
+        isTaxable
+        optionTitle
+        parcel {
+          containers
+          distanceUnit
+          height
+          length
+          massUnit
+          weight
+          width
+        }
+        price {
+          amount
+          currency {
+            code
+          }
+          displayAmount
+        }
+        productConfiguration {
+          productId
+          productVariantId
+        }
+        productSlug
+        productType
+        productVendor
+        quantity
+        shop {
+          _id
+        }
+        subtotal {
+          amount
+          currency {
+            code
+          }
+          displayAmount
+        }
+        taxCode
+        title
+        updatedAt
+        variantTitle
+      }
+    }
+    payment {
       _id
-      addedAt
-      createdAt
-      imageURLs {
-        large
-        medium
-        original
-        small
-        thumbnail
-      }
-      isTaxable
-      optionTitle
-      parcel {
-        containers
-        distanceUnit
-        height
-        length
-        massUnit
-        weight
-        width
-      }
-      price {
-        amount,
+      amount {
+        amount
         currency {
           code
         }
         displayAmount
       }
-      productConfiguration {
-        productId
-        productVariantId
-      }
-      productSlug
-      productType
-      productVendor
-      quantity
-      shop {
-        _id
-      }
-      subtotal
-      taxCode
-      title
-      updatedAt
-      variantTitle
-    }
-    payment {
-      _id
-      amount
       createdAt
-      data
+      data {
+        ... on StripeCardPaymentData {
+          chargeId
+          billingAddress {
+            _id
+            address1
+            address2
+            city
+            company
+            country
+            fullName
+            isCommercial
+            isShippingDefault
+            phone
+            postal
+            region
+          }
+        }
+      }
       displayName
       method {
         name
@@ -79,14 +125,14 @@ fragment OrderCommon on Order {
         name
       }
       handlingPrice {
-        amount,
+        amount
         currency {
           code
         }
         displayAmount
       }
       price {
-        amount,
+        amount
         currency {
           code
         }
@@ -105,7 +151,8 @@ fragment OrderCommon on Order {
   updatedAt
 }
 
+
 # Fragment for order query
-fragment OrderQueryFragment on Cart {
+fragment OrderQueryFragment on Order {
   ...OrderCommon
 }

--- a/src/containers/order/mutations.gql
+++ b/src/containers/order/mutations.gql
@@ -1,0 +1,3 @@
+#import "./fragments.gql"
+
+# ... add mutations below

--- a/src/containers/order/queries.gql
+++ b/src/containers/order/queries.gql
@@ -1,8 +1,8 @@
 #import "./fragments.gql"
 
 # Get an order
-query orderByOrderId($orderId: ID!, $token: String) {
-  order: orderByOrderId(cartId: $cartId, token: $token) {
+query orderById($id: ID!, $shopId: ID!, $token: String) {
+  order: orderById(id: $id, shopId: $shopId, token: $token) {
     ...OrderQueryFragment
   }
 }

--- a/src/containers/order/queries.gql
+++ b/src/containers/order/queries.gql
@@ -1,0 +1,8 @@
+#import "./fragments.gql"
+
+# Get an order
+query orderByOrderId($orderId: ID!, $token: String) {
+  order: orderByOrderId(cartId: $cartId, token: $token) {
+    ...OrderQueryFragment
+  }
+}

--- a/src/containers/order/withOrder.js
+++ b/src/containers/order/withOrder.js
@@ -2,7 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import { Query, withApollo } from "react-apollo";
 import { inject, observer } from "mobx-react";
-import { orderByOrderId } from "./queries.gql";
+import { orderById } from "./queries.gql";
 
 /**
  * withOrder higher order query component for fetching an order
@@ -29,6 +29,7 @@ export default (Component) => (
       client: PropTypes.shape({
         mutate: PropTypes.func.isRequired
       }),
+      primaryShopId: PropTypes.string.isRequired,
       routingStore: PropTypes.shape({
         query: PropTypes.shape({
           orderId: PropTypes.string.isRequired,
@@ -38,15 +39,16 @@ export default (Component) => (
     }
 
     render() {
-      const { authStore, cartStore, routingStore } = this.props;
+      const { primaryShopId, routingStore } = this.props;
 
       const variables = {
         id: routingStore.query.orderId,
-        token: routingStore.query.token || (!authStore.isAuthenticated && cartStore.anonymousCartToken)
+        shopId: primaryShopId,
+        token: routingStore.query.token || null
       };
 
       return (
-        <Query query={orderByOrderId} variables={variables}>
+        <Query query={orderById} variables={variables}>
           {({ loading: isLoading, data: orderData }) => {
             const { order } = orderData || {};
 

--- a/src/containers/order/withOrder.js
+++ b/src/containers/order/withOrder.js
@@ -1,0 +1,65 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { Query, withApollo } from "react-apollo";
+import { inject, observer } from "mobx-react";
+import { orderByOrderId } from "./queries.gql";
+
+/**
+ * withOrder higher order query component for fetching an order
+ * @name WithOrder
+ * @param {React.Component} Component to decorate
+ * @returns {React.Component} - Component with `cart` props and callbacks
+ */
+export default (Component) => (
+  @withApollo
+  @inject("cartStore", "routingStore")
+  @observer
+  class WithOrder extends React.Component {
+    static propTypes = {
+      authStore: PropTypes.shape({
+        accountId: PropTypes.string,
+        token: PropTypes.string,
+        isAuthenticated: PropTypes.bool
+      }),
+      cartStore: PropTypes.shape({
+        anonymousCartId: PropTypes.string,
+        anonymousCartToken: PropTypes.string,
+        setAnonymousCartCredentialsFromLocalStorage: PropTypes.func
+      }),
+      client: PropTypes.shape({
+        mutate: PropTypes.func.isRequired
+      }),
+      routingStore: PropTypes.shape({
+        query: PropTypes.shape({
+          orderId: PropTypes.string.isRequired,
+          token: PropTypes.string
+        })
+      })
+    }
+
+    render() {
+      const { authStore, cartStore, routingStore } = this.props;
+
+      const variables = {
+        id: routingStore.query.orderId,
+        token: routingStore.query.token || (!authStore.isAuthenticated && cartStore.anonymousCartToken)
+      };
+
+      return (
+        <Query query={orderByOrderId} variables={variables}>
+          {({ loading: isLoading, data: orderData }) => {
+            const { order } = orderData || {};
+
+            return (
+              <Component
+                {...this.props}
+                isLoading={isLoading}
+                order={order}
+              />
+            );
+          }}
+        </Query>
+      );
+    }
+  }
+);

--- a/src/lib/theme/reactionTheme.js
+++ b/src/lib/theme/reactionTheme.js
@@ -140,7 +140,17 @@ const theme = createMuiTheme({
     fontWeightLight: 200,
     fontWeightRegular: 400,
     fontWeightMedium: 700,
-    fontWeightBold: 700
+    fontWeightBold: 700,
+    body2: {
+      fontSize: 14,
+      fontWeight: 400,
+      color: "#595959"
+    },
+    subheading: {
+      fontSize: 14,
+      fontWeight: 600,
+      color: "#737373"
+    }
   }
 });
 

--- a/src/pages/checkoutComplete.js
+++ b/src/pages/checkoutComplete.js
@@ -18,28 +18,29 @@ import withCart from "containers/cart/withCart";
 import Link from "components/Link";
 import CheckoutSummary from "components/CheckoutSummary";
 import OrderFulfillmentGroups from "components/OrderFulfillmentGroups";
+import OrderSummary from "components/OrderSummary";
 
 
 const styles = (theme) => ({
-  checkoutActions: {
+  section: {
+    paddingTop: theme.spacing.unit * 2
+  },
+  sectionHeader: {
+    marginBottom: theme.spacing.unit * 3
+  },
+  title: {
+    marginBottom: theme.spacing.unit * 3
+  },
+  orderDetails: {
     width: "100%",
-    maxWidth: "600px",
-    alignSelf: "flex-end",
-    [theme.breakpoints.up("md")]: {
-      paddingRight: "2rem"
-    }
+    maxWidth: 600
   },
   cartSummary: {
-    maxWidth: "400px",
-    alignSelf: "flex-start",
-    [theme.breakpoints.up("md")]: {
-      paddingRight: "2rem"
-    }
+
   },
   checkoutContent: {
     flex: "1",
     maxWidth: theme.layout.mainContentMaxWidth,
-    padding: "1rem"
   },
   checkoutContentContainer: {
     display: "flex",
@@ -139,17 +140,13 @@ class CheckoutComplete extends Component {
     const displayEmail = hasAccount ? cart.account.emailRecords[0].address : cart.email;
 
     return (
-      <Grid container spacing={24}>
-        <Grid item xs={12} md={12}>
-          <div className={classes.flexContainer}>
-            <div className={classes.cartSummary}>
-              <OrderFulfillmentGroups
-                cart={cart}
-              />
-            </div>
-          </div>
-        </Grid>
-      </Grid>
+      <div className={classes.flexContainer}>
+        <div className={classes.cartSummary}>
+          <OrderFulfillmentGroups
+            cart={cart}
+          />
+        </div>
+      </div>
     );
   }
 
@@ -165,13 +162,7 @@ class CheckoutComplete extends Component {
 
       return (
         <Grid item xs={12}>
-          <CartSummary
-            isDense
-            displayShipping={fulfillmentTotal && fulfillmentTotal.displayAmount}
-            displaySubtotal={itemTotal && itemTotal.displayAmount}
-            displayTotal={total && total.displayAmount}
-            itemsQuantity={cart.totalItemQuantity}
-          />
+          <OrderSummary order={cart} />
         </Grid>
       );
     }
@@ -188,12 +179,23 @@ class CheckoutComplete extends Component {
           <title>{shop && shop.name} | Checkout</title>
           <meta name="description" content={shop && shop.description} />
         </Helmet>
-        <section className={classes.checkoutContentContainer}>
-          <div className={classes.checkoutContent}>
-            {this.renderCheckout()}
-            {this.renderSummary()}
+        <div className={classes.checkoutContentContainer}>
+          <div className={classes.orderDetails}>
+            <section className={classes.section}>
+              <header className={classes.sectionHeader}>
+                <Typography className={classes.title} variant="title">{"Thank you for your order"}</Typography>
+                <Typography variant="body1">{"Your order number is"} <strong>{"000"}</strong></Typography>
+                <Typography variant="body1">{"We've send a confirmation email to"} <strong>{"sample@email.com"}</strong></Typography>
+              </header>
+              <div className={classes.checkoutContent}>
+                {this.renderCheckout()}
+              </div>
+            </section>
+            <section className={classes.section}>
+              {this.renderSummary()}
+            </section>
           </div>
-        </section>
+        </div>
       </Fragment>
     );
   }

--- a/src/pages/checkoutComplete.js
+++ b/src/pages/checkoutComplete.js
@@ -7,16 +7,8 @@ import { withStyles } from "@material-ui/core/styles";
 import Typography from "@material-ui/core/Typography";
 import Grid from "@material-ui/core/Grid";
 import CartEmptyMessage from "@reactioncommerce/components/CartEmptyMessage/v1";
-import CartSummary from "@reactioncommerce/components/CartSummary/v1";
-import CheckoutActions from "components/CheckoutActions";
-import CheckoutEmailAddress from "@reactioncommerce/components/CheckoutEmailAddress/v1";
-import CheckoutTopHat from "@reactioncommerce/components/CheckoutTopHat/v1";
-import ShopLogo from "@reactioncommerce/components/ShopLogo/v1";
-import CartIcon from "mdi-material-ui/Cart";
-import LockIcon from "mdi-material-ui/Lock";
 import withCart from "containers/cart/withCart";
 import Link from "components/Link";
-import CheckoutSummary from "components/CheckoutSummary";
 import OrderFulfillmentGroups from "components/OrderFulfillmentGroups";
 import OrderSummary from "components/OrderSummary";
 
@@ -154,12 +146,6 @@ class CheckoutComplete extends Component {
     const { cart } = this.props;
 
     if (cart && cart.checkout && cart.checkout.summary) {
-      const {
-        fulfillmentTotal,
-        itemTotal,
-        total
-      } = cart.checkout.summary;
-
       return (
         <Grid item xs={12}>
           <OrderSummary order={cart} />

--- a/src/pages/checkoutComplete.js
+++ b/src/pages/checkoutComplete.js
@@ -126,7 +126,7 @@ class CheckoutComplete extends Component {
             <section className={classes.section}>
               <header className={classes.sectionHeader}>
                 <Typography className={classes.title} variant="title">{"Thank you for your order"}</Typography>
-                <Typography variant="body1">{"Your order number is"} <strong>{order && order._id}</strong></Typography>
+                <Typography variant="body1">{"Your order ID is"} <strong>{order && order._id}</strong></Typography>
                 <Typography variant="body1">{"We've send a confirmation email to"} <strong>{order && order.email}</strong></Typography>
               </header>
               <div className={classes.checkoutContent}>

--- a/src/pages/checkoutComplete.js
+++ b/src/pages/checkoutComplete.js
@@ -5,16 +5,10 @@ import { observer } from "mobx-react";
 import Helmet from "react-helmet";
 import { withStyles } from "@material-ui/core/styles";
 import Typography from "@material-ui/core/Typography";
-import Grid from "@material-ui/core/Grid";
 import withOrder from "containers/order/withOrder";
 import OrderFulfillmentGroups from "components/OrderFulfillmentGroups";
-import OrderSummary from "components/OrderSummary";
-
 
 const styles = (theme) => ({
-  section: {
-    paddingTop: theme.spacing.unit * 2
-  },
   sectionHeader: {
     marginBottom: theme.spacing.unit * 3
   },
@@ -25,9 +19,7 @@ const styles = (theme) => ({
     width: "100%",
     maxWidth: 600
   },
-  cartSummary: {
-
-  },
+  fulfillmentGroups: {},
   checkoutContent: {
     flex: "1",
     maxWidth: theme.layout.mainContentMaxWidth
@@ -111,27 +103,13 @@ class CheckoutComplete extends Component {
 
     return (
       <div className={classes.flexContainer}>
-        <div className={classes.cartSummary}>
+        <div className={classes.fulfillmentGroups}>
           <OrderFulfillmentGroups
             order={order}
           />
         </div>
       </div>
     );
-  }
-
-  renderSummary() {
-    const { order } = this.props;
-
-    if (order) {
-      return (
-        <Grid item xs={12}>
-          <OrderSummary order={order} />
-        </Grid>
-      );
-    }
-
-    return null;
   }
 
   render() {
@@ -154,9 +132,6 @@ class CheckoutComplete extends Component {
               <div className={classes.checkoutContent}>
                 {this.renderFulfillmentGroups()}
               </div>
-            </section>
-            <section className={classes.section}>
-              {this.renderSummary()}
             </section>
           </div>
         </div>

--- a/src/pages/checkoutComplete.js
+++ b/src/pages/checkoutComplete.js
@@ -6,9 +6,7 @@ import Helmet from "react-helmet";
 import { withStyles } from "@material-ui/core/styles";
 import Typography from "@material-ui/core/Typography";
 import Grid from "@material-ui/core/Grid";
-import CartEmptyMessage from "@reactioncommerce/components/CartEmptyMessage/v1";
-import withCart from "containers/cart/withCart";
-import Link from "components/Link";
+import withOrder from "containers/order/withOrder";
 import OrderFulfillmentGroups from "components/OrderFulfillmentGroups";
 import OrderSummary from "components/OrderSummary";
 
@@ -32,7 +30,7 @@ const styles = (theme) => ({
   },
   checkoutContent: {
     flex: "1",
-    maxWidth: theme.layout.mainContentMaxWidth,
+    maxWidth: theme.layout.mainContentMaxWidth
   },
   checkoutContentContainer: {
     display: "flex",
@@ -79,23 +77,18 @@ const styles = (theme) => ({
   }
 });
 
-@withCart
+@withOrder
 @observer
 @withStyles(styles, { withTheme: true })
 class CheckoutComplete extends Component {
   static propTypes = {
-    cart: PropTypes.shape({
-      account: PropTypes.object,
-      checkout: PropTypes.object,
-      email: PropTypes.string,
-      items: PropTypes.array
-    }),
     classes: PropTypes.object,
     hasMoreCartItems: PropTypes.bool,
     isLoading: PropTypes.bool,
     loadMoreCartItems: PropTypes.func,
     onChangeCartItemsQuantity: PropTypes.func,
     onRemoveCartItems: PropTypes.func,
+    order: PropTypes.object,
     shop: PropTypes.shape({
       name: PropTypes.string.isRequired,
       description: PropTypes.string
@@ -107,35 +100,20 @@ class CheckoutComplete extends Component {
 
   handleCartEmptyClick = () => Router.pushRoute("/")
 
-  renderCheckout() {
+  renderFulfillmentGroups() {
     const {
       classes,
-      cart,
-      isLoading,
+      order,
+      isLoading
     } = this.props;
 
     if (isLoading) return null;
-
-    if (!cart || (cart && Array.isArray(cart.items) && cart.items.length === 0)) {
-      return (
-        <div className={classes.emptyCartContainer}>
-          <div className={classes.emptyCart}>
-            <div>
-              <CartEmptyMessage onClick={this.handleCartEmptyClick} />
-            </div>
-          </div>
-        </div>
-      );
-    }
-
-    const hasAccount = !!cart.account;
-    const displayEmail = hasAccount ? cart.account.emailRecords[0].address : cart.email;
 
     return (
       <div className={classes.flexContainer}>
         <div className={classes.cartSummary}>
           <OrderFulfillmentGroups
-            cart={cart}
+            order={order}
           />
         </div>
       </div>
@@ -143,12 +121,12 @@ class CheckoutComplete extends Component {
   }
 
   renderSummary() {
-    const { cart } = this.props;
+    const { order } = this.props;
 
-    if (cart && cart.checkout && cart.checkout.summary) {
+    if (order) {
       return (
         <Grid item xs={12}>
-          <OrderSummary order={cart} />
+          <OrderSummary order={order} />
         </Grid>
       );
     }
@@ -157,7 +135,7 @@ class CheckoutComplete extends Component {
   }
 
   render() {
-    const { classes, shop } = this.props;
+    const { classes, shop, order } = this.props;
 
     return (
       <Fragment>
@@ -170,11 +148,11 @@ class CheckoutComplete extends Component {
             <section className={classes.section}>
               <header className={classes.sectionHeader}>
                 <Typography className={classes.title} variant="title">{"Thank you for your order"}</Typography>
-                <Typography variant="body1">{"Your order number is"} <strong>{"000"}</strong></Typography>
-                <Typography variant="body1">{"We've send a confirmation email to"} <strong>{"sample@email.com"}</strong></Typography>
+                <Typography variant="body1">{"Your order number is"} <strong>{order && order._id}</strong></Typography>
+                <Typography variant="body1">{"We've send a confirmation email to"} <strong>{order && order.email}</strong></Typography>
               </header>
               <div className={classes.checkoutContent}>
-                {this.renderCheckout()}
+                {this.renderFulfillmentGroups()}
               </div>
             </section>
             <section className={classes.section}>

--- a/src/pages/checkoutComplete.js
+++ b/src/pages/checkoutComplete.js
@@ -1,0 +1,202 @@
+import React, { Component, Fragment } from "react";
+import PropTypes from "prop-types";
+import { Router } from "routes";
+import { observer } from "mobx-react";
+import Helmet from "react-helmet";
+import { withStyles } from "@material-ui/core/styles";
+import Typography from "@material-ui/core/Typography";
+import Grid from "@material-ui/core/Grid";
+import CartEmptyMessage from "@reactioncommerce/components/CartEmptyMessage/v1";
+import CartSummary from "@reactioncommerce/components/CartSummary/v1";
+import CheckoutActions from "components/CheckoutActions";
+import CheckoutEmailAddress from "@reactioncommerce/components/CheckoutEmailAddress/v1";
+import CheckoutTopHat from "@reactioncommerce/components/CheckoutTopHat/v1";
+import ShopLogo from "@reactioncommerce/components/ShopLogo/v1";
+import CartIcon from "mdi-material-ui/Cart";
+import LockIcon from "mdi-material-ui/Lock";
+import withCart from "containers/cart/withCart";
+import Link from "components/Link";
+import CheckoutSummary from "components/CheckoutSummary";
+import OrderFulfillmentGroups from "components/OrderFulfillmentGroups";
+
+
+const styles = (theme) => ({
+  checkoutActions: {
+    width: "100%",
+    maxWidth: "600px",
+    alignSelf: "flex-end",
+    [theme.breakpoints.up("md")]: {
+      paddingRight: "2rem"
+    }
+  },
+  cartSummary: {
+    maxWidth: "400px",
+    alignSelf: "flex-start",
+    [theme.breakpoints.up("md")]: {
+      paddingRight: "2rem"
+    }
+  },
+  checkoutContent: {
+    flex: "1",
+    maxWidth: theme.layout.mainContentMaxWidth,
+    padding: "1rem"
+  },
+  checkoutContentContainer: {
+    display: "flex",
+    justifyContent: "center"
+  },
+  checkoutTitleContainer: {
+    alignSelf: "flex-end",
+    width: "8rem",
+    [theme.breakpoints.up("md")]: {
+      width: "10rem"
+    }
+  },
+  checkoutTitle: {
+    fontSize: "1.125rem",
+    color: theme.palette.reaction.black35,
+    display: "inline",
+    marginLeft: "0.3rem"
+  },
+  flexContainer: {
+    display: "flex",
+    flexDirection: "column"
+  },
+  headerContainer: {
+    display: "flex",
+    justifyContent: "space-between",
+    marginBottom: "2rem"
+  },
+  emptyCartContainer: {
+    display: "flex",
+    justifyContent: "center",
+    alignItems: "center"
+  },
+  emptyCart: {
+    display: "flex",
+    justifyContent: "center",
+    alignItems: "center",
+    width: 320,
+    height: 320
+  },
+  logo: {
+    color: theme.palette.reaction.reactionBlue,
+    marginRight: theme.spacing.unit,
+    borderBottom: `solid 5px ${theme.palette.reaction.reactionBlue200}`
+  }
+});
+
+@withCart
+@observer
+@withStyles(styles, { withTheme: true })
+class CheckoutComplete extends Component {
+  static propTypes = {
+    cart: PropTypes.shape({
+      account: PropTypes.object,
+      checkout: PropTypes.object,
+      email: PropTypes.string,
+      items: PropTypes.array
+    }),
+    classes: PropTypes.object,
+    hasMoreCartItems: PropTypes.bool,
+    isLoading: PropTypes.bool,
+    loadMoreCartItems: PropTypes.func,
+    onChangeCartItemsQuantity: PropTypes.func,
+    onRemoveCartItems: PropTypes.func,
+    shop: PropTypes.shape({
+      name: PropTypes.string.isRequired,
+      description: PropTypes.string
+    }),
+    theme: PropTypes.object.isRequired
+  };
+
+  state = {}
+
+  handleCartEmptyClick = () => Router.pushRoute("/")
+
+  renderCheckout() {
+    const {
+      classes,
+      cart,
+      isLoading,
+    } = this.props;
+
+    if (isLoading) return null;
+
+    if (!cart || (cart && Array.isArray(cart.items) && cart.items.length === 0)) {
+      return (
+        <div className={classes.emptyCartContainer}>
+          <div className={classes.emptyCart}>
+            <div>
+              <CartEmptyMessage onClick={this.handleCartEmptyClick} />
+            </div>
+          </div>
+        </div>
+      );
+    }
+
+    const hasAccount = !!cart.account;
+    const displayEmail = hasAccount ? cart.account.emailRecords[0].address : cart.email;
+
+    return (
+      <Grid container spacing={24}>
+        <Grid item xs={12} md={12}>
+          <div className={classes.flexContainer}>
+            <div className={classes.cartSummary}>
+              <OrderFulfillmentGroups
+                cart={cart}
+              />
+            </div>
+          </div>
+        </Grid>
+      </Grid>
+    );
+  }
+
+  renderSummary() {
+    const { cart } = this.props;
+
+    if (cart && cart.checkout && cart.checkout.summary) {
+      const {
+        fulfillmentTotal,
+        itemTotal,
+        total
+      } = cart.checkout.summary;
+
+      return (
+        <Grid item xs={12}>
+          <CartSummary
+            isDense
+            displayShipping={fulfillmentTotal && fulfillmentTotal.displayAmount}
+            displaySubtotal={itemTotal && itemTotal.displayAmount}
+            displayTotal={total && total.displayAmount}
+            itemsQuantity={cart.totalItemQuantity}
+          />
+        </Grid>
+      );
+    }
+
+    return null;
+  }
+
+  render() {
+    const { classes, shop } = this.props;
+
+    return (
+      <Fragment>
+        <Helmet>
+          <title>{shop && shop.name} | Checkout</title>
+          <meta name="description" content={shop && shop.description} />
+        </Helmet>
+        <section className={classes.checkoutContentContainer}>
+          <div className={classes.checkoutContent}>
+            {this.renderCheckout()}
+            {this.renderSummary()}
+          </div>
+        </section>
+      </Fragment>
+    );
+  }
+}
+
+export default CheckoutComplete;

--- a/src/routes.js
+++ b/src/routes.js
@@ -4,6 +4,7 @@ routes
   .add("home", "/", "index")
   .add("cart", "/cart", "cart")
   .add("checkout", "/cart/checkout", "checkout")
+  .add("checkout-complete", "/checkout/order/:orderId", "checkoutComplete")
   .add("login", "/login", "login")
   .add("shopProduct", "/shop/:shopSlug/product/:slugOrId", "product")
   .add("product", "/product/:slugOrId/:variantId?", "product")

--- a/src/routes.js
+++ b/src/routes.js
@@ -4,7 +4,7 @@ routes
   .add("home", "/", "index")
   .add("cart", "/cart", "cart")
   .add("checkout", "/cart/checkout", "checkout")
-  .add("checkout-complete", "/checkout/order/:orderId", "checkoutComplete")
+  .add("checkoutComplete", "/checkout/order/:orderId", "checkoutComplete")
   .add("login", "/login", "login")
   .add("shopProduct", "/shop/:shopSlug/product/:slugOrId", "product")
   .add("product", "/product/:slugOrId/:variantId?", "product")


### PR DESCRIPTION
Resolves #244 
Impact: **minor**
Type: **feature**

## Issue

Add a checkout complete page

## Solution

Added a checkout complete page using many existing components from cart and checkout.

## Breaking changes

none

## Testing

1. In Reaction, sign in, add items to cart and checkout
1. Run through the checkout process and create an order
1. After the order is created, open Robo3T and look for the newly created order
1. Copy the order id and base64 encode it as `reaction/order:<order-id>`
1. In the starter kit, ensure you're signed in as the same user as reaction with the `meteor-login-token`
1. Then navigate to `http://localhost:4000/checkout/order/<order-id>`
1. See the checkout completed page with all relevant data