### PR TITLE
fix: update reaction components version for grid image size fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@material-ui/core": "^3.1.0",
-    "@reactioncommerce/components": "^0.38.1",
+    "@reactioncommerce/components": "^0.39.1",
     "@reactioncommerce/components-context": "^1.0.0",
     "@segment/snippet": "^4.3.1",
     "apollo-cache-inmemory": "^1.1.11",

--- a/src/components/CheckoutSummary/__snapshots__/CheckoutSummary.test.js.snap
+++ b/src/components/CheckoutSummary/__snapshots__/CheckoutSummary.test.js.snap
@@ -12,7 +12,7 @@ exports[`basic snapshot 1`] = `
         className="CartItems__Items-gEXRwN gdnVAG"
       >
         <div
-          className="CartItem__Item-ghDCXl gKDHYG"
+          className="CartItem__Item-ghDCXl cOMnbm"
         >
           <a
             href="/product-slug"
@@ -120,7 +120,7 @@ exports[`basic snapshot 1`] = `
           </div>
         </div>
         <div
-          className="CartItem__Item-ghDCXl gKDHYG"
+          className="CartItem__Item-ghDCXl cOMnbm"
         >
           <a
             href="/product-slug"
@@ -226,46 +226,46 @@ exports[`basic snapshot 1`] = `
         <tbody>
           <tr>
             <td
-              className="CartSummary__Td-jXBgKC hdqJNm"
+              className="CartSummary__Td-jXBgKC jKaJQb"
             >
               Item total
             </td>
             <td
-              className="CartSummary__Td-boDvWU dNHWhU"
+              className="CartSummary__Td-boDvWU kKknSH"
             >
               $118
             </td>
           </tr>
           <tr>
             <td
-              className="CartSummary__Td-jXBgKC hdqJNm"
+              className="CartSummary__Td-jXBgKC jKaJQb"
             >
               Shipping
             </td>
             <td
-              className="CartSummary__Td-boDvWU dNHWhU"
+              className="CartSummary__Td-boDvWU kKknSH"
             />
           </tr>
           <tr>
             <td
-              className="CartSummary__Td-jXBgKC hdqJNm"
+              className="CartSummary__Td-jXBgKC jKaJQb"
             >
               Tax
             </td>
             <td
-              className="CartSummary__Td-boDvWU dNHWhU"
+              className="CartSummary__Td-boDvWU kKknSH"
             >
               -
             </td>
           </tr>
           <tr>
             <td
-              className="CartSummary__Td-jXBgKC hViozU"
+              className="CartSummary__Td-jXBgKC grsCCy"
             >
               Order total
             </td>
             <td
-              className="CartSummary__Td-boDvWU cttmNN"
+              className="CartSummary__Td-boDvWU xcYQR"
             >
               <span
                 className="CartSummary__Total-BZUQP bdUKHv"

--- a/src/components/OrderFulfillmentGroup/__snapshots__/OrderFulfillmentGroup.test.js.snap
+++ b/src/components/OrderFulfillmentGroup/__snapshots__/OrderFulfillmentGroup.test.js.snap
@@ -38,7 +38,7 @@ Array [
         className="CartItems__Items-gEXRwN gdnVAG"
       >
         <div
-          className="CartItem__Item-ghDCXl gKDHYG"
+          className="CartItem__Item-ghDCXl cOMnbm"
         >
           <a
             href="/product-slug"
@@ -146,7 +146,7 @@ Array [
           </div>
         </div>
         <div
-          className="CartItem__Item-ghDCXl gKDHYG"
+          className="CartItem__Item-ghDCXl cOMnbm"
         >
           <a
             href="/product-slug"
@@ -288,46 +288,46 @@ Array [
           <tbody>
             <tr>
               <td
-                className="CartSummary__Td-jXBgKC hdqJNm"
+                className="CartSummary__Td-jXBgKC jKaJQb"
               >
                 Item total
               </td>
               <td
-                className="CartSummary__Td-boDvWU dNHWhU"
+                className="CartSummary__Td-boDvWU kKknSH"
               >
                 $118
               </td>
             </tr>
             <tr>
               <td
-                className="CartSummary__Td-jXBgKC hdqJNm"
+                className="CartSummary__Td-jXBgKC jKaJQb"
               >
                 Shipping
               </td>
               <td
-                className="CartSummary__Td-boDvWU dNHWhU"
+                className="CartSummary__Td-boDvWU kKknSH"
               />
             </tr>
             <tr>
               <td
-                className="CartSummary__Td-jXBgKC hdqJNm"
+                className="CartSummary__Td-jXBgKC jKaJQb"
               >
                 Tax
               </td>
               <td
-                className="CartSummary__Td-boDvWU dNHWhU"
+                className="CartSummary__Td-boDvWU kKknSH"
               >
                 -
               </td>
             </tr>
             <tr>
               <td
-                className="CartSummary__Td-jXBgKC hViozU"
+                className="CartSummary__Td-jXBgKC grsCCy"
               >
                 Order total
               </td>
               <td
-                className="CartSummary__Td-boDvWU cttmNN"
+                className="CartSummary__Td-boDvWU xcYQR"
               >
                 <span
                   className="CartSummary__Total-BZUQP bdUKHv"

--- a/src/components/OrderFulfillmentGroups/__snapshots__/OrderFulfillmentGroups.test.js.snap
+++ b/src/components/OrderFulfillmentGroups/__snapshots__/OrderFulfillmentGroups.test.js.snap
@@ -38,7 +38,7 @@ Array [
         className="CartItems__Items-gEXRwN gdnVAG"
       >
         <div
-          className="CartItem__Item-ghDCXl gKDHYG"
+          className="CartItem__Item-ghDCXl cOMnbm"
         >
           <a
             href="/product-slug"
@@ -146,7 +146,7 @@ Array [
           </div>
         </div>
         <div
-          className="CartItem__Item-ghDCXl gKDHYG"
+          className="CartItem__Item-ghDCXl cOMnbm"
         >
           <a
             href="/product-slug"
@@ -288,46 +288,46 @@ Array [
           <tbody>
             <tr>
               <td
-                className="CartSummary__Td-jXBgKC hdqJNm"
+                className="CartSummary__Td-jXBgKC jKaJQb"
               >
                 Item total
               </td>
               <td
-                className="CartSummary__Td-boDvWU dNHWhU"
+                className="CartSummary__Td-boDvWU kKknSH"
               >
                 $118
               </td>
             </tr>
             <tr>
               <td
-                className="CartSummary__Td-jXBgKC hdqJNm"
+                className="CartSummary__Td-jXBgKC jKaJQb"
               >
                 Shipping
               </td>
               <td
-                className="CartSummary__Td-boDvWU dNHWhU"
+                className="CartSummary__Td-boDvWU kKknSH"
               />
             </tr>
             <tr>
               <td
-                className="CartSummary__Td-jXBgKC hdqJNm"
+                className="CartSummary__Td-jXBgKC jKaJQb"
               >
                 Tax
               </td>
               <td
-                className="CartSummary__Td-boDvWU dNHWhU"
+                className="CartSummary__Td-boDvWU kKknSH"
               >
                 -
               </td>
             </tr>
             <tr>
               <td
-                className="CartSummary__Td-jXBgKC hViozU"
+                className="CartSummary__Td-jXBgKC grsCCy"
               >
                 Order total
               </td>
               <td
-                className="CartSummary__Td-boDvWU cttmNN"
+                className="CartSummary__Td-boDvWU xcYQR"
               >
                 <span
                   className="CartSummary__Total-BZUQP bdUKHv"

--- a/src/components/OrderSummary/__snapshots__/OrderSummary.test.js.snap
+++ b/src/components/OrderSummary/__snapshots__/OrderSummary.test.js.snap
@@ -42,46 +42,46 @@ exports[`basic snapshot 1`] = `
       <tbody>
         <tr>
           <td
