### PR TITLE
Loading states, styled-components SSR, SSR screen width check, fix getInitialProps

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -16,6 +16,7 @@
   "env": {
     "development": {
       "plugins": [
+        "babel-plugin-styled-components",
         ["module-resolver", {"root": ["./src", "./config"]}],
         "transform-decorators-legacy",
         "transform-class-properties"
@@ -23,6 +24,7 @@
     },
     "production": {
       "plugins": [
+        "babel-plugin-styled-components",
         ["module-resolver", {"root": ["./src", "./config"]}],
         ["@babel/plugin-proposal-decorators", { "legacy": true }],
         ["@babel/plugin-proposal-class-properties", { "loose": true }]
@@ -30,6 +32,7 @@
     },
     "jesttest": {
       "plugins": [
+        "babel-plugin-styled-components",
         ["module-resolver", {"root": ["./src", "./config"]}],
         ["@babel/plugin-proposal-decorators", { "legacy": true }],
         ["@babel/plugin-proposal-class-properties", { "loose": true }]

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@material-ui/core": "^3.1.0",
-    "@reactioncommerce/components": "0.35.2",
+    "@reactioncommerce/components": "^0.36.0",
     "@reactioncommerce/components-context": "^1.0.0",
     "@segment/snippet": "^4.3.1",
     "apollo-cache-inmemory": "^1.1.11",
@@ -85,6 +85,7 @@
     "babel-eslint": "^8.2.2",
     "babel-jest": "^22.4.3",
     "babel-plugin-module-resolver": "^3.1.1",
+    "babel-plugin-styled-components": "^1.7.1",
     "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-plugin-transform-decorators-legacy": "^1.3.4",
     "broken-link-checker": "^0.7.8",

--- a/src/components/Entry/__snapshots__/Entry.test.js.snap
+++ b/src/components/Entry/__snapshots__/Entry.test.js.snap
@@ -11,7 +11,7 @@ exports[`basic snapshot 1`] = `
       className="Entry-loginWrapper-1"
     >
       <h2
-        className="MuiTypography-root-101 MuiTypography-title-107 MuiTypography-gutterBottom-118"
+        className="MuiTypography-root-101 MuiTypography-title-107 MuiTypography-gutterBottom-119"
       >
         Returning Customer
       </h2>
@@ -128,7 +128,7 @@ exports[`basic snapshot 1`] = `
       className="Entry-guestWrapper-3"
     >
       <h2
-        className="MuiTypography-root-101 MuiTypography-title-107 MuiTypography-gutterBottom-118"
+        className="MuiTypography-root-101 MuiTypography-title-107 MuiTypography-gutterBottom-119"
       >
         Guest Checkout
       </h2>

--- a/src/components/OrderFulfillmentGroup/__snapshots__/OrderFulfillmentGroup.test.js.snap
+++ b/src/components/OrderFulfillmentGroup/__snapshots__/OrderFulfillmentGroup.test.js.snap
@@ -280,7 +280,7 @@ Array [
         className="MuiDivider-root-135"
       />
       <div
-        className="sc-bdVaJa iXzmsn"
+        className="OrderSummary__OrderSummaryContainer-sc-1cvbk1h-0 hsLQId"
       >
         <table
           className="CartSummary__Table-cWcArh gWGRvE"

--- a/src/components/OrderFulfillmentGroups/__snapshots__/OrderFulfillmentGroups.test.js.snap
+++ b/src/components/OrderFulfillmentGroups/__snapshots__/OrderFulfillmentGroups.test.js.snap
@@ -280,7 +280,7 @@ Array [
         className="MuiDivider-root-135"
       />
       <div
-        className="sc-bdVaJa iXzmsn"
+        className="OrderSummary__OrderSummaryContainer-sc-1cvbk1h-0 hsLQId"
       >
         <table
           className="CartSummary__Table-cWcArh gWGRvE"

--- a/src/components/OrderSummary/__snapshots__/OrderSummary.test.js.snap
+++ b/src/components/OrderSummary/__snapshots__/OrderSummary.test.js.snap
@@ -34,7 +34,7 @@ exports[`basic snapshot 1`] = `
     className="MuiDivider-root-128"
   />
   <div
-    className="sc-bdVaJa iXzmsn"
+    className="OrderSummary__OrderSummaryContainer-sc-1cvbk1h-0 hsLQId"
   >
     <table
       className="CartSummary__Table-cWcArh gWGRvE"

--- a/src/components/PageLoading/PageLoading.js
+++ b/src/components/PageLoading/PageLoading.js
@@ -25,18 +25,18 @@ class PageLoading extends Component {
     delayIsDone: false
   }
 
-  componentWillUnmount() {
-    if (this.timeout) {
-      clearTimeout(this.timeout);
-    }
-  }
-
   componentDidMount() {
     this.timeout = setTimeout(() => {
       this.setState({
         delayIsDone: true
       });
     }, 800);
+  }
+
+  componentWillUnmount() {
+    if (this.timeout) {
+      clearTimeout(this.timeout);
+    }
   }
 
   renderSpinner() {
@@ -66,7 +66,7 @@ class PageLoading extends Component {
             keySplines="0.45 0 0.9 0.55;0 0.45 0.55 0.9"
             begin="0s"
             repeatCount="indefinite"
-          ></animate>
+          />
         </circle>
       </svg>
     );

--- a/src/components/PageLoading/PageLoading.js
+++ b/src/components/PageLoading/PageLoading.js
@@ -1,0 +1,69 @@
+import React, { Component } from "react";
+
+class PageLoading extends Component {
+  state = {
+    delayIsDone: false
+  }
+
+  componentWillUnmount() {
+    if (this.timeout) {
+      clearTimeout(this.timeout);
+    }
+  }
+
+
+  componentDidMount() {
+    this.timeout = setTimeout(() => {
+      this.setState({
+        delayIsDone: true
+      });
+    }, 800);
+  }
+
+  renderSpinner() {
+    return (
+      <svg
+        className="lds-ball"
+        height="150px"
+        preserveAspectRatio="xMidYMid"
+        style={{ background: "none" }}
+        viewBox="0 0 100 100"
+        width="150px"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <circle
+          cx="50"
+          cy="36.7846"
+          fill="#58A8DB"
+          ng-attr-cy="{{config.cy}}"
+          ng-attr-fill="{{config.color}}"
+          ng-attr-r="{{config.radius}}"
+          r="13"
+        >
+          <animate
+            attributeName="cy"
+            calcMode="spline"
+            values="23;77;23"
+            keyTimes="0;0.5;1"
+            dur="1.2"
+            keySplines="0.45 0 0.9 0.55;0 0.45 0.55 0.9"
+            begin="0s"
+            repeatCount="indefinite"
+          ></animate>
+        </circle>
+      </svg>
+    );
+  }
+
+  render() {
+    const { delayIsDone } = this.state;
+
+    return (
+      <div style={{ height: "75vh", display: "flex", alignItems: "center", justifyContent: "center"}}>
+        {!!delayIsDone && this.renderSpinner()}
+      </div>
+    );
+  }
+}
+
+export default PageLoading;

--- a/src/components/PageLoading/PageLoading.js
+++ b/src/components/PageLoading/PageLoading.js
@@ -1,6 +1,26 @@
 import React, { Component } from "react";
+import PropTypes from "prop-types";
+import { withStyles } from "@material-ui/core/styles";
 
+const styles = () => ({
+  svg: {
+    background: "none"
+  },
+  wrapper: {
+    alignItems: "center",
+    display: "flex",
+    height: "75vh",
+    justifyContent: "center"
+  }
+});
+
+@withStyles(styles, { withTheme: true })
 class PageLoading extends Component {
+  static propTypes = {
+    classes: PropTypes.object,
+    theme: PropTypes.object
+  };
+
   state = {
     delayIsDone: false
   }
@@ -11,7 +31,6 @@ class PageLoading extends Component {
     }
   }
 
-
   componentDidMount() {
     this.timeout = setTimeout(() => {
       this.setState({
@@ -21,12 +40,13 @@ class PageLoading extends Component {
   }
 
   renderSpinner() {
+    const { classes, theme } = this.props;
+
     return (
       <svg
-        className="lds-ball"
+        className={classes.svg}
         height="150px"
         preserveAspectRatio="xMidYMid"
-        style={{ background: "none" }}
         viewBox="0 0 100 100"
         width="150px"
         xmlns="http://www.w3.org/2000/svg"
@@ -34,10 +54,7 @@ class PageLoading extends Component {
         <circle
           cx="50"
           cy="36.7846"
-          fill="#58A8DB"
-          ng-attr-cy="{{config.cy}}"
-          ng-attr-fill="{{config.color}}"
-          ng-attr-r="{{config.radius}}"
+          fill={theme.palette.reaction.pageLoading.color}
           r="13"
         >
           <animate
@@ -56,10 +73,11 @@ class PageLoading extends Component {
   }
 
   render() {
+    const { classes } = this.props;
     const { delayIsDone } = this.state;
 
     return (
-      <div style={{ height: "75vh", display: "flex", alignItems: "center", justifyContent: "center"}}>
+      <div className={classes.wrapper}>
         {!!delayIsDone && this.renderSpinner()}
       </div>
     );

--- a/src/components/PageLoading/index.js
+++ b/src/components/PageLoading/index.js
@@ -1,0 +1,1 @@
+export { default } from "./PageLoading";

--- a/src/components/PageStepper/PageStepper.js
+++ b/src/components/PageStepper/PageStepper.js
@@ -24,6 +24,26 @@ export default class PageStepper extends Component {
     theme: PropTypes.object
   };
 
+  handleNextClick = () => {
+    const { pageInfo } = this.props;
+
+    if (typeof window !== "undefined" && typeof window.scrollTo === "function") {
+      window.scrollTo({ top: 0, behavior: "smooth" });
+    }
+
+    pageInfo.loadNextPage();
+  }
+
+  handlePreviousClick = () => {
+    const { pageInfo } = this.props;
+
+    if (typeof window !== "undefined" && typeof window.scrollTo === "function") {
+      window.scrollTo({ top: 0, behavior: "smooth" });
+    }
+
+    pageInfo.loadPreviousPage();
+  }
+
   render() {
     const { classes, pageInfo } = this.props;
 
@@ -31,12 +51,12 @@ export default class PageStepper extends Component {
       <Grid className={classes.root} container justify="space-between">
         <Grid item>
           {pageInfo.hasPreviousPage &&
-            <Button onClick={pageInfo.loadPreviousPage}>Previous</Button>
+            <Button onClick={this.handlePreviousClick}>Previous</Button>
           }
         </Grid>
         <Grid item>
           {pageInfo.hasNextPage &&
-            <Button onClick={pageInfo.loadNextPage}>Next</Button>
+            <Button onClick={this.handleNextClick}>Next</Button>
           }
         </Grid>
       </Grid>

--- a/src/components/ProductGrid/ProductGrid.js
+++ b/src/components/ProductGrid/ProductGrid.js
@@ -25,6 +25,7 @@ export default class ProductGrid extends Component {
     catalogItems: PropTypes.arrayOf(PropTypes.object),
     classes: PropTypes.object,
     currencyCode: PropTypes.string.isRequired,
+    initialSize: PropTypes.object,
     isLoadingCatalogItems: PropTypes.bool,
     pageInfo: PropTypes.shape({
       startCursor: PropTypes.string,
@@ -59,7 +60,7 @@ export default class ProductGrid extends Component {
   onItemClick = (event, product) => {} // eslint-disable-line no-unused-vars
 
   renderMainArea() {
-    const { catalogItems, isLoadingCatalogItems, pageInfo } = this.props;
+    const { catalogItems, initialSize, isLoadingCatalogItems, pageInfo } = this.props;
 
     if (isLoadingCatalogItems) return <PageLoading />;
 
@@ -70,7 +71,7 @@ export default class ProductGrid extends Component {
       <Fragment>
         <Grid container spacing={24}>
           <CatalogGrid
-            initialSize={{ width: 1000 }}
+            initialSize={initialSize}
             onItemClick={this.onItemClick}
             products={products}
             placeholderImageURL="/static/placeholder.gif"

--- a/src/components/ProductGrid/ProductGrid.js
+++ b/src/components/ProductGrid/ProductGrid.js
@@ -58,27 +58,35 @@ export default class ProductGrid extends Component {
   @trackProductClicked()
   onItemClick = (event, product) => {} // eslint-disable-line no-unused-vars
 
-  render() {
+  renderMainArea() {
     const { catalogItems, isLoadingCatalogItems, pageInfo } = this.props;
-    const products = (catalogItems || []).map((item) => item.node.product);
 
+    if (isLoadingCatalogItems) return <PageLoading />;
+
+    const products = (catalogItems || []).map((item) => item.node.product);
     if (products.length === 0) return <ProductGridEmptyMessage />;
 
     return (
       <Fragment>
-        {this.renderFilters()}
-
-        {isLoadingCatalogItems && <PageLoading />}
-        {!isLoadingCatalogItems && <Grid container spacing={24}>
+        <Grid container spacing={24}>
           <CatalogGrid
-            products={products}
+            initialSize={{ width: 1000 }}
             onItemClick={this.onItemClick}
+            products={products}
             placeholderImageURL="/static/placeholder.gif"
             {...this.props}
           />
-        </Grid>}
+        </Grid>
+        {pageInfo && <PageStepper pageInfo={pageInfo} />}
+      </Fragment>
+    )
+  }
 
-        {!isLoadingCatalogItems && pageInfo && <PageStepper pageInfo={pageInfo} />}
+  render() {
+    return (
+      <Fragment>
+        {this.renderFilters()}
+        {this.renderMainArea()}
       </Fragment>
     );
   }

--- a/src/components/ProductGrid/ProductGrid.js
+++ b/src/components/ProductGrid/ProductGrid.js
@@ -5,6 +5,7 @@ import { withStyles } from "@material-ui/core/styles";
 import CatalogGrid from "@reactioncommerce/components/CatalogGrid/v1";
 import track from "lib/tracking/track";
 import trackProductClicked from "lib/tracking/trackProductClicked";
+import PageLoading from "components/PageLoading";
 import PageStepper from "components/PageStepper";
 import PageSizeSelector from "components/PageSizeSelector";
 import SortBySelector from "components/SortBySelector";
@@ -24,6 +25,7 @@ export default class ProductGrid extends Component {
     catalogItems: PropTypes.arrayOf(PropTypes.object),
     classes: PropTypes.object,
     currencyCode: PropTypes.string.isRequired,
+    isLoadingCatalogItems: PropTypes.bool,
     pageInfo: PropTypes.shape({
       startCursor: PropTypes.string,
       endCursor: PropTypes.string,
@@ -57,7 +59,7 @@ export default class ProductGrid extends Component {
   onItemClick = (event, product) => {} // eslint-disable-line no-unused-vars
 
   render() {
-    const { catalogItems, pageInfo } = this.props;
+    const { catalogItems, isLoadingCatalogItems, pageInfo } = this.props;
     const products = (catalogItems || []).map((item) => item.node.product);
 
     if (products.length === 0) return <ProductGridEmptyMessage />;
@@ -65,16 +67,18 @@ export default class ProductGrid extends Component {
     return (
       <Fragment>
         {this.renderFilters()}
-        <Grid container spacing={24}>
+
+        {isLoadingCatalogItems && <PageLoading />}
+        {!isLoadingCatalogItems && <Grid container spacing={24}>
           <CatalogGrid
             products={products}
             onItemClick={this.onItemClick}
             placeholderImageURL="/static/placeholder.gif"
             {...this.props}
           />
-        </Grid>
+        </Grid>}
 
-        { pageInfo && <PageStepper pageInfo={pageInfo} /> }
+        {!isLoadingCatalogItems && pageInfo && <PageStepper pageInfo={pageInfo} />}
       </Fragment>
     );
   }

--- a/src/components/ProductGrid/ProductGrid.js
+++ b/src/components/ProductGrid/ProductGrid.js
@@ -79,7 +79,7 @@ export default class ProductGrid extends Component {
         </Grid>
         {pageInfo && <PageStepper pageInfo={pageInfo} />}
       </Fragment>
-    )
+    );
   }
 
   render() {

--- a/src/components/ProductGrid/__snapshots__/ProductGrid.test.js.snap
+++ b/src/components/ProductGrid/__snapshots__/ProductGrid.test.js.snap
@@ -1,29 +1,139 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Empty product grid message 1`] = `
-<div
-  className="inject-ProductGridEmptyMessage-with-routingStore-root-155"
->
-  <p
-    className="MuiTypography-root-158 MuiTypography-body1-167 MuiTypography-paragraph-177 inject-ProductGridEmptyMessage-with-routingStore-notFoundMessage-157"
+Array [
+  <div
+    className="MuiGrid-container-2 MuiGrid-spacing-xs-8-24 WithTracking-ProductGrid--filters-1"
   >
-    Sorry! We couldn't find what you're looking for.
-  </p>
-  <p
-    className="MuiTypography-root-158 MuiTypography-body1-167 inject-ProductGridEmptyMessage-with-routingStore-actionMessage-156"
-  >
-    <a
-      className=""
-      href="tag/test-tag"
-      onClick={[Function]}
-      onKeyDown={[Function]}
-      role="link"
-      tabIndex={0}
+    <div
+      className="MuiGrid-item-3"
     >
-      Clear filters
-    </a>
-  </p>
-</div>
+      <div
+        className="MuiInputBase-root-124 MuiInput-root-111 Select-input-103"
+        onClick={[Function]}
+      >
+        <div
+          className="MuiSelect-root-104"
+        >
+          <div
+            aria-haspopup="true"
+            aria-owns={null}
+            aria-pressed="false"
+            className="MuiSelect-select-105 MuiSelect-selectMenu-108 Select-selectMenu-101 MuiInputBase-input-134 MuiInput-input-119"
+            onBlur={[Function]}
+            onClick={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            role="button"
+            tabIndex={0}
+          >
+            20 Products
+          </div>
+          <input
+            autoComplete={undefined}
+            autoFocus={undefined}
+            defaultValue={undefined}
+            id="page-size"
+            name="pageSize"
+            onKeyDown={undefined}
+            onKeyUp={undefined}
+            placeholder={undefined}
+            rows={undefined}
+            type="hidden"
+            value={20}
+          />
+          <svg
+            aria-hidden="true"
+            className="MuiSvgIcon-root-141 MuiSelect-icon-110"
+            color={undefined}
+            focusable="false"
+            role="presentation"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M7 10l5 5 5-5z"
+            />
+          </svg>
+        </div>
+      </div>
+    </div>
+    <div
+      className="MuiGrid-item-3"
+    >
+      <div
+        className="MuiInputBase-root-124 MuiInput-root-111 Select-input-103"
+        onClick={[Function]}
+      >
+        <div
+          className="MuiSelect-root-104"
+        >
+          <div
+            aria-haspopup="true"
+            aria-owns={null}
+            aria-pressed="false"
+            className="MuiSelect-select-105 MuiSelect-selectMenu-108 Select-selectMenu-101 MuiInputBase-input-134 MuiInput-input-119"
+            onBlur={[Function]}
+            onClick={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            role="button"
+            tabIndex={0}
+          >
+            Newest
+          </div>
+          <input
+            autoComplete={undefined}
+            autoFocus={undefined}
+            defaultValue={undefined}
+            id="sort-by"
+            name="sortBy"
+            onKeyDown={undefined}
+            onKeyUp={undefined}
+            placeholder={undefined}
+            rows={undefined}
+            type="hidden"
+            value="updatedAt-desc"
+          />
+          <svg
+            aria-hidden="true"
+            className="MuiSvgIcon-root-141 MuiSelect-icon-110"
+            color={undefined}
+            focusable="false"
+            role="presentation"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M7 10l5 5 5-5z"
+            />
+          </svg>
+        </div>
+      </div>
+    </div>
+  </div>,
+  <div
+    className="inject-ProductGridEmptyMessage-with-routingStore-root-155"
+  >
+    <p
+      className="MuiTypography-root-158 MuiTypography-body1-167 MuiTypography-paragraph-177 inject-ProductGridEmptyMessage-with-routingStore-notFoundMessage-157"
+    >
+      Sorry! We couldn't find what you're looking for.
+    </p>
+    <p
+      className="MuiTypography-root-158 MuiTypography-body1-167 inject-ProductGridEmptyMessage-with-routingStore-actionMessage-156"
+    >
+      <a
+        className=""
+        href="tag/test-tag"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        role="link"
+        tabIndex={0}
+      >
+        Clear filters
+      </a>
+    </p>
+  </div>,
+]
 `;
 
 exports[`basic snapshot 1`] = `
@@ -143,7 +253,7 @@ Array [
       className="CatalogGrid__GridContainer-iLBjFm bXBNVP"
     >
       <div
-        className="CatalogGrid__GridItem-eahVxr kvUYzf"
+        className="CatalogGrid__GridItem-eahVxr FBXTD"
       >
         <CatalogGridItem
           currencyCode="USD"
@@ -185,7 +295,7 @@ Array [
         />
       </div>
       <div
-        className="CatalogGrid__GridItem-eahVxr kvUYzf"
+        className="CatalogGrid__GridItem-eahVxr FBXTD"
       >
         <CatalogGridItem
           currencyCode="USD"

--- a/src/components/ProductGrid/__snapshots__/ProductGrid.test.js.snap
+++ b/src/components/ProductGrid/__snapshots__/ProductGrid.test.js.snap
@@ -253,7 +253,7 @@ Array [
       className="CatalogGrid__GridContainer-iLBjFm bXBNVP"
     >
       <div
-        className="CatalogGrid__GridItem-eahVxr FBXTD"
+        className="CatalogGrid__GridItem-eahVxr kvUYzf"
       >
         <CatalogGridItem
           currencyCode="USD"
@@ -295,7 +295,7 @@ Array [
         />
       </div>
       <div
-        className="CatalogGrid__GridItem-eahVxr FBXTD"
+        className="CatalogGrid__GridItem-eahVxr kvUYzf"
       >
         <CatalogGridItem
           currencyCode="USD"

--- a/src/containers/account/withViewer.js
+++ b/src/containers/account/withViewer.js
@@ -2,6 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import { Query } from "react-apollo";
 import { inject, observer } from "mobx-react";
+import hoistNonReactStatic from "hoist-non-react-statics";
 import viewerQuery from "./viewer.gql";
 
 /**
@@ -10,7 +11,7 @@ import viewerQuery from "./viewer.gql";
  * @param {React.Component} Component to decorate
  * @returns {React.Component} - Component with `viewer` prop
  */
-export default (Component) => (
+export default function withViewer(Component) {
   @inject("authStore")
   @observer
   class WithViewer extends React.Component {
@@ -41,4 +42,8 @@ export default (Component) => (
       );
     }
   }
-);
+
+  hoistNonReactStatic(WithViewer, Component);
+
+  return WithViewer;
+}

--- a/src/containers/cart/withCart.js
+++ b/src/containers/cart/withCart.js
@@ -2,6 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import { Mutation, Query, withApollo } from "react-apollo";
 import { inject, observer } from "mobx-react";
+import hoistNonReactStatic from "hoist-non-react-statics";
 import cartItemsConnectionToArray from "lib/utils/cartItemsConnectionToArray";
 import withShop from "containers/shop/withShop";
 import {
@@ -26,7 +27,7 @@ import {
  * @param {React.Component} Component to decorate
  * @returns {React.Component} - Component with `cart` props and callbacks
  */
-export default (Component) => (
+export default function withCart(Component) {
   @withApollo
   @withShop
   @inject("cartStore", "authStore")
@@ -456,4 +457,8 @@ export default (Component) => (
       );
     }
   }
-);
+
+  hoistNonReactStatic(WithCart, Component);
+
+  return WithCart;
+}

--- a/src/containers/catalog/withCatalogItemProduct.js
+++ b/src/containers/catalog/withCatalogItemProduct.js
@@ -12,12 +12,11 @@ import catalogItemProductQuery from "./catalogItemProduct.gql";
 export default (Component) => (
   class WithCatalogItem extends React.Component {
     static propTypes = {
-      router: PropTypes.object.isRequired,
-      shop: PropTypes.object.isRequired
+      router: PropTypes.object.isRequired
     }
 
     render() {
-      const { router: { query }, shop } = this.props;
+      const { router: { query } } = this.props;
 
       return (
         <Query query={catalogItemProductQuery} variables={{ slugOrId: query.slugOrId }}>

--- a/src/containers/catalog/withCatalogItemProduct.js
+++ b/src/containers/catalog/withCatalogItemProduct.js
@@ -23,15 +23,15 @@ export default (Component) => (
       return (
         <Query query={catalogItemProductQuery} variables={{ slugOrId: query.slugOrId }}>
           {({ loading, data }) => {
-            if (loading) return null;
-
             const { catalogItemProduct } = data;
+            const { product } = catalogItemProduct || {};
 
-            // If no product was found, render "Not Found" page
-            return catalogItemProduct ? (
-              <Component {...this.props} product={catalogItemProduct.product} />
-            ) : (
-              (<Error shop={shop} subtitle="Not Found" />)
+            if (!loading && !product) {
+              return <Error shop={shop} subtitle="Not Found" />;
+            }
+
+            return (
+              <Component {...this.props} isLoadingProduct={loading} product={product} />
             );
           }}
         </Query>

--- a/src/containers/catalog/withCatalogItemProduct.js
+++ b/src/containers/catalog/withCatalogItemProduct.js
@@ -1,16 +1,17 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { Query } from "react-apollo";
+import hoistNonReactStatic from "hoist-non-react-statics";
 import catalogItemProductQuery from "./catalogItemProduct.gql";
 
 /**
- * withCatalogItem higher order query component for fetching primaryShopId and catalog data
- * @name withCatalogItem
+ * withCatalogItemProduct higher order query component for fetching primaryShopId and catalog data
+ * @name withCatalogItemProduct
  * @param {React.Component} Component to decorate and apply
  * @returns {React.Component} - component decorated with primaryShopId and catalog as props
  */
-export default (Component) => (
-  class WithCatalogItem extends React.Component {
+export default function withCatalogItemProduct(Component) {
+  class WithCatalogItemProduct extends React.Component {
     static propTypes = {
       router: PropTypes.object.isRequired
     }
@@ -32,4 +33,8 @@ export default (Component) => (
       );
     }
   }
-);
+
+  hoistNonReactStatic(WithCatalogItemProduct, Component);
+
+  return WithCatalogItemProduct;
+}

--- a/src/containers/catalog/withCatalogItemProduct.js
+++ b/src/containers/catalog/withCatalogItemProduct.js
@@ -1,7 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { Query } from "react-apollo";
-import Error from "../../pages/_error";
 import catalogItemProductQuery from "./catalogItemProduct.gql";
 
 /**
@@ -22,13 +21,9 @@ export default (Component) => (
 
       return (
         <Query query={catalogItemProductQuery} variables={{ slugOrId: query.slugOrId }}>
-          {({ loading, data }) => {
+          {({ data, loading }) => {
             const { catalogItemProduct } = data;
             const { product } = catalogItemProduct || {};
-
-            if (!loading && !product) {
-              return <Error shop={shop} subtitle="Not Found" />;
-            }
 
             return (
               <Component {...this.props} isLoadingProduct={loading} product={product} />

--- a/src/containers/catalog/withCatalogItems.js
+++ b/src/containers/catalog/withCatalogItems.js
@@ -65,4 +65,4 @@ export default function withCatalogItems(Component) {
   hoistNonReactStatic(CatalogItems, Component);
 
   return CatalogItems;
-};
+}

--- a/src/containers/catalog/withCatalogItems.js
+++ b/src/containers/catalog/withCatalogItems.js
@@ -38,7 +38,7 @@ export default (Component) => {
 
       return (
         <Query query={catalogItemsQuery} variables={variables}>
-          {({ data, fetchMore }) => {
+          {({ data, fetchMore, loading }) => {
             const { catalogItems } = data || {};
 
             return (
@@ -52,6 +52,7 @@ export default (Component) => {
                   limit: uiStore.pageSize
                 })}
                 catalogItems={(catalogItems && catalogItems.edges) || []}
+                isLoadingCatalogItems={loading}
               />
             );
           }}

--- a/src/containers/catalog/withCatalogItems.js
+++ b/src/containers/catalog/withCatalogItems.js
@@ -2,6 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import { inject, observer } from "mobx-react";
 import { Query } from "react-apollo";
+import hoistNonReactStatic from "hoist-non-react-statics";
 import { pagination, paginationVariablesFromUrlParams } from "lib/helpers/pagination";
 import catalogItemsQuery from "./catalogItems.gql";
 
@@ -11,7 +12,7 @@ import catalogItemsQuery from "./catalogItems.gql";
  * @param {React.Component} Component to decorate and apply
  * @returns {React.Component} - component decorated with primaryShopId and catalog as props
  */
-export default (Component) => {
+export default function withCatalogItems(Component) {
   @inject("primaryShopId")
   @inject("routingStore")
   @inject("uiStore")
@@ -60,6 +61,8 @@ export default (Component) => {
       );
     }
   }
+
+  hoistNonReactStatic(CatalogItems, Component);
 
   return CatalogItems;
 };

--- a/src/containers/order/withOrder.js
+++ b/src/containers/order/withOrder.js
@@ -2,6 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import { Query, withApollo } from "react-apollo";
 import { inject, observer } from "mobx-react";
+import hoistNonReactStatic from "hoist-non-react-statics";
 import { orderById } from "./queries.gql";
 
 /**
@@ -10,7 +11,7 @@ import { orderById } from "./queries.gql";
  * @param {React.Component} Component to decorate
  * @returns {React.Component} - Component with `cart` props and callbacks
  */
-export default (Component) => (
+export default function withOrder(Component) {
   @withApollo
   @inject("cartStore", "routingStore")
   @observer
@@ -64,4 +65,8 @@ export default (Component) => (
       );
     }
   }
-);
+
+  hoistNonReactStatic(WithOrder, Component);
+
+  return WithOrder;
+}

--- a/src/containers/shop/withShop.js
+++ b/src/containers/shop/withShop.js
@@ -1,6 +1,7 @@
 import React from "react";
 import { Query } from "react-apollo";
 import { Provider } from "mobx-react";
+import hoistNonReactStatic from "hoist-non-react-statics";
 import primaryShopIdQuery from "../common-gql/primaryShopId.gql";
 import shopQuery from "./shop.gql";
 
@@ -10,7 +11,7 @@ import shopQuery from "./shop.gql";
  * @param {React.Component} Component to decorate and apply
  * @returns {React.Component} - component decorated with primaryShopId and shop as props
  */
-export default (Component) => (
+export default function withShop(Component) {
   class Shop extends React.Component {
     render() {
       return (
@@ -43,4 +44,8 @@ export default (Component) => (
       );
     }
   }
-);
+
+  hoistNonReactStatic(Shop, Component);
+
+  return Shop;
+};

--- a/src/containers/shop/withShop.js
+++ b/src/containers/shop/withShop.js
@@ -48,4 +48,4 @@ export default function withShop(Component) {
   hoistNonReactStatic(Shop, Component);
 
   return Shop;
-};
+}

--- a/src/containers/tags/withNavigationTags.js
+++ b/src/containers/tags/withNavigationTags.js
@@ -2,6 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import { computed, observable, action, toJS } from "mobx";
 import { inject, observer } from "mobx-react";
+import hoistNonReactStatic from "hoist-non-react-statics";
 
 /**
  * withNavigationTags higher order query component for fetching tags for the navigation
@@ -9,7 +10,7 @@ import { inject, observer } from "mobx-react";
  * @param {React.Component} Component to decorate
  * @returns {React.Component} - Component with `navItems` prop
  */
-export default (Component) => (
+export default function withNavigationTags(Component) {
   @inject("primaryShopId")
   @inject("tags")
   @observer
@@ -90,4 +91,8 @@ export default (Component) => (
       );
     }
   }
-);
+
+  hoistNonReactStatic(NavigationTags, Component);
+
+  return NavigationTags;
+}

--- a/src/containers/tags/withTag.js
+++ b/src/containers/tags/withTag.js
@@ -1,6 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { Query } from "react-apollo";
+import hoistNonReactStatic from "hoist-non-react-statics";
 import tagQuery from "./tag.gql";
 
 /**
@@ -9,7 +10,7 @@ import tagQuery from "./tag.gql";
  * @param {React.Component} Component to decorate
  * @returns {React.Component} - Component with `tag` prop
  */
-export default (Component) => (
+export default function withTag(Component) {
   class WithTag extends React.Component {
     static propTypes = {
       /**
@@ -38,4 +39,8 @@ export default (Component) => (
       );
     }
   }
-);
+
+  hoistNonReactStatic(WithTag, Component);
+
+  return WithTag;
+}

--- a/src/containers/tags/withTags.js
+++ b/src/containers/tags/withTags.js
@@ -2,6 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import { inject, Provider } from "mobx-react";
 import { Query } from "react-apollo";
+import hoistNonReactStatic from "hoist-non-react-statics";
 import tagsQuery from "./tags.gql";
 
 /**
@@ -10,7 +11,7 @@ import tagsQuery from "./tags.gql";
  * @param {React.Component} Component to decorate
  * @returns {React.Component} - Component with `tag` prop
  */
-export default (Component) => (
+export default function withTag(Component) {
   @inject("primaryShopId")
   class WithTag extends React.Component {
     static propTypes = {
@@ -97,4 +98,8 @@ export default (Component) => (
       );
     }
   }
-);
+
+  hoistNonReactStatic(WithTag, Component);
+
+  return WithTag;
+}

--- a/src/lib/apollo/withApolloClient.js
+++ b/src/lib/apollo/withApolloClient.js
@@ -16,6 +16,12 @@ function getComponentDisplayName(Component) {
   return Component.displayName || Component.name || "Unknown";
 }
 
+/**
+ * @name withApolloClient
+ * @summary Wraps the component with a configured Apollo client provider
+ * @param {React.Component} WrappedComponent Component to wrap
+ * @returns {React.Component} Higher order component
+ */
 export default function withApolloClient(WrappedComponent) {
   class WithApolloClient extends React.Component {
     static async getInitialProps(ctx) {

--- a/src/lib/apollo/withApolloClient.js
+++ b/src/lib/apollo/withApolloClient.js
@@ -1,6 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { ApolloProvider, getDataFromTree } from "react-apollo";
+import hoistNonReactStatic from "hoist-non-react-statics";
 import Head from "next/head";
 import rootMobxStores from "lib/stores";
 import initApollo from "./initApollo";
@@ -15,7 +16,7 @@ function getComponentDisplayName(Component) {
   return Component.displayName || Component.name || "Unknown";
 }
 
-export default (App) =>
+export default function withApolloClient(WrappedComponent) {
   class WithApolloClient extends React.Component {
     static async getInitialProps(ctx) {
       const { Component, router, ctx: { req, res, query, pathname } } = ctx;
@@ -28,9 +29,9 @@ export default (App) =>
 
       ctx.ctx.apolloClient = apollo;
 
-      let appProps = {};
-      if (App.getInitialProps) {
-        appProps = await App.getInitialProps(ctx);
+      let wrappedComponentProps = {};
+      if (WrappedComponent.getInitialProps) {
+        wrappedComponentProps = await WrappedComponent.getInitialProps(ctx);
       }
 
       if (res && res.finished) {
@@ -49,7 +50,7 @@ export default (App) =>
           // eslint-disable-next-line
           await getDataFromTree(
             <ApolloProvider client={apollo}>
-              <App {...appProps} Component={Component} router={router} />
+              <WrappedComponent {...wrappedComponentProps} Component={Component} router={router} />
             </ApolloProvider>
           ); // eslint-disable-line
         } catch (error) {
@@ -71,13 +72,13 @@ export default (App) =>
       }
 
       return {
-        ...appProps,
+        ...wrappedComponentProps,
         apolloState,
         accessToken: user && user.accessToken
       };
     }
 
-    static displayName = `WithApolloClient(${getComponentDisplayName(App)})`;
+    static displayName = `WithApolloClient(${getComponentDisplayName(WrappedComponent)})`;
 
     static propTypes = {
       accessToken: PropTypes.string,
@@ -107,8 +108,14 @@ export default (App) =>
     render() {
       return (
         <ApolloProvider client={this.apollo}>
-          <App {...this.props} />
+          <WrappedComponent {...this.props} />
         </ApolloProvider>
       );
     }
-  };
+  }
+
+  // Exclude copying `getInitialProps` because WithApolloClient has its own
+  hoistNonReactStatic(WithApolloClient, WrappedComponent, { getInitialProps: true });
+
+  return WithApolloClient;
+}

--- a/src/lib/stores/withMobX.js
+++ b/src/lib/stores/withMobX.js
@@ -1,5 +1,6 @@
 import React from "react";
 import { Provider } from "mobx-react";
+import hoistNonReactStatic from "hoist-non-react-statics";
 import rootMobxStores from "./index";
 
 /**
@@ -18,6 +19,8 @@ function withMobX(Component) {
       );
     }
   }
+
+  hoistNonReactStatic(WithMobX, Component);
 
   return WithMobX;
 }

--- a/src/lib/theme/reactionTheme.js
+++ b/src/lib/theme/reactionTheme.js
@@ -114,6 +114,9 @@ const theme = createMuiTheme({
       red400: "#bc1d2b",
       red500: "#5e3033",
       red600: "#3c1f21",
+      pageLoading: {
+        color: "#58A8DB"
+      },
       teal: "#8ce0c9",
       teal100: "#edfdf8",
       teal200: "#d9ece6",

--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -29,8 +29,8 @@ const { publicRuntimeConfig } = getConfig();
 @withTags
 @track({}, { dispatch })
 export default class App extends NextApp {
-  static async getInitialProps({ Component, router, ctx }) {
-    let pageProps = {}
+  static async getInitialProps({ Component, ctx }) {
+    let pageProps = {};
 
     if (Component.getInitialProps) {
       pageProps = await Component.getInitialProps(ctx);

--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -29,6 +29,16 @@ const { publicRuntimeConfig } = getConfig();
 @withTags
 @track({}, { dispatch })
 export default class App extends NextApp {
+  static async getInitialProps({ Component, router, ctx }) {
+    let pageProps = {}
+
+    if (Component.getInitialProps) {
+      pageProps = await Component.getInitialProps(ctx);
+    }
+
+    return { pageProps };
+  }
+
   constructor(props) {
     super(props);
     this.pageContext = getPageContext();
@@ -57,7 +67,7 @@ export default class App extends NextApp {
   }
 
   render() {
-    const { Component, shop, ...rest } = this.props;
+    const { Component, pageProps, shop, ...rest } = this.props;
     const { route } = this.props.router;
     const { stripe } = this.state;
 
@@ -77,11 +87,11 @@ export default class App extends NextApp {
                 {
                   (route === "/checkout" || route === "/login") ? (
                     <StripeProvider stripe={stripe}>
-                      <Component pageContext={this.pageContext} shop={shop} {...rest} />
+                      <Component pageContext={this.pageContext} shop={shop} {...rest} {...pageProps} />
                     </StripeProvider>
                   ) : (
                     <Layout shop={shop}>
-                      <Component pageContext={this.pageContext} shop={shop} {...rest} />
+                      <Component pageContext={this.pageContext} shop={shop} {...rest} {...pageProps} />
                     </Layout>
                   )
                 }

--- a/src/pages/_document.js
+++ b/src/pages/_document.js
@@ -4,9 +4,8 @@ import Document, { Head, Main, NextScript } from "next/document";
 import flush from "styled-jsx/server";
 import Helmet from "react-helmet";
 import analyticsProviders from "analytics";
-import { ServerStyleSheet } from 'styled-components'
+import { ServerStyleSheet } from "styled-components";
 // import getConfig from "next/config";
-import rootMobxStores from "../lib/stores";
 import favicons from "../lib/utils/favicons";
 import globalStyles from "../lib/theme/globalStyles";
 

--- a/src/pages/product.js
+++ b/src/pages/product.js
@@ -4,6 +4,7 @@ import Helmet from "react-helmet";
 import withCart from "containers/cart/withCart";
 import withCatalogItemProduct from "containers/catalog/withCatalogItemProduct";
 import ProductDetail from "components/ProductDetail";
+import PageLoading from "components/PageLoading";
 
 @withCart
 @withCatalogItemProduct
@@ -16,6 +17,7 @@ class ProductDetailPage extends Component {
      * @type function
      */
     addItemsToCart: PropTypes.func,
+    isLoadingProduct: PropTypes.bool,
     /**
      * Catalog Product item
      */
@@ -80,8 +82,8 @@ class ProductDetailPage extends Component {
   }
 
   render() {
-    const currencyCode = this.props.shop.currency.code || "USD";
-    const { product, shop } = this.props;
+    const { addItemsToCart, isLoadingProduct, product, shop, tags } = this.props;
+    const currencyCode = (shop && shop.currency.code) || "USD";
 
     return (
       <Fragment>
@@ -90,13 +92,14 @@ class ProductDetailPage extends Component {
           meta={[{ name: "description", content: product && product.description }]}
           script={[{ type: "application/ld+json", innerHTML: this.buildJSONLd() }]}
         />
-        <ProductDetail
-          addItemsToCart={this.props.addItemsToCart}
+        {!!isLoadingProduct && <PageLoading />}
+        {!isLoadingProduct && <ProductDetail
+          addItemsToCart={addItemsToCart}
           currencyCode={currencyCode}
-          product={this.props.product}
-          shop={this.props.shop}
-          tags={this.props.tags}
-        />
+          product={product}
+          shop={shop}
+          tags={tags}
+        />}
       </Fragment>
     );
   }

--- a/src/pages/product.js
+++ b/src/pages/product.js
@@ -1,11 +1,11 @@
 import React, { Component, Fragment } from "react";
 import PropTypes from "prop-types";
 import Helmet from "react-helmet";
-import ErrorPage from "./_error";
 import withCart from "containers/cart/withCart";
 import withCatalogItemProduct from "containers/catalog/withCatalogItemProduct";
 import ProductDetail from "components/ProductDetail";
 import PageLoading from "components/PageLoading";
+import ErrorPage from "./_error";
 
 @withCart
 @withCatalogItemProduct

--- a/src/pages/productGrid.js
+++ b/src/pages/productGrid.js
@@ -14,6 +14,7 @@ class ProductGridPage extends Component {
   static propTypes = {
     catalogItems: PropTypes.array,
     catalogItemsPageInfo: PropTypes.object,
+    initialGridSize: PropTypes.object,
     isLoadingCatalogItems: PropTypes.bool,
     routingStore: PropTypes.object,
     shop: PropTypes.shape({
@@ -29,6 +30,15 @@ class ProductGridPage extends Component {
       sortBy: PropTypes.string.isRequired
     })
   };
+
+  static async getInitialProps({ req }) {
+    // It is not perfect, but the only way we can guess at the screen width of the
+    // requesting device is to parse the `user-agent` header it sends.
+    const userAgent = req ? req.headers['user-agent'] : navigator.userAgent
+    const width = (userAgent && userAgent.indexOf("Mobi")) > -1 ? 320 : 1024;
+
+    return { initialGridSize: { width } };
+  }
 
   @trackProductListViewed()
   componentDidMount() {
@@ -59,6 +69,7 @@ class ProductGridPage extends Component {
     const {
       catalogItems,
       catalogItemsPageInfo,
+      initialGridSize,
       isLoadingCatalogItems,
       routingStore: { query },
       shop,
@@ -77,6 +88,7 @@ class ProductGridPage extends Component {
         <ProductGrid
           catalogItems={catalogItems}
           currencyCode={shop.currency.code}
+          initialSize={initialGridSize}
           isLoadingCatalogItems={isLoadingCatalogItems}
           pageInfo={catalogItemsPageInfo}
           pageSize={pageSize}

--- a/src/pages/productGrid.js
+++ b/src/pages/productGrid.js
@@ -10,10 +10,11 @@ import { inPageSizes } from "lib/utils/pageSizes";
 @withCatalogItems
 @inject("routingStore", "uiStore")
 @observer
-class Shop extends Component {
+class ProductGridPage extends Component {
   static propTypes = {
     catalogItems: PropTypes.array,
     catalogItemsPageInfo: PropTypes.object,
+    isLoadingCatalogItems: PropTypes.bool,
     routingStore: PropTypes.object,
     shop: PropTypes.shape({
       currency: PropTypes.shape({
@@ -55,7 +56,14 @@ class Shop extends Component {
   };
 
   render() {
-    const { catalogItems, catalogItemsPageInfo, uiStore, routingStore: { query }, shop } = this.props;
+    const {
+      catalogItems,
+      catalogItemsPageInfo,
+      isLoadingCatalogItems,
+      routingStore: { query },
+      shop,
+      uiStore
+    } = this.props;
     const pageSize = query && inPageSizes(query.limit) ? parseInt(query.limit, 10) : uiStore.pageSize;
     const sortBy = query && query.sortby ? query.sortby : uiStore.sortBy;
     const pageTitle = shop && shop.description ? `${shop.name} | ${shop.description}` : shop.name;
@@ -69,6 +77,7 @@ class Shop extends Component {
         <ProductGrid
           catalogItems={catalogItems}
           currencyCode={shop.currency.code}
+          isLoadingCatalogItems={isLoadingCatalogItems}
           pageInfo={catalogItemsPageInfo}
           pageSize={pageSize}
           setPageSize={this.setPageSize}
@@ -80,4 +89,4 @@ class Shop extends Component {
   }
 }
 
-export default Shop;
+export default ProductGridPage;

--- a/src/pages/productGrid.js
+++ b/src/pages/productGrid.js
@@ -34,7 +34,7 @@ class ProductGridPage extends Component {
   static async getInitialProps({ req }) {
     // It is not perfect, but the only way we can guess at the screen width of the
     // requesting device is to parse the `user-agent` header it sends.
-    const userAgent = req ? req.headers['user-agent'] : navigator.userAgent
+    const userAgent = req ? req.headers["user-agent"] : navigator.userAgent;
     const width = (userAgent && userAgent.indexOf("Mobi")) > -1 ? 320 : 1024;
 
     return { initialGridSize: { width } };

--- a/src/pages/tag.js
+++ b/src/pages/tag.js
@@ -13,11 +13,12 @@ import trackProductListViewed from "lib/tracking/trackProductListViewed";
 @withCatalogItems
 @inject("routingStore", "uiStore")
 @observer
-export default class TagShop extends Component {
+export default class TagGridPage extends Component {
   static propTypes = {
     catalogItems: PropTypes.array.isRequired,
     catalogItemsPageInfo: PropTypes.object,
     classes: PropTypes.object,
+    isLoadingCatalogItems: PropTypes.bool,
     routingStore: PropTypes.object,
     shop: PropTypes.shape({
       currency: PropTypes.shape({
@@ -70,7 +71,16 @@ export default class TagShop extends Component {
   };
 
   render() {
-    const { catalogItems, catalogItemsPageInfo, routingStore: { query }, shop, tag, tags, uiStore } = this.props;
+    const {
+      catalogItems,
+      catalogItemsPageInfo,
+      isLoadingCatalogItems,
+      routingStore: { query },
+      shop,
+      tag,
+      tags,
+      uiStore
+    } = this.props;
     const pageSize = query && query.limit ? parseInt(query.limit, 10) : uiStore.pageSize;
     const sortBy = query && query.sortby ? query.sortby : uiStore.sortBy;
 
@@ -85,6 +95,7 @@ export default class TagShop extends Component {
         <ProductGrid
           catalogItems={catalogItems}
           currencyCode={shop.currency.code}
+          isLoadingCatalogItems={isLoadingCatalogItems}
           pageInfo={catalogItemsPageInfo}
           pageSize={pageSize}
           setPageSize={this.setPageSize}

--- a/src/routes.js
+++ b/src/routes.js
@@ -1,14 +1,14 @@
 const routes = require("next-routes")();
 
 routes
-  .add("home", "/", "index")
+  .add("home", "/", "productGrid")
   .add("cart", "/cart", "cart")
   .add("checkout", "/cart/checkout", "checkout")
   .add("checkoutComplete", "/checkout/order/:orderId", "checkoutComplete")
   .add("login", "/login", "login")
   .add("shopProduct", "/shop/:shopSlug/product/:slugOrId", "product")
   .add("product", "/product/:slugOrId/:variantId?", "product")
-  .add("shop", "/shop/:shopId/:tag", "index")
+  .add("shop", "/shop/:shopId/:tag", "productGrid")
   .add("tag", "/tag/:slug", "tag");
 
 module.exports = routes;

--- a/yarn.lock
+++ b/yarn.lock
@@ -81,6 +81,12 @@
   dependencies:
     "@babel/types" "7.0.0-beta.42"
 
+"@babel/helper-annotate-as-pure@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0.tgz#323d39dd0b50e10c7c06ca7d7638e6864d8c5c32"
+  dependencies:
+    "@babel/types" "^7.0.0"
+
 "@babel/helper-builder-binary-assignment-operator-visitor@7.0.0-beta.42":
   version "7.0.0-beta.42"
   resolved "https://registry.yarnpkg.com/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.0.0-beta.42.tgz#7305281eb996954c47f87ec7710e2a9a8edd8077"
@@ -844,6 +850,14 @@
     lodash "^4.17.5"
     to-fast-properties "^2.0.0"
 
+"@babel/types@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.0.0.tgz#6e191793d3c854d19c6749989e3bc55f0e962118"
+  dependencies:
+    esutils "^2.0.2"
+    lodash "^4.17.10"
+    to-fast-properties "^2.0.0"
+
 "@emotion/babel-utils@^0.6.4":
   version "0.6.8"
   resolved "https://registry.yarnpkg.com/@emotion/babel-utils/-/babel-utils-0.6.8.tgz#1ebb41b789e345bbdf3dd6c73d0df2c4fa7d01db"
@@ -969,9 +983,9 @@
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@reactioncommerce/components-context/-/components-context-1.0.0.tgz#587764cf0d1b0312c786b8e4657379de02e13845"
 
-"@reactioncommerce/components@0.35.2":
-  version "0.35.2"
-  resolved "https://registry.yarnpkg.com/@reactioncommerce/components/-/components-0.35.2.tgz#c86d0bd48c077dc0c878e992d2262d96eeb6bae0"
+"@reactioncommerce/components@^0.36.0":
+  version "0.36.0"
+  resolved "https://registry.yarnpkg.com/@reactioncommerce/components/-/components-0.36.0.tgz#64078d2efccbea39a49d8719d5cee3761a06b1ea"
   dependencies:
     "@material-ui/core" "^1.4.0"
     lodash.debounce "^4.0.8"
@@ -1587,6 +1601,13 @@ babel-plugin-module-resolver@^3.1.1:
 babel-plugin-react-require@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-react-require/-/babel-plugin-react-require-3.0.0.tgz#2e4e7b4496b93a654a1c80042276de4e4eeb20e3"
+
+babel-plugin-styled-components@^1.7.1:
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-styled-components/-/babel-plugin-styled-components-1.7.1.tgz#c291d2a48ec77bb0828275b87696b6594a2f80f9"
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.0.0"
+    lodash "^4.17.10"
 
 babel-plugin-syntax-class-properties@^6.8.0:
   version "6.13.0"


### PR DESCRIPTION
Impact: **minor**
Type: **bugfix**

## Issue 200
Need a loading indicator on the grid pages and PDP page when loading is slow.

### Solution
- Created a `PageLoading` component
- Pass through Apollo `loading` to the wrapped components
- Update pages to show `PageLoading` while Apollo is loading the data
- Made Previous and Next buttons scroll to the top of the page when clicked
- There is an 800 milliseconds delay before the loading spinner will show, to avoid a quick flash of it on fast connections.

NOTE: Designers are working on final loading design. The animated SVG in there now is CC0-licensed and will work for now.

Resolves #200 

### Testing
1. Load the home page in Chrome and use the Chrome dev tools network tab to turn on throttling to "Slow 3G" speed. Click "Next" button and see that the page scrolls to the top and then the bouncing ball animation appears.
1. Same test on tag grid page
1. Same test on PDP page (It can be difficult to get it to appear on this page in some cases due to the SSR.)

## Issue 293
Components that use styled-components such as the catalog grid appear unstyled or partially styled on initial load.

### Solution
Followed the instructions to enable styled-components SSR. https://www.styled-components.com/docs/advanced#server-side-rendering

Resolves #293

### Testing
Load the catalog grid and ensure that the items are not small and squished to the left. "Next" button at the bottom should be properly styled, too. They may still adjust a bit after a second because we are guessing what the screen width is while doing the SSR on the server. But it should generally look much better.

## Issue 214
Grid pages can briefly show the "Sorry! We couldn't find what you're looking for." message but then load results.

### Solution
Don't show that message unless we really have no results and have finished the query.

Resolves #214

### Testing
Click around between catalog grid home page and various tag pages and make sure you see the message only when there are really no results.

## getInitialProps Issue
The `getInitialProps` static functions in many cases were not being called. This was because none of our HOC components were hoisting static functions. 

### Solution
Added and used `hoist-non-react-statics` NPM pkg as recommended in the React docs here: https://reactjs.org/docs/higher-order-components.html#static-methods-must-be-copied-over

### Testing
Put a console.log in all the `getInitialProps` functions and verify that you see that logging in the server logs.

## Other changes
- Renamed `index` page to `productGrid` to help clarify that you can add your own custom home page (request from Brent)