### PR TITLE
feat: Add sign in/up info in auth URL generated by Passport

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,7 @@ KEYCLOAK_REDIRECT_URI=http://localhost:4000/auth
 STRIPE_PUBLIC_API_KEY=ENTER_STRIPE_PUBLIC_KEY_HERE
 OAUTH2_AUTH_URL=http://localhost:4444/oauth2/auth
 OAUTH2_TOKEN_URL=http://hydra:4444/oauth2/token
+HYDRA_ADMIN_URL=http://hydra:4445
 OAUTH2_CLIENT_ID=reaction-next-starterkit
 OAUTH2_CLIENT_SECRET=CHANGEME
 OAUTH2_REDIRECT_URL=http://localhost:4000/callback

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@material-ui/core": "^3.1.0",
-    "@reactioncommerce/components": "0.39.2",
+    "@reactioncommerce/components": "0.40.0",
     "@reactioncommerce/components-context": "^1.0.0",
     "@segment/snippet": "^4.3.1",
     "apollo-cache-inmemory": "^1.1.11",

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "react-stripe-elements": "^2.0.1",
     "react-tracking": "^5.2.1",
     "reacto-form": "^0.0.2",
+    "request": "^2.88.0",
     "styled-components": "^3.4.9"
   },
   "devDependencies": {
@@ -105,7 +106,6 @@
     "jest-transform-graphql": "2.1.0",
     "mocha": "^5.2.0",
     "react-test-renderer": "^16.3.1",
-    "request": "^2.87.0",
     "rimraf": "^2.6.2",
     "snyk": "^1.73.0"
   },

--- a/src/components/AccountDropdown/AccountDropdown.js
+++ b/src/components/AccountDropdown/AccountDropdown.js
@@ -4,6 +4,7 @@ import { inject, observer } from "mobx-react";
 import { withStyles } from "@material-ui/core/styles";
 import IconButton from "@material-ui/core/IconButton";
 import Button from "@material-ui/core/Button";
+import ButtonBase from "@material-ui/core/ButtonBase";
 import AccountIcon from "mdi-material-ui/Account";
 import Popover from "@material-ui/core/Popover";
 import ViewerInfo from "@reactioncommerce/components/ViewerInfo/v1";
