### PR TITLE
fix: sortBy filter doesn't reset pageSize filter

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@material-ui/core": "^1.5.0",
-    "@reactioncommerce/components": "0.35.1",
+    "@reactioncommerce/components": "0.35.2",
     "@reactioncommerce/components-context": "^1.0.0",
     "@segment/snippet": "^4.3.1",
     "apollo-cache-inmemory": "^1.1.11",

--- a/src/components/CheckoutSummary/__snapshots__/CheckoutSummary.test.js.snap
+++ b/src/components/CheckoutSummary/__snapshots__/CheckoutSummary.test.js.snap
@@ -12,7 +12,7 @@ exports[`basic snapshot 1`] = `
         className="CartItems__Items-gEXRwN gdnVAG"
       >
         <div
-          className="CartItem__Item-ghDCXl cfXPgA"
+          className="CartItem__Item-ghDCXl gKDHYG"
         >
           <a
             href="/product-slug"
@@ -120,7 +120,7 @@ exports[`basic snapshot 1`] = `
           </div>
         </div>
         <div
-          className="CartItem__Item-ghDCXl cfXPgA"
+          className="CartItem__Item-ghDCXl gKDHYG"
         >
           <a
             href="/product-slug"

--- a/src/components/OrderFulfillmentGroup/__snapshots__/OrderFulfillmentGroup.test.js.snap
+++ b/src/components/OrderFulfillmentGroup/__snapshots__/OrderFulfillmentGroup.test.js.snap
@@ -38,7 +38,7 @@ Array [
         className="CartItems__Items-gEXRwN gdnVAG"
       >
         <div
-          className="CartItem__Item-ghDCXl cfXPgA"
+          className="CartItem__Item-ghDCXl gKDHYG"
         >
           <a
             href="/product-slug"
@@ -146,7 +146,7 @@ Array [
           </div>
         </div>
         <div
-          className="CartItem__Item-ghDCXl cfXPgA"
+          className="CartItem__Item-ghDCXl gKDHYG"
         >
           <a
             href="/product-slug"

--- a/src/components/OrderFulfillmentGroups/__snapshots__/OrderFulfillmentGroups.test.js.snap
+++ b/src/components/OrderFulfillmentGroups/__snapshots__/OrderFulfillmentGroups.test.js.snap
@@ -38,7 +38,7 @@ Array [
         className="CartItems__Items-gEXRwN gdnVAG"
       >
         <div
-          className="CartItem__Item-ghDCXl cfXPgA"
+          className="CartItem__Item-ghDCXl gKDHYG"
         >
           <a
             href="/product-slug"
@@ -146,7 +146,7 @@ Array [
           </div>
         </div>
         <div
-          className="CartItem__Item-ghDCXl cfXPgA"
+          className="CartItem__Item-ghDCXl gKDHYG"
         >
           <a
             href="/product-slug"

--- a/src/lib/stores/RoutingStore.js
+++ b/src/lib/stores/RoutingStore.js
@@ -35,11 +35,13 @@ export default class RoutingStore {
    */
   @observable tag = {};
 
-  @action setTag = (tag) => {
+  @action
+  setTag = (tag) => {
     this.tag = tag;
-  }
+  };
 
-  @action updateRoute({ pathname, query }) {
+  @action
+  updateRoute({ pathname, query }) {
     this.pathname = pathname;
     this.query = query;
   }
@@ -50,14 +52,15 @@ export default class RoutingStore {
    * @param {String} search Search query string first=1&after=123
    * @returns {String} full url with query string
    */
-  @action setSearch(search) {
+  @action
+  setSearch(search) {
     const _query = { ...toJS(this.query), ...search };
     const _slug = _query.slug;
+    const _limit = parseInt(_query.limit, 10);
     delete _query.slug;
 
     // Validate limit
     _query.limit = inPageSizes(_query.limit) ? _query.limit : PAGE_SIZES._20;
-
     let urlQueryString = "";
     Object.keys(_query).forEach((key, index, arr) => {
       urlQueryString += `${key}=${_query[key]}`;

--- a/src/lib/stores/RoutingStore.js
+++ b/src/lib/stores/RoutingStore.js
@@ -60,7 +60,7 @@ export default class RoutingStore {
     delete _query.slug;
 
     // Validate limit
-    _query.limit = inPageSizes(_query.limit) ? _query.limit : PAGE_SIZES._20;
+    _query.limit = inPageSizes(_limit) ? _limit : PAGE_SIZES._20;
     let urlQueryString = "";
     Object.keys(_query).forEach((key, index, arr) => {
       urlQueryString += `${key}=${_query[key]}`;

--- a/src/pages/_document.js
+++ b/src/pages/_document.js
@@ -76,10 +76,10 @@ class HTMLDocument extends Document {
         type: "text/javascript",
         innerHTML: provider.renderScript()
       })),
-      {
-        type: "text/javascript",
-        src: `${keycloakConfig.url}/js/keycloak.js`
-      },
+      // {
+      //   type: "text/javascript",
+      //   src: `${keycloakConfig.url}/js/keycloak.js`
+      // },
       {
         type: "text/javascript",
         src: "https://js.stripe.com/v3/"

--- a/src/pages/_document.js
+++ b/src/pages/_document.js
@@ -5,7 +5,7 @@ import flush from "styled-jsx/server";
 import Helmet from "react-helmet";
 import { Provider } from "mobx-react";
 import analyticsProviders from "analytics";
-import getConfig from "next/config";
+// import getConfig from "next/config";
 import rootMobxStores from "../lib/stores";
 import favicons from "../lib/utils/favicons";
 import globalStyles from "../lib/theme/globalStyles";
@@ -53,8 +53,8 @@ class HTMLDocument extends Document {
   render() {
     const { pageContext, helmet } = this.props;
     const htmlAttrs = helmet.htmlAttributes.toComponent();
-    const { publicRuntimeConfig } = getConfig();
-    const { keycloakConfig } = publicRuntimeConfig;
+    // const { publicRuntimeConfig } = getConfig();
+    // const { keycloakConfig } = publicRuntimeConfig;
     const links = [
       { rel: "canonical", href: process.env.CANONICAL_URL },
       { rel: "stylesheet", href: "https://fonts.googleapis.com/css?family=Source+Sans+Pro:200,400,700" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -969,9 +969,9 @@
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@reactioncommerce/components-context/-/components-context-1.0.0.tgz#587764cf0d1b0312c786b8e4657379de02e13845"
 
-"@reactioncommerce/components@0.35.1":
-  version "0.35.1"
-  resolved "https://registry.yarnpkg.com/@reactioncommerce/components/-/components-0.35.1.tgz#8570b721b1479ce7a37911d9371f647b90abde42"
+"@reactioncommerce/components@0.35.2":
+  version "0.35.2"
+  resolved "https://registry.yarnpkg.com/@reactioncommerce/components/-/components-0.35.2.tgz#c86d0bd48c077dc0c878e992d2262d96eeb6bae0"
   dependencies:
     "@material-ui/core" "^1.4.0"
     lodash.debounce "^4.0.8"


### PR DESCRIPTION
Resolves #263 
Impact: **minor**
Type: **bugfix**

## Issue
On the catalog grid If a `pageSize` filter had been set and then the `sortBy` filter was changed the `pageSize` filter would be reset back to 20. The issue was being caused by trying to compare the `query.limit` which is a string to an int while validating the limit inside the `routingStore`, this validation check would return false every time the `sortBy` field was changed reseting the `pageSize` to `20`. 

## Solution
Make sure `_query.limit` is converted to an int before the `inPageSizes` validation function is used.

## Breaking changes
N/A

## Testing
1. Visit storefront and change the `pageSize` filter to 60 or 100.
2. Now change the `sortBy` filter to HI2LO or LO2HI, the products should reorg and the `pageSize` filter should persist.
3. Load the page directly with the query string in the URL, verify the filter values match the query string in the URL.