### PR TITLE
fix: added to browser history stack instead of replacing it

### DIFF
--- a/src/lib/stores/RoutingStore.js
+++ b/src/lib/stores/RoutingStore.js
@@ -86,7 +86,7 @@ export default class RoutingStore {
       path = `${this.pathname}?${this.queryString}`;
     }
 
-    Router.replaceRoute(path, path, { shallow: true });
+    Router.pushRoute(path, path, { shallow: true });
     return path;
   }
 }


### PR DESCRIPTION
Impact: **minor**
Type: **bugfix**

## Issue
Query param changes due to pagination mess with the history stack.

## Solution
Pushed to the stack instead of replacing the current item.

## Breaking changes
None


## Testing
1. Load `/`, or a page with pagination
2. Click `Next`
3. Go back (as in the browser's back button/mapping)
4. Before this fix the page you go back to would be wrong, and inconsistent. After, it is always the page you just came from.