### PR TITLE
feat: Open mini-cart on add to cart

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 NODE_ENV=development
-INTERNAL_GRAPHQL_URL=http://devserver.reaction-api:3000/graphql-alpha
+INTERNAL_GRAPHQL_URL=http://reaction.reaction-api:3000/graphql-alpha
 EXTERNAL_GRAPHQL_URL=http://localhost:3000/graphql-alpha
 FAVICON_URL=https://assets.reactioncommerce.com/favicon
 PLACEHOLDER_IMAGE_URL_GALLERY=/resources/placeholder.gif

--- a/src/components/Layout/Layout.js
+++ b/src/components/Layout/Layout.js
@@ -4,7 +4,6 @@ import Helmet from "react-helmet";
 import { withStyles } from "@material-ui/core/styles";
 import Header from "components/Header";
 import Footer from "components/Footer";
-import { Cart } from "components/Cart";
 
 const styles = (theme) => ({
   root: {
@@ -52,7 +51,6 @@ class Layout extends Component {
           </main>
           <Footer />
         </div>
-        <Cart />
       </React.Fragment>
     );
   }

--- a/src/components/MiniCart/MiniCart.test.js
+++ b/src/components/MiniCart/MiniCart.test.js
@@ -79,11 +79,17 @@ const authStore = {
   isAuthenticated: false
 };
 
+const uiStore = {
+  openCart() {},
+  closeCart() {},
+  isCartOpen: false
+};
+
 test("basic snapshot", () => {
   const component = renderer.create((
     <MockedProvider mocks={mocks} addTypename={false}>
       <MuiThemeProvider theme={theme}>
-        <Provider primaryShopId={shop._id} cartStore={cartStore} authStore={authStore} shop={shop}>
+        <Provider primaryShopId={shop._id} cartStore={cartStore} authStore={authStore} shop={shop} uiStore={uiStore}>
           <MiniCart />
         </Provider>
       </MuiThemeProvider>

--- a/src/components/MiniCart/__snapshots__/MiniCart.test.js.snap
+++ b/src/components/MiniCart/__snapshots__/MiniCart.test.js.snap
@@ -1,43 +1,45 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`basic snapshot 1`] = `
-<button
-  className="MuiButtonBase-root-10 MuiIconButton-root-4 MuiIconButton-colorInherit-5"
-  disabled={false}
-  onBlur={[Function]}
-  onClick={[Function]}
-  onFocus={[Function]}
-  onKeyDown={[Function]}
-  onKeyUp={[Function]}
-  onMouseDown={[Function]}
-  onMouseEnter={[Function]}
-  onMouseLeave={[Function]}
-  onMouseUp={[Function]}
-  onTouchEnd={[Function]}
-  onTouchMove={[Function]}
-  onTouchStart={[Function]}
-  tabIndex="0"
-  type="button"
->
-  <span
-    className="MuiIconButton-label-9"
+<div>
+  <button
+    className="MuiButtonBase-root-10 MuiIconButton-root-4 MuiIconButton-colorInherit-5"
+    disabled={false}
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onKeyDown={[Function]}
+    onKeyUp={[Function]}
+    onMouseDown={[Function]}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
+    onMouseUp={[Function]}
+    onTouchEnd={[Function]}
+    onTouchMove={[Function]}
+    onTouchStart={[Function]}
+    tabIndex="0"
+    type="button"
   >
-    <svg
-      aria-hidden="true"
-      className="MuiSvgIcon-root-13"
-      color={undefined}
-      focusable="false"
-      viewBox="0 0 24 24"
+    <span
+      className="MuiIconButton-label-9"
     >
-      <g>
-        <path
-          d="M17,18C15.89,18 15,18.89 15,20C15,21.1 15.9,22 17,22C18.1,22 19,21.1 19,20C19,18.89 18.1,18 17,18M1,2V4H3L6.6,11.59L5.24,14.04C5.09,14.32 5,14.65 5,15C5,16.1 5.9,17 7,17H19V15H7.42C7.28,15 7.17,14.89 7.17,14.75C7.17,14.7 7.18,14.66 7.2,14.63L8.1,13H15.55C16.3,13 16.96,12.58 17.3,11.97L20.88,5.5C20.95,5.34 21,5.17 21,5C21,4.45 20.55,4 20,4H5.21L4.27,2M7,18C5.89,18 5,18.89 5,20C5,21.1 5.9,22 7,22C8.1,22 9,21.1 9,20C9,18.89 8.1,18 7,18Z"
-        />
-      </g>
-    </svg>
-  </span>
-  <span
-    className="MuiTouchRipple-root-20"
-  />
-</button>
+      <svg
+        aria-hidden="true"
+        className="MuiSvgIcon-root-13"
+        color={undefined}
+        focusable="false"
+        viewBox="0 0 24 24"
+      >
+        <g>
+          <path
+            d="M17,18C15.89,18 15,18.89 15,20C15,21.1 15.9,22 17,22C18.1,22 19,21.1 19,20C19,18.89 18.1,18 17,18M1,2V4H3L6.6,11.59L5.24,14.04C5.09,14.32 5,14.65 5,15C5,16.1 5.9,17 7,17H19V15H7.42C7.28,15 7.17,14.89 7.17,14.75C7.17,14.7 7.18,14.66 7.2,14.63L8.1,13H15.55C16.3,13 16.96,12.58 17.3,11.97L20.88,5.5C20.95,5.34 21,5.17 21,5C21,4.45 20.55,4 20,4H5.21L4.27,2M7,18C5.89,18 5,18.89 5,20C5,21.1 5.9,22 7,22C8.1,22 9,21.1 9,20C9,18.89 8.1,18 7,18Z"
+          />
+        </g>
+      </svg>
+    </span>
+    <span
+      className="MuiTouchRipple-root-20"
+    />
+  </button>
+</div>
 `;

--- a/src/components/ProductDetail/ProductDetail.js
+++ b/src/components/ProductDetail/ProductDetail.js
@@ -59,7 +59,7 @@ class ProductDetail extends Component {
     }),
     theme: PropTypes.object,
     uiStore: PropTypes.object.isRequired,
-    width: PropTypes.number.isRequired
+    width: PropTypes.string.isRequired
   }
 
   componentDidMount() {

--- a/src/components/ProductDetail/ProductDetail.js
+++ b/src/components/ProductDetail/ProductDetail.js
@@ -111,6 +111,8 @@ class ProductDetail extends Component {
       currencyCode,
       product,
       uiStore: {
+        openCart,
+        closeCart,
         pdpSelectedOptionId,
         pdpSelectedVariantId
       }
@@ -140,6 +142,9 @@ class ProductDetail extends Component {
         }
       ]);
     }
+
+    openCart(); // Open the cart
+    closeCart(3000); // Close the cart after a 3 second delay
   };
 
   /**

--- a/src/components/ProductDetail/ProductDetail.js
+++ b/src/components/ProductDetail/ProductDetail.js
@@ -2,6 +2,7 @@ import React, { Component, Fragment } from "react";
 import PropTypes from "prop-types";
 import { withStyles } from "@material-ui/core/styles";
 import Grid from "@material-ui/core/Grid";
+import withWidth, { isWidthUp } from "@material-ui/core/withWidth";
 import { inject, observer } from "mobx-react";
 import Helmet from "react-helmet";
 import track from "lib/tracking/track";
@@ -33,6 +34,7 @@ const styles = (theme) => ({
  * @param {Object} props Component props
  * @returns {React.Component} React component node that represents a product detail view
  */
+@withWidth()
 @withStyles(styles, { withTheme: true })
 @inject("routingStore", "uiStore")
 @track()
@@ -56,7 +58,8 @@ class ProductDetail extends Component {
       edges: PropTypes.arrayOf(PropTypes.object).isRequired
     }),
     theme: PropTypes.object,