@@ -25,6 +26,7 @@ const styles = (theme) => ({
 class AccountDropdown extends Component {
   static propTypes = {
     authStore: PropTypes.object.isRequired,
+    viewer: PropTypes.object,
     classes: PropTypes.object
   };
 
@@ -83,12 +85,19 @@ class AccountDropdown extends Component {
   render() {
     const { classes, authStore } = this.props;
     const { anchorElement } = this.state;
+    const { account } = authStore;
 
     return (
       <Fragment>
-        <IconButton color="inherit" onClick={this.toggleOpen}>
-          <AccountIcon />
-        </IconButton>
+        { authStore.isAuthenticated ?
+          <ButtonBase onClick={this.toggleOpen}>
+            <ViewerInfo viewer={account} />
+          </ButtonBase>
+          :
+          <IconButton color="inherit" onClick={this.toggleOpen}>
+            <AccountIcon />
+          </IconButton>
+        }
 
         <Popover
           anchorEl={anchorElement}
@@ -102,15 +111,7 @@ class AccountDropdown extends Component {
           <div className={classes.accountDropdown}>
             {authStore.isAuthenticated ?
               <Fragment>
-                <div className={classes.authContent}>
-                  <ViewerInfo
-                    viewer={{
-                      firstName: authStore.account.name,
-                      lastName: " "
-                    }}
-                  />
-                </div>
-                <Button color="primary" fullWidth href="/logout" variant="raised">
+                <Button color="primary" fullWidth href={`/logout/${account._id}`} variant="raised">
                   Sign Out
                 </Button>
               </Fragment>

--- a/src/components/AccountDropdown/AccountDropdown.js
+++ b/src/components/AccountDropdown/AccountDropdown.js
@@ -117,11 +117,11 @@ class AccountDropdown extends Component {
               :
               <Fragment>
                 <div className={classes.authContent}>
-                  <Button color="primary" fullWidth href="/auth2" variant="raised">
+                  <Button color="primary" fullWidth href="/signin" variant="raised">
                     Sign In
                   </Button>
                 </div>
-                <Button color="primary" fullWidth href="/auth2">
+                <Button color="primary" fullWidth href="/signup">
                   Create Account
                 </Button>
               </Fragment>

--- a/src/components/Entry/Entry.js
+++ b/src/components/Entry/Entry.js
@@ -53,10 +53,10 @@ export default class Entry extends Component {
 
   static defaultProps = {
     onLoginButtonClick() {
-      Router.pushRoute("/auth2");
+      Router.pushRoute("/signin");
     },
     onRegisterButtonClick() {
-      Router.pushRoute("/auth2");
+      Router.pushRoute("/signup");
     },
     setEmailOnAnonymousCart() {}
   };

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -10,7 +10,6 @@ import { NavigationDesktop } from "components/NavigationDesktop";
 import { NavigationMobile, NavigationToggleMobile } from "components/NavigationMobile";
 import AccountDropdown from "components/AccountDropdown";
 import ShopLogo from "@reactioncommerce/components/ShopLogo/v1";
-import ViewerInfo from "@reactioncommerce/components/ViewerInfo/v1";
 import Link from "components/Link";
 import MiniCart from "components/MiniCart";
 
@@ -59,31 +58,8 @@ class Header extends Component {
     this.props.uiStore.toggleMenuDrawerOpen();
   };
 
-  // TODO: quick fix until we figure out the viewer name stuff.
-  // See https://github.com/reactioncommerce/reaction/issues/4646
-  get splitNames() {
-    const { viewer: { name } } = this.props;
-    const firstName =
-      name &&
-      name
-        .split(" ")
-        .slice(0, -1)
-        .join(" ");
-    const lastName =
-      name &&
-      name
-        .split(" ")
-        .slice(-1)
-        .join(" ");
-
-    return {
-      firstName,
-      lastName
-    };
-  }
-
   render() {
-    const { classes: { appBar, controls, toolbar, title }, shop, viewer } = this.props;
+    const { classes: { appBar, controls, toolbar, title }, shop } = this.props;
 
     return (
       <AppBar position="static" elevation={0} className={appBar}>
@@ -104,7 +80,7 @@ class Header extends Component {
             </Hidden>
           </div>
 
-          {viewer ? <ViewerInfo viewer={{ ...this.splitNames, ...viewer }} /> : <AccountDropdown />}
+          <AccountDropdown />
           <MiniCart />
         </Toolbar>
         <NavigationMobile />

--- a/src/lib/stores/AuthStore.js
+++ b/src/lib/stores/AuthStore.js
@@ -71,9 +71,32 @@ class AuthStore {
     return false;
   }
 
+  // TODO: Temporary workaround until name fields get added from GQL
+  // See https://github.com/reactioncommerce/reaction/issues/4646
+  splitNames(account) {
+    const { name } = account;
+    const firstName =
+      name &&
+      name
+        .split(" ")
+        .slice(0, -1)
+        .join(" ");
+    const lastName =
+      name &&
+      name
+        .split(" ")
+        .slice(-1)
+        .join(" ");
+
+    return {
+      firstName,
+      lastName
+    };
+  }
+
   @action setAccount(account) {
     this.accountId = account._id || null;
-    this.account = account;
+    this.account = { ...this.splitNames(account), ...account };
   }
 }
 

--- a/src/lib/stores/AuthStore.js
+++ b/src/lib/stores/AuthStore.js
@@ -74,8 +74,13 @@ class AuthStore {
   // TODO: Temporary workaround until name fields get added from GQL
   // See https://github.com/reactioncommerce/reaction/issues/4646
   splitNames(account) {
+    let firstName = "";
+    let lastName = "";
     const { name } = account;
-    const [firstName, lastName] = name.split(" ");
+    const nameParts = name && name.split(" ");
+    if (Array.isArray(nameParts)) {
+      [firstName, lastName] = nameParts;
+    }
 
     return {
       firstName,

--- a/src/server.js
+++ b/src/server.js
@@ -2,6 +2,7 @@ import cookieParser from "cookie-parser";
 import express from "express";
 import session from "express-session";
 import nextApp from "next";
+import request from "request";
 import { useStaticRendering } from "mobx-react";
 import logger from "lib/logger";
 import passport from "passport";
@@ -68,9 +69,13 @@ app
       res.redirect(req.session.redirectTo || "/");
     });
 
-    server.get("/logout", (req, res) => {
-      req.logout();
-      res.redirect(req.get("Referer") || "/");
+    server.get("/logout/:userId", (req, res) => {
+      request.delete(`${process.env.HYDRA_ADMIN_URL}/oauth2/auth/sessions/login/${req.params.userId}`, (error) => {
+        if (!error) {
+          req.logout();
+          res.redirect(req.get("Referer") || "/");
+        }
+      });
     });
 
     // Setup next routes

--- a/src/server.js
+++ b/src/server.js
@@ -53,24 +53,24 @@ app
     server.use(cookieParser());
 
     server.get("/signin", (req, res, next) => {
-      if (!req.user) req.session.redirectTo = req.get("Referer");
+      req.session.redirectTo = req.get("Referer");
       next(); // eslint-disable-line promise/no-callback-in-promise
     }, passport.authenticate("oauth2", { loginAction: "signin" }));
 
     server.get("/signup", (req, res, next) => {
-      if (!req.user) req.session.redirectTo = req.get("Referer");
+      req.session.redirectTo = req.get("Referer");
       next(); // eslint-disable-line promise/no-callback-in-promise
     }, passport.authenticate("oauth2", { loginAction: "signup" }));
 
     // This endpoint handles OAuth2 requests (exchanges code for token)
     server.get("/callback", passport.authenticate("oauth2"), (req, res) => {
       // After success, redirect to the page we came from originally
-      res.redirect(req.session.redirectTo);
+      res.redirect(req.session.redirectTo || "/");
     });
 
     server.get("/logout", (req, res) => {
       req.logout();
-      res.redirect(req.get("Referer"));
+      res.redirect(req.get("Referer") || "/");
     });
 
     // Setup next routes

--- a/yarn.lock
+++ b/yarn.lock
@@ -1399,6 +1399,10 @@ aws4@^1.6.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.7.0.tgz#d4d0e9b9dbfca77bf08eeb0a8a471550fe39e289"
 
+aws4@^1.8.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
+
 axobject-query@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-0.1.0.tgz#62f59dbc59c9f9242759ca349960e7a2fe3c36c0"
@@ -2301,6 +2305,12 @@ combined-stream2@^1.0.2:
 combined-stream@1.0.6, combined-stream@~1.0.5:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.6.tgz#723e7df6e801ac5613113a7e445a9b69cb632818"
+  dependencies:
+    delayed-stream "~1.0.0"
+
+combined-stream@~1.0.6:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.7.tgz#2d1d24317afb8abe95d6d2c0b07b57813539d828"
   dependencies:
     delayed-stream "~1.0.0"
 
@@ -3440,6 +3450,10 @@ extend@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/extend/-/extend-2.0.2.tgz#1b74985400171b85554894459c978de6ef453ab7"
 
+extend@~3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
+
 external-editor@^2.0.4:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-2.2.0.tgz#045511cfd8d133f3846673d1047c154e214ad3d5"
@@ -3675,7 +3689,7 @@ form-data2@^1.0.0:
     mime "^1.2.11"
     uuid "^2.0.1"
 
-form-data@~2.3.1:
+form-data@~2.3.1, form-data@~2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.2.tgz#4970498be604c20c005d4f5c23aecd21d6b49099"
   dependencies:
@@ -3928,6 +3942,13 @@ har-validator@~5.0.3:
   resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-5.0.3.tgz#ba402c266194f15956ef15e0fcf242993f6a7dfd"
   dependencies:
     ajv "^5.1.0"
+    har-schema "^2.0.0"
+
+har-validator@~5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-5.1.0.tgz#44657f5688a22cfd4b72486e81b3a3fb11742c29"
+  dependencies:
+    ajv "^5.3.0"
     har-schema "^2.0.0"
 
 has-ansi@^0.1.0:
@@ -5469,11 +5490,21 @@ mime-db@~1.33.0:
   version "1.33.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.33.0.tgz#a3492050a5cb9b63450541e39d9788d2272783db"
 
+mime-db@~1.36.0:
+  version "1.36.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.36.0.tgz#5020478db3c7fe93aad7bbcc4dcf869c43363397"
+
 mime-types@^2.1.12, mime-types@~2.1.17, mime-types@~2.1.18:
   version "2.1.18"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.18.tgz#6f323f60a83d11146f831ff11fd66e2fe5503bb8"
   dependencies:
     mime-db "~1.33.0"
+
+mime-types@~2.1.19:
+  version "2.1.20"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.20.tgz#930cb719d571e903738520f8470911548ca2cc19"
+  dependencies:
+    mime-db "~1.36.0"
 
 mime@1.4.1:
   version "1.4.1"
@@ -5917,6 +5948,10 @@ nwmatcher@^1.4.3:
 oauth-sign@~0.8.2:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.8.2.tgz#46a6ab7f0aead8deae9ec0565780b7d4efeb9d43"
+
+oauth-sign@~0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
 
 oauth@0.9.x:
   version "0.9.15"
@@ -6505,6 +6540,10 @@ pseudomap@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
 
+psl@^1.1.24:
+  version "1.1.29"
+  resolved "https://registry.yarnpkg.com/psl/-/psl-1.1.29.tgz#60f580d360170bb722a797cc704411e6da850c67"
+
 public-encrypt@^4.0.0:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/public-encrypt/-/public-encrypt-4.0.2.tgz#46eb9107206bf73489f8b85b69d91334c6610994"
@@ -6546,7 +6585,7 @@ qs@6.5.1:
   version "6.5.1"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.1.tgz#349cdf6eef89ec45c12d7d5eb3fc0c870343a6d8"
 
-qs@6.5.2, qs@~6.5.1:
+qs@6.5.2, qs@~6.5.1, qs@~6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
 
@@ -7024,30 +7063,30 @@ request@^2.83.0:
     tunnel-agent "^0.6.0"
     uuid "^3.1.0"
 
-request@^2.87.0:
-  version "2.87.0"
-  resolved "https://registry.yarnpkg.com/request/-/request-2.87.0.tgz#32f00235cd08d482b4d0d68db93a829c0ed5756e"
+request@^2.88.0:
+  version "2.88.0"
+  resolved "https://registry.yarnpkg.com/request/-/request-2.88.0.tgz#9c2fca4f7d35b592efe57c7f0a55e81052124fef"
   dependencies:
     aws-sign2 "~0.7.0"
-    aws4 "^1.6.0"
+    aws4 "^1.8.0"
     caseless "~0.12.0"
-    combined-stream "~1.0.5"
-    extend "~3.0.1"
+    combined-stream "~1.0.6"
+    extend "~3.0.2"
     forever-agent "~0.6.1"
-    form-data "~2.3.1"
-    har-validator "~5.0.3"
+    form-data "~2.3.2"
+    har-validator "~5.1.0"
     http-signature "~1.2.0"
     is-typedarray "~1.0.0"
     isstream "~0.1.2"
     json-stringify-safe "~5.0.1"
-    mime-types "~2.1.17"
-    oauth-sign "~0.8.2"
+    mime-types "~2.1.19"
+    oauth-sign "~0.9.0"
     performance-now "^2.1.0"
-    qs "~6.5.1"
-    safe-buffer "^5.1.1"
-    tough-cookie "~2.3.3"
+    qs "~6.5.2"
+    safe-buffer "^5.1.2"
+    tough-cookie "~2.4.3"
     tunnel-agent "^0.6.0"
-    uuid "^3.1.0"
+    uuid "^3.3.2"
 
 require-directory@^2.1.1:
   version "2.1.1"
@@ -8125,6 +8164,13 @@ tough-cookie@>=2.3.3, tough-cookie@^2.3.1, tough-cookie@^2.3.3, tough-cookie@~2.
   dependencies:
     punycode "^1.4.1"
 
+tough-cookie@~2.4.3:
+  version "2.4.3"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.4.3.tgz#53f36da3f47783b0925afa06ff9f3b165280f781"
+  dependencies:
+    psl "^1.1.24"
+    punycode "^1.4.1"
+
 tr46@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-1.0.1.tgz#a8b13fd6bfd2489519674ccde55ba3693b706d09"
@@ -8383,6 +8429,10 @@ uuid@^2.0.1:
 uuid@^3.0.1, uuid@^3.1.0, uuid@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.2.1.tgz#12c528bb9d58d0b9265d9a2f6f0fe8be17ff1f14"
+
+uuid@^3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
 
 v8flags@^3.0.0:
   version "3.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -943,9 +943,9 @@
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@reactioncommerce/components-context/-/components-context-1.0.0.tgz#587764cf0d1b0312c786b8e4657379de02e13845"
 
-"@reactioncommerce/components@0.39.2":
-  version "0.39.2"
-  resolved "https://registry.yarnpkg.com/@reactioncommerce/components/-/components-0.39.2.tgz#50d6b07258d4b905dc3f1885b9ef71e162a293c2"
+"@reactioncommerce/components@0.40.0":
+  version "0.40.0"
+  resolved "https://registry.yarnpkg.com/@reactioncommerce/components/-/components-0.40.0.tgz#f6e7f8d4b2c5e06f13c5bbcf3f789b6e2a9a9b5b"
   dependencies:
     "@material-ui/core" "^3.1.0"
     lodash.debounce "^4.0.8"


### PR DESCRIPTION
Part of reactioncommerce/reaction/issues/4640
Type: **feature**

## Issue
When a Starterkit user clicks "Register", we redirect to the Reaction Hydra login page, but it shows the "Sign In" view rather than "Create Account" view.

## Solution
Pass extra info to Hydra about the specific auth flow the user is going through: Sign up OR Sign in. 

## Changes
- Extend Passport configuration to allow passing custom field denoting  "signin" or "signup" flow
- Separate `/auth` route into two distinct `/signin` and `signup` routes to allow requirement above (I couldn't find a way around it with single route)
- Changes needed on the Identity provider to use above update is done in reactioncommerce/reaction/pull/4651.
- Update logout function to delete session in Hydra
- fix: Show logout dropdown onclick Viewer when logged in
- Also moved `splitnames` helper into AuthStore, making it available for reuse beyond Header comp

## Breaking changes
N/A

## Testing
NB: This is to be tested along with reactioncommerce/reaction/pull/4651
1. From Starterkit, click "Sign In"
2. Confirm that you see a "Sign In" form on the Meteor Login page
3. From Starterkit, click "Create Account"
4. Confirm that you see a "Create Account" form on the Meteor Login page
