### PR TITLE
fix: remove global styles

### DIFF
--- a/src/lib/theme/globalStyles.js
+++ b/src/lib/theme/globalStyles.js
@@ -1,9 +1,0 @@
-export default
-<style global jsx>
-  {`
-    a {
-      color: inherit;
-      text-decoration: none;
-    }
-  `}
-</style>;

--- a/src/pages/_document.js
+++ b/src/pages/_document.js
@@ -8,7 +8,6 @@ import analyticsProviders from "analytics";
 import getConfig from "next/config";
 import rootMobxStores from "../lib/stores";
 import favicons from "../lib/utils/favicons";
-import globalStyles from "../lib/theme/globalStyles";
 
 class HTMLDocument extends Document {
   static getInitialProps = (ctx) => {
@@ -105,7 +104,6 @@ class HTMLDocument extends Document {
           {helmet.style.toComponent()}
           {helmet.script.toComponent()}
           {helmet.noscript.toComponent()}
-          {globalStyles}
         </Head>
         <body>
           <Main />


### PR DESCRIPTION
Resolves #292 
Impact: **minor**
Type: **bugfix**

## Issue

Default styling for links shows up on occasion.

## Solution

Remove global styles. Links look fine without it?

## Breaking changes

none

## Testing
1. Start app
2. Ensure links across app look as they should