### PR TITLE
feat: Redirect user to page opened before auth flow started

### DIFF
--- a/src/components/CheckoutActions/CheckoutActions.js
+++ b/src/components/CheckoutActions/CheckoutActions.js
@@ -102,6 +102,8 @@ export default class CheckoutActions extends Component {
   }
 
   render() {
+    if (!this.props.cart) return null;
+
     const { cartStore: { stripeToken } } = this.props;
     const { checkout: { fulfillmentGroups, summary }, items } = this.props.cart;
     const shippingAddressSet = isShippingAddressSet(fulfillmentGroups);

--- a/src/server.js
+++ b/src/server.js
@@ -47,17 +47,20 @@ app
     server.use(cookieParser());
 
     // This endpoint initializes the OAuth2 request
-    server.get("/auth2", passport.authenticate("oauth2"));
+    server.get("/auth2", (req, res, next) => {
+      if (!req.user) req.session.redirectTo = req.get("Referer");
+      next();
+    }, passport.authenticate("oauth2"));
 
     // This endpoint handles OAuth2 requests (exchanges code for token)
     server.get("/callback", passport.authenticate("oauth2"), (req, res) => {
       // After success, redirect to the page we came from originally
-      res.redirect("/");
+      res.redirect(req.session.redirectTo);
     });
 
     server.get("/logout", (req, res) => {
       req.logout();
-      res.redirect("/");
+      res.redirect(req.get("Referer"));
     });
 
     // Setup next routes


### PR DESCRIPTION
Related to #272
Impact: **minor**
Type: **feature**

## Issue
After completion of login flow, users are always getting redirected to the home page. We should be returning users to the current page being viewed before the OAuth redirect happened.

## Solution
- Capture page url in the [current] session object, and redirect there after login / logout completion.

## Breaking changes
N/a


## Testing
1. Browse to any page on the storefront while not logged in
2. Attempt a login
3. Confirm you get taken back to the page you were viewing before attempting login