-            className="CartSummary__Td-jXBgKC hdqJNm"
+            className="CartSummary__Td-jXBgKC jKaJQb"
           >
             Item total
           </td>
           <td
-            className="CartSummary__Td-boDvWU dNHWhU"
+            className="CartSummary__Td-boDvWU kKknSH"
           >
             $118
           </td>
         </tr>
         <tr>
           <td
-            className="CartSummary__Td-jXBgKC hdqJNm"
+            className="CartSummary__Td-jXBgKC jKaJQb"
           >
             Shipping
           </td>
           <td
-            className="CartSummary__Td-boDvWU dNHWhU"
+            className="CartSummary__Td-boDvWU kKknSH"
           />
         </tr>
         <tr>
           <td
-            className="CartSummary__Td-jXBgKC hdqJNm"
+            className="CartSummary__Td-jXBgKC jKaJQb"
           >
             Tax
           </td>
           <td
-            className="CartSummary__Td-boDvWU dNHWhU"
+            className="CartSummary__Td-boDvWU kKknSH"
           >
             -
           </td>
         </tr>
         <tr>
           <td
-            className="CartSummary__Td-jXBgKC hViozU"
+            className="CartSummary__Td-jXBgKC grsCCy"
           >
             Order total
           </td>
           <td
-            className="CartSummary__Td-boDvWU cttmNN"
+            className="CartSummary__Td-boDvWU xcYQR"
           >
             <span
               className="CartSummary__Total-BZUQP bdUKHv"

--- a/yarn.lock
+++ b/yarn.lock
@@ -943,9 +943,9 @@
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@reactioncommerce/components-context/-/components-context-1.0.0.tgz#587764cf0d1b0312c786b8e4657379de02e13845"
 
-"@reactioncommerce/components@^0.38.1":
-  version "0.38.1"
-  resolved "https://registry.yarnpkg.com/@reactioncommerce/components/-/components-0.38.1.tgz#9d0edf2dd83f46caf869b80f585c798028f9ce2c"
+"@reactioncommerce/components@^0.39.1":
+  version "0.39.1"
+  resolved "https://registry.yarnpkg.com/@reactioncommerce/components/-/components-0.39.1.tgz#1fe5f7e1797d4f5c6c6b6ee0c9000fa39e150a6b"
   dependencies:
     "@material-ui/core" "^3.1.0"
     lodash.debounce "^4.0.8"


### PR DESCRIPTION
Resolves #324 
Impact: **minor**
Type: **bugfix**

## Issue
In the grid, the image `fit` prop was not recalculating when the `CatalogGridItem` component was updated with a different product

## Solution
Simply called image fit calculation logic on `componentDidUpdate` fixed the issue.

## Breaking changes
None

## Testing
1. Load up the starterkit with the catalog sample data
2. Visit homepage, click next, click previous
3. Confirm images all still perfectly fit the square. Previously after clicking previous, portrait images would have white bars on the left/ & right.
