### PR TITLE
chore: Rename the reaction-api Docker network

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 NODE_ENV=development
-INTERNAL_GRAPHQL_URL=http://reaction.reaction-api:3000/graphql-alpha
+INTERNAL_GRAPHQL_URL=http://reaction.api.reaction.localhost:3000/graphql-alpha
 EXTERNAL_GRAPHQL_URL=http://localhost:3000/graphql-alpha
 FAVICON_URL=https://assets.reactioncommerce.com/favicon
 PLACEHOLDER_IMAGE_URL_GALLERY=/resources/placeholder.gif

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ _Follow steps as necessary. If you already have Reaction installed, you may be a
 
     You'll need to create a docker network for the GraphQL service and the Reaction Storefront to communicate
     ```
-    docker network create reaction-api
+    docker network create api.reaction.localhost
     ```
     You can run `docker network ls` to verify the network has been created.
 
@@ -128,7 +128,7 @@ Sometimes we need to test [`reaction-component-library`](https://github.com/reac
 1. After the build is done, `cd` into the new `dist` folder it just built and run `yarn link` to allow the library to be installed into the starterkit. This will link `@reactioncommerce/components`
 1. Inside the `reaction-next-starterkit` repo, temporarily rename your `.yarnrc` file to anything else (i.e. `.yarnrc-temp`)
 1. Run `yarn install` and then the command `yarn link "@reactioncommerce/components"` to set the local version as an override of the published npm version
-1. Inside your `.env` file, change `INTERNAL_GRAPHQL_URL` to equal `http://localhost:3030/graphql-alpha`, the same as the `EXTERNAL_GRAPHQL_URL` 
+1. Inside your `.env` file, change `INTERNAL_GRAPHQL_URL` to equal `http://localhost:3030/graphql-alpha`, the same as the `EXTERNAL_GRAPHQL_URL`
 1. Start the starterkit locally by running the command `export $(cat .env | xargs) && yarn dev`
 1. Your starterkit should now be running at `localhost:4000`
     - If you see errors about not being able to find peer dependency packages, that seems to be an issues with yarn linking. You can just temporarily `yarn add` each of those packages in the component library `package/dist` folder. (This folder is gitignored anyway.)
@@ -164,7 +164,7 @@ docker build -t reaction-storefront --build-arg BUILD_ENV=production .
 To start the app in production mode execute:
 
 ```
-docker run -d --name storefront -p ${port}:4000 --env-file .env --network reaction-api reaction-storefront
+docker run -d --name storefront -p ${port}:4000 --env-file .env --network api.reaction.localhost reaction-storefront
 ```
 
 To stop the docker container after starting it with the above command

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,9 @@
 version: '3.4'
 
 networks:
-  reaction-api:
+  api:
     external:
-      name: reaction-api
+      name: api.reaction.localhost
 
 services:
   web:
@@ -17,7 +17,7 @@ services:
     environment:
       REACTION_APP_NAME: "reaction-next-starterkit.web"
     networks:
-      reaction-api:
+      api:
         aliases:
           - storefront
     ports:

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test:unit": "NODE_ENV=jesttest jest",
     "test:unit:watch": "NODE_ENV=jesttest jest --watchAll",
     "test:integration": "mocha tests/integration",
-    "test:link": "blc http://web.reaction-api:4000 -ro -filter=3 -e"
+    "test:link": "blc http://web.api.reaction.localhost:4000 -ro -filter=3 -e"
   },
   "eslintConfig": {
     "extends": [


### PR DESCRIPTION
Renames the Docker network on which the GraphQL enabled web services are
attached.

Platform networks in the Docker environment should be named as
*.reaction.localhost. The localhost TLD is reserved and guaranteed to
not conflict with a real TLD.

ref: reactioncommerce/reaction#4447

Resolves #issueNumber
Impact: major
Type: chore

**Merge Considerations**

- The network is only updated in newly created projects.
- To enable network communication, other projects must use this new network name.
- PRs related to reactioncommerce/reaction#4447 should be coordinated.
