### PR TITLE
fix: clear apollo client cache after placing an order as an authenticated user

### DIFF
--- a/src/components/CheckoutActions/CheckoutActions.js
+++ b/src/components/CheckoutActions/CheckoutActions.js
@@ -102,6 +102,10 @@ export default class CheckoutActions extends Component {
   }
 
   render() {
+    if (!this.props.cart) {
+      return null;
+    }
+
     const { cartStore: { stripeToken } } = this.props;
     const { checkout: { fulfillmentGroups, summary }, items } = this.props.cart;
     const shippingAddressSet = isShippingAddressSet(fulfillmentGroups);

--- a/src/containers/cart/withCart.js
+++ b/src/containers/cart/withCart.js
@@ -249,6 +249,7 @@ export default function withCart(Component) {
         }
       });
     }
+
     /**
      * @name handleUpdateFulfillmentOptionsForGroup
      * @summary Sets a fulfillment method for items in a cart
@@ -402,10 +403,16 @@ export default function withCart(Component) {
                 {(mutationFunction) => (
                   <Component
                     {...this.props}
-                    isLoading={skipQuery ? false : isLoading}
+                    addItemsToCart={(items) => {
+                      this.handleAddItemsToCart(mutationFunction, { items }, !cart);
+                    }}
+                    cart={processedCartData}
+                    checkoutMutations={{
+                      onSetFulfillmentOption: this.handleSetFulfillmentOption,
+                      onSetShippingAddress: this.handleSetShippingAddress
+                    }}
                     hasMoreCartItems={(pageInfo && pageInfo.hasNextPage) || false}
-                    onChangeCartItemsQuantity={this.handleChangeCartItemsQuantity}
-                    onRemoveCartItems={this.handleRemoveCartItems}
+                    isLoading={skipQuery ? false : isLoading}
                     loadMoreCartItems={() => {
                       fetchMore({
                         variables: {
@@ -438,15 +445,10 @@ export default function withCart(Component) {
                         }
                       });
                     }}
-                    addItemsToCart={(items) => {
-                      this.handleAddItemsToCart(mutationFunction, { items }, !cart);
-                    }}
+                    onChangeCartItemsQuantity={this.handleChangeCartItemsQuantity}
+                    onRemoveCartItems={this.handleRemoveCartItems}
+                    refetchCart={refetchCart}
                     setEmailOnAnonymousCart={this.handleSetEmailOnAnonymousCart}
-                    checkoutMutations={{
-                      onSetFulfillmentOption: this.handleSetFulfillmentOption,
-                      onSetShippingAddress: this.handleSetShippingAddress
-                    }}
-                    cart={processedCartData}
                   />
                 )}
               </Mutation>

--- a/src/containers/order/withPlaceStripeOrder.js
+++ b/src/containers/order/withPlaceStripeOrder.js
@@ -3,10 +3,6 @@ import PropTypes from "prop-types";
 import { withApollo } from "react-apollo";
 import { inject, observer } from "mobx-react";
 import { Router } from "routes";
-import {
-  accountCartByAccountIdQuery,
-  anonymousCartByCartIdQuery
-} from "../cart/queries.gql";
 import { placeOrderWithStripeCardPayment } from "./mutations.gql";
 
 /**
@@ -61,18 +57,6 @@ export default (Component) => (
             order: accountOrder,
             payment
           }
-        },
-        update: (cache) => {
-          // TODO: revisit and verify this actually clears the apollo cache
-          cache.writeQuery({
-            query: accountCartByAccountIdQuery,
-            data: { cart: null }
-          });
-
-          cache.writeQuery({
-            query: anonymousCartByCartIdQuery,
-            data: { cart: null }
-          });
         }
       });
 
@@ -81,7 +65,9 @@ export default (Component) => (
         const { placeOrderWithStripeCardPayment: { orders, token } } = data;
 
         // Clear anonymous cart
-        cartStore.clearAnonymousCartCredentials();
+        if (!authStore.isAuthenticated) {
+          cartStore.clearAnonymousCartCredentials();
+        }
 
         // Send user to order confirmation page
         Router.pushRoute("checkoutComplete", { orderId: orders[0]._id, token });

--- a/src/pages/checkoutComplete.js
+++ b/src/pages/checkoutComplete.js
@@ -7,6 +7,7 @@ import { withStyles } from "@material-ui/core/styles";
 import Typography from "@material-ui/core/Typography";
 import withOrder from "containers/order/withOrder";
 import OrderFulfillmentGroups from "components/OrderFulfillmentGroups";
+import withCart from "containers/cart/withCart";
 
 const styles = (theme) => ({
   sectionHeader: {
@@ -70,6 +71,7 @@ const styles = (theme) => ({
 });
 
 @withOrder
+@withCart
 @observer
 @withStyles(styles, { withTheme: true })
 class CheckoutComplete extends Component {
@@ -81,6 +83,7 @@ class CheckoutComplete extends Component {
     onChangeCartItemsQuantity: PropTypes.func,
     onRemoveCartItems: PropTypes.func,
     order: PropTypes.object,
+    refetchCart: PropTypes.func.isRequired,
     shop: PropTypes.shape({
       name: PropTypes.string.isRequired,
       description: PropTypes.string
@@ -89,6 +92,12 @@ class CheckoutComplete extends Component {
   };
 
   state = {}
+
+  componentDidMount() {
+    const { refetchCart } = this.props;
+
+    refetchCart();
+  }
 
   handleCartEmptyClick = () => Router.pushRoute("/")
 


### PR DESCRIPTION
Resolves #302 
Impact: minor
Type: bugfix 

### Summary
Clear Apollo Client cache after placing an order as an authenticated user.

## Testing
1. Login as admin
2. Place an order
3. Verify cart page & mini cart do NOT contain cart items

