### PR TITLE
fix(328): disable all ripples

### DIFF
--- a/src/components/AccountDropdown/AccountDropdown.js
+++ b/src/components/AccountDropdown/AccountDropdown.js
@@ -9,7 +9,7 @@ import Popover from "@material-ui/core/Popover";
 import ViewerInfo from "@reactioncommerce/components/ViewerInfo/v1";
 import { login } from "lib/auth";
 
-const styles = (theme) => ({
+const styles = theme => ({
   accountDropdown: {
     width: 320,
     padding: theme.spacing.unit * 2
@@ -51,17 +51,17 @@ class AccountDropdown extends Component {
     anchorElement: null
   };
 
-  toggleOpen = (event) => {
+  toggleOpen = event => {
     this.setState({ anchorElement: event.currentTarget });
-  }
+  };
 
   onClose = () => {
     this.setState({ anchorElement: null });
-  }
+  };
 
-  onTokenChange = (event) => {
+  onTokenChange = event => {
     this.setState({ token: event.target.value || "" });
-  }
+  };
 
   onTokenSave = () => {
     const { authStore } = this.props;
@@ -70,15 +70,15 @@ class AccountDropdown extends Component {
 
     // Reload so the auth changes can be reflected on server and in browser
     window.location.reload();
-  }
+  };
 
   onLogin = () => {
     login();
-  }
+  };
 
   onLogout = () => {
     window.location.reload();
-  }
+  };
 
   render() {
     const { classes, authStore } = this.props;
@@ -86,7 +86,7 @@ class AccountDropdown extends Component {
 
     return (
       <Fragment>
-        <IconButton color="inherit" onClick={this.toggleOpen}>
+        <IconButton color="inherit" onClick={this.toggleOpen} disableRipple>
           <AccountIcon />
         </IconButton>
 
@@ -100,7 +100,7 @@ class AccountDropdown extends Component {
           onClose={this.onClose}
         >
           <div className={classes.accountDropdown}>
-            {authStore.isAuthenticated ?
+            {authStore.isAuthenticated ? (
               <Fragment>
                 <div className={classes.authContent}>
                   <ViewerInfo
@@ -110,22 +110,22 @@ class AccountDropdown extends Component {
                     }}
                   />
                 </div>
-                <Button color="primary" fullWidth href="/logout" variant="raised">
+                <Button color="primary" fullWidth href="/logout" variant="raised" disableRipple>
                   Sign Out
                 </Button>
               </Fragment>
-              :
+            ) : (
               <Fragment>
                 <div className={classes.authContent}>
-                  <Button color="primary" fullWidth href="/auth2" variant="raised">
+                  <Button color="primary" fullWidth href="/auth2" variant="raised" disableRipple>
                     Sign In
                   </Button>
                 </div>
-                <Button color="primary" fullWidth href="/auth2">
+                <Button color="primary" fullWidth href="/auth2" disableRipple>
                   Create Account
                 </Button>
               </Fragment>
-            }
+            )}
           </div>
         </Popover>
       </Fragment>

--- a/src/components/MiniCart/MiniCart.js
+++ b/src/components/MiniCart/MiniCart.js
@@ -67,12 +67,12 @@ export default class MiniCart extends Component {
       openCart: PropTypes.func.isRequired,
       closeCart: PropTypes.func.isRequired
     })
-  }
+  };
 
   constructor(props) {
     super(props);
 
-    this.setPopoverAnchorEl = (element) => {
+    this.setPopoverAnchorEl = element => {
       this.anchorElement = element;
     };
   }
@@ -82,12 +82,12 @@ export default class MiniCart extends Component {
     anchorElement: null
   };
 
-  anchorElement = null
+  anchorElement = null;
 
   handlePopperOpen = () => {
     const { openCart } = this.props.uiStore;
     openCart();
-  }
+  };
 
   handleClick = () => Router.pushRoute("/");
   handleCheckoutButtonClick = () => Router.pushRoute("/cart/checkout");
@@ -95,29 +95,29 @@ export default class MiniCart extends Component {
   handlePopperClose = () => {
     const { closeCart } = this.props.uiStore;
     closeCart();
-  }
+  };
 
   handleEnterPopper = () => {
     const { openCart } = this.props.uiStore;
     openCart();
-  }
+  };
 
   handleLeavePopper = () => {
     const { closeCart } = this.props.uiStore;
     closeCart();
-  }
+  };
 
   handleOnClick = () => {
     const { closeCart } = this.props.uiStore;
     closeCart();
     Router.pushRoute("cart");
-  }
+  };
 
   handleItemQuantityChange = (quantity, cartItemId) => {
     const { onChangeCartItemsQuantity } = this.props;
 
     onChangeCartItemsQuantity({ quantity, cartItemId });
-  }
+  };
 
   renderMiniCart() {
     const { cart, classes, hasMoreCartItems, loadMoreCartItems, onRemoveCartItems } = this.props;
@@ -129,7 +129,7 @@ export default class MiniCart extends Component {
           onCheckoutButtonClick={this.handleCheckoutButtonClick}
           components={{
             QuantityInput: "div",
-            CartItems: (cartItemProps) => (
+            CartItems: cartItemProps => (
               <CartItems
                 {...cartItemProps}
                 hasMoreCartItems={hasMoreCartItems}
@@ -160,10 +160,12 @@ export default class MiniCart extends Component {
     return (
       <Fragment>
         <div ref={this.setPopoverAnchorEl}>
-          <IconButton color="inherit"
+          <IconButton
+            color="inherit"
             onMouseEnter={this.handlePopperOpen}
             onMouseLeave={this.handlePopperClose}
             onClick={this.handleOnClick}
+            disableRipple
           >
             {(cart && cart.totalItemQuantity > 0)
               ? (
@@ -191,9 +193,7 @@ export default class MiniCart extends Component {
         >
           {({ TransitionProps }) => (
             <Fade {...TransitionProps}>
-              <div className={classes.cart}>
-                {this.renderMiniCart()}
-              </div>
+              <div className={classes.cart}>{this.renderMiniCart()}</div>
             </Fade>
           )}
         </Popper>

--- a/src/components/NavigationDesktop/NavigationItemDesktop.js
+++ b/src/components/NavigationDesktop/NavigationItemDesktop.js
@@ -15,7 +15,7 @@ import { withStyles } from "@material-ui/core/styles";
 import { Router } from "routes";
 import Link from "components/Link";
 
-const styles = (theme) => ({
+const styles = theme => ({
   popover: {
     left: "0!important",
     maxWidth: "100vw",
@@ -58,7 +58,7 @@ class NavigationItemDesktop extends Component {
 
   state = { isSubNavOpen: false };
 
-  linkPath = (providedNavItem) => {
+  linkPath = providedNavItem => {
     const { navItem, routingStore } = this.props;
 
     const currentNavItem = providedNavItem || navItem;
@@ -66,14 +66,16 @@ class NavigationItemDesktop extends Component {
     return routingStore.queryString !== ""
       ? `/tag/${currentNavItem.slug}?${routingStore.queryString}`
       : `/tag/${currentNavItem.slug}`;
-  }
+  };
 
   get hasSubNavItems() {
-    const { navItem: { subTags } } = this.props;
+    const {
+      navItem: { subTags }
+    } = this.props;
     return subTags && Array.isArray(subTags.edges) && subTags.edges.length > 0;
   }
 
-  onClick = (event) => {
+  onClick = event => {
     event.preventDefault();
 
     const { navItem } = this.props;
@@ -104,7 +106,11 @@ class NavigationItemDesktop extends Component {
   }
 
   renderPopover() {
-    const { classes, navItem, navItem: { subTags } } = this.props;
+    const {
+      classes,
+      navItem,
+      navItem: { subTags }
+    } = this.props;
 
     if (subTags) {
       return (
@@ -131,7 +137,9 @@ class NavigationItemDesktop extends Component {
             ))}
           </Grid>
           <Link className={classes.navigationShopAllLink} onClick={this.onClose} route={`${this.linkPath()}`}>
-            <span>Shop all {navItem.name} <ChevronRight className={classes.navigationShopAllLinkIcon} /></span>
+            <span>
+              Shop all {navItem.name} <ChevronRight className={classes.navigationShopAllLinkIcon} />
+            </span>
           </Link>
         </Popover>
       );
@@ -141,13 +149,24 @@ class NavigationItemDesktop extends Component {
   }
 
   render() {
-    const { classes: { primaryNavItem }, navItem } = this.props;
+    const {
+      classes: { primaryNavItem },
+      navItem
+    } = this.props;
 
     return (
       <Fragment>
-        <Button className={primaryNavItem} color="inherit" onClick={this.onClick} href={this.linkPath(navItem)}>
+        <Button
+          disableRipple
+          className={primaryNavItem}
+          color="inherit"
+          onClick={this.onClick}
+          href={this.linkPath(navItem)}
+        >
           {navItem.name}
-          {this.hasSubNavItems && <Fragment>{this.state.isSubNavOpen ? <ChevronUpIcon /> : <ChevronDownIcon />}</Fragment>}
+          {this.hasSubNavItems && (
+            <Fragment>{this.state.isSubNavOpen ? <ChevronUpIcon /> : <ChevronDownIcon />}</Fragment>
+          )}
         </Button>
         {this.hasSubNavItems && this.renderPopover()}
       </Fragment>

--- a/src/components/ProductDetailAddToCart/ProductDetailAddToCart.js
+++ b/src/components/ProductDetailAddToCart/ProductDetailAddToCart.js
@@ -42,12 +42,12 @@ const cartItem = {
 // pending the GraphQL endpoint being hooked up
 // Remove the code between these comments when live data is available
 
-const styles = (theme) => ({
+const styles = theme => ({
   addToCartButton: {
-    "padding": theme.spacing.unit,
-    "backgroundColor": theme.palette.primary.main,
-    "borderRadius": theme.palette.reaction.buttonBorderRadius,
-    "minWidth": "66%",
+    padding: theme.spacing.unit,
+    backgroundColor: theme.palette.primary.main,
+    borderRadius: theme.palette.reaction.buttonBorderRadius,
+    minWidth: "66%",
     "&:hover": {
       borderColor: theme.palette.reaction.activeElementBorderColor
     },
@@ -78,16 +78,16 @@ const styles = (theme) => ({
     marginBottom: theme.spacing.unit * 3
   },
   quantityInput: {
-    "color": theme.palette.reaction.coolGray500,
-    "fontSize": "12px",
-    "width": "40px",
-    "textAlign": "center",
+    color: theme.palette.reaction.coolGray500,
+    fontSize: "12px",
+    width: "40px",
+    textAlign: "center",
     "&:focus": {
       borderColor: "#80bdff",
       boxShadow: "0 0 0 0.2rem rgba(0,123,255,.25)"
     },
-    "borderLeft": `1px solid ${theme.palette.reaction.black15}`,
-    "borderRight": `1px solid ${theme.palette.reaction.black15}`
+    borderLeft: `1px solid ${theme.palette.reaction.black15}`,
+    borderRight: `1px solid ${theme.palette.reaction.black15}`
   },
   quantitySvg: {
     fontSize: "18px"
@@ -97,7 +97,6 @@ const styles = (theme) => ({
     marginBottom: theme.spacing.unit * 2
   }
 });
-
 
 @withStyles(styles, { name: "SkProductDetailAddToCart" })
 @inject("uiStore")
@@ -142,9 +141,9 @@ export default class ProductDetailAddToCart extends Component {
     setTimeout(() => {
       uiStore.closeCartPopover();
     }, 3000);
-  }
+  };
 
-  handleQuantityInputChange = (event) => {
+  handleQuantityInputChange = event => {
     const { value } = event.target;
 
     const numericValue = Math.floor(Number(value));
@@ -154,13 +153,13 @@ export default class ProductDetailAddToCart extends Component {
     }
 
     return this.setState({ addToCartQuantity: numericValue });
-  }
+  };
 
   handleIncrementButton = () => {
     const value = this.state.addToCartQuantity + 1;
 
     this.setState({ addToCartQuantity: value });
-  }
+  };
 
   handleDecrementButton = () => {
     const value = this.state.addToCartQuantity - 1;
@@ -168,7 +167,7 @@ export default class ProductDetailAddToCart extends Component {
     if (value >= 1) {
       this.setState({ addToCartQuantity: value });
     }
-  }
+  };
 
   render() {
     const {
@@ -191,7 +190,9 @@ export default class ProductDetailAddToCart extends Component {
         <Grid container>
           <Grid item xs={12} className={quantityGrid}>
             <Divider />
-            <Typography component="span" className={quantityTypography}>Quantity</Typography>
+            <Typography component="span" className={quantityTypography}>
+              Quantity
+            </Typography>
             <TextField
               id="addToCartQuantityInput"
               value={addToCartQuantity}
@@ -204,6 +205,7 @@ export default class ProductDetailAddToCart extends Component {
                       variant="outlined"
                       onClick={this.handleDecrementButton}
                       className={incrementButton}
+                      disableRipple
                     >
                       <Minus className={quantitySvg} />
                     </ButtonBase>
@@ -216,6 +218,7 @@ export default class ProductDetailAddToCart extends Component {
                       color="default"
                       onClick={this.handleIncrementButton}
                       className={incrementButton}
+                      disableRipple
                     >
                       <Plus className={quantitySvg} />
                     </ButtonBase>
@@ -230,10 +233,7 @@ export default class ProductDetailAddToCart extends Component {
             />
           </Grid>
           <Grid item xs={12}>
-            <ButtonBase
-              onClick={this.handleOnClick}
-              className={addToCartButton}
-            >
+            <ButtonBase onClick={this.handleOnClick} className={addToCartButton} disableRipple>
               <Typography className={addToCartText} component="span" variant="body1">
                 Add to cart
               </Typography>


### PR DESCRIPTION
Resolves #328
Impact: **minor**
Type: **style**

## Issue
Our official style is to _not_ have any Material UI button ripples anywhere.

## Solution

Disabled the ripple on:

    Navigation item button
    Profile button
    Profile: Sign in button
    Profile: Create account button
    Profile: Sign out button
    Cart button

PDP

    Add to cart
    + button
    - button

## Testing
1. Test nav, both signed in and signed out
2. Test PDP

