### PR TITLE
fix: null shop description & unexpected token

### DIFF
--- a/src/containers/cart/fragments.gql
+++ b/src/containers/cart/fragments.gql
@@ -56,9 +56,6 @@ fragment CartCommon on Cart {
         }
       }
     }
-    payments{
-      _id
-    }
     summary {
       fulfillmentTotal {
         displayAmount

--- a/src/pages/_document.js
+++ b/src/pages/_document.js
@@ -85,7 +85,6 @@ class HTMLDocument extends Document {
         src: "https://js.stripe.com/v3/"
       }
     ];
-
     return (
       <html lang="en" {...htmlAttrs}>
         <Head>
@@ -93,7 +92,12 @@ class HTMLDocument extends Document {
           {meta.map((tag) => <meta {...tag} />)}
           {links.map((link) => <link {...link} />)}
           {scripts.map((script) =>
-            (script.innerHTML ? <script type={script.type}>{script.innerHTML}</script> : <script {...script} />))}
+            (script.innerHTML ? (
+            /* eslint-disable-next-line */
+              <script type={script.type} dangerouslySetInnerHTML={{ __html: script.innerHTML }} />
+            ) : (
+              <script {...script} />
+            )))}
           {helmet.base.toComponent()}
           {helmet.title.toComponent()}
           {helmet.meta.toComponent()}

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -58,11 +58,12 @@ class Shop extends Component {
     const { catalogItems, catalogItemsPageInfo, uiStore, routingStore: { query }, shop } = this.props;
     const pageSize = query && inPageSizes(query.limit) ? parseInt(query.limit, 10) : uiStore.pageSize;
     const sortBy = query && query.sortby ? query.sortby : uiStore.sortBy;
+    const pageTitle = shop && shop.description ? `${shop.name} | ${shop.description}` : shop.name;
 
     return (
       <Fragment>
         <Helmet
-          title={`${shop && shop.name} | ${shop && shop.description}`}
+          title={pageTitle}
           meta={[{ name: "description", content: shop && shop.description }]}
         />
         <ProductGrid


### PR DESCRIPTION
Resolves N/A
Impact: **minor**
Type: **bugfix**

## Issue
  1. If a reaction shop didn't have a shop description set the storefront's index page would display a page title of "Reaction | null".
  2. Adding scripts with innerHTML was causing an unexpected token error in the browser console.

## Solution
 1. Updated how the index page title is created to only add the ` | <shop.description>` to the end of the description if the property is set.
 2. Updated how the innerHTML is set on `<script />` tags to use `dangerouslySetInnerHTML` this prevents the output JS from being formatted incorrectly causing the syntax error.

## Breaking changes
N/A

## Testing
1. Load the storefront's index page and verify that either: `<shop.name> | <shop.description>` or `<shop.name>` is the page title pattern.
2. In Reaction as an admin add/remove the shop's description and refresh the storefront. You should see those changes reflected in the index page title.
3. Open the browser console and verify the is no longer an `Unexpected token ;` error being shown.