-    uiStore: PropTypes.object.isRequired
+    uiStore: PropTypes.object.isRequired,
+    width: PropTypes.number.isRequired
   }
 
   componentDidMount() {
@@ -115,7 +118,8 @@ class ProductDetail extends Component {
         closeCart,
         pdpSelectedOptionId,
         pdpSelectedVariantId
-      }
+      },
+      width
     } = this.props;
 
     // Get selected variant or variant option
@@ -143,8 +147,10 @@ class ProductDetail extends Component {
       ]);
     }
 
-    openCart(); // Open the cart
-    closeCart(3000); // Close the cart after a 3 second delay
+    if (isWidthUp("md", width)) {
+      openCart(); // Open the cart
+      closeCart(3000); // Close the cart after a 3 second delay
+    }
   };
 
   /**

--- a/src/lib/stores/UIStore.js
+++ b/src/lib/stores/UIStore.js
@@ -86,8 +86,45 @@ class UIStore {
     this.pdpSelectedOptionId = optionId;
   }
 
-  @action closeCart() {
-    this.isCartOpen = false;
+  /**
+   * @name openCart
+   * @summary Open the mini-cart drawer
+   * @returns {undefined} No return
+   */
+  @action openCart = () => {
+    this.isCartOpen = true;
+    this.clearOpenCartTimeout();
+  }
+
+  /**
+   * @name closeCart
+   * @summary Close the mini-cart drawer, optionally supply a delay
+   * @param {Number} delay Time in milliseconds to keep cart open after which it will be closed
+   * @returns {undefined} No return
+   */
+  @action closeCart = (delay = 500) => {
+    this.openCartTimeout = setTimeout(action(() => {
+      this.isCartOpen = false;
+      this.clearOpenCartTimeout();
+    }), delay);
+  }
+
+  @action openCartWithTimeout = (delay = 3000) => {
+    this.openCart();
+
+    this.openCartTimeout = setTimeout(action(() => {
+      this.isCartOpen = false;
+      clearTimeout(this.openCartTimeout);
+    }), delay);
+  }
+
+  /**
+   * @name clearOpenCartTimeout
+   * @summary Clear the cart open timeout
+   * @returns {undefined} No return
+   */
+  clearOpenCartTimeout = () => {
+    this.openCartTimeout && clearTimeout(this.openCartTimeout);
   }
 
   @action toggleCartOpen() {


### PR DESCRIPTION
Resolves #255
Impact: **minor**
Type: **feature**

## Issue

Open the mini-cart when the add to cart button is clicked

## Solution

- Move cart state management to the `uiStore`
- Open the cart using the `uiStore`, close it on a delay

## Breaking changes

none

## Testing

### Desktop

1. Hover over the cart icon, it should open
1. Move the mouse away from the cart, it should close in 500ms (quickly)
1. Add an item to the cart, see the mini-cart open
1. Mini-cart should close after 3 seconds (so... not so quickly)
1. Add another item to the cart
1. Mouse over the mini-cart before it closes
1. The mini-cart should **not** close after 3 seconds
1. Mouse off of the mini-cart
1. The mini-cart should close in 500ms

### Mobile

1. Resize the window to a mobile size
1. Add an item to the cart
1. You should still see the mobile add to cart slide-out and no mini-cart
