### PR TITLE
fix: clear a user's cart after placing an order, and remove MiniCart popper from order completed page.

### DIFF
--- a/src/components/CheckoutActions/CheckoutActions.js
+++ b/src/components/CheckoutActions/CheckoutActions.js
@@ -131,7 +131,7 @@ export default class CheckoutActions extends Component {
     }
 
     if (this.state.placingOrder) {
-      return <PageLoading message="Placing your order..."/>;
+      return <PageLoading delay={0} message="Placing your order..."/>;
     }
 
     const { cartStore: { stripeToken } } = this.props;

--- a/src/components/CheckoutActions/CheckoutActions.js
+++ b/src/components/CheckoutActions/CheckoutActions.js
@@ -123,7 +123,6 @@ export default class CheckoutActions extends Component {
     }
 
     // TODO: if an error occurred, notify user
-
   }
 
   render() {

--- a/src/components/CheckoutActions/CheckoutActions.js
+++ b/src/components/CheckoutActions/CheckoutActions.js
@@ -11,7 +11,6 @@ import withPlaceStripeOrder from "containers/order/withPlaceStripeOrder";
 import Dialog from "@material-ui/core/Dialog";
 import PageLoading from "components/PageLoading";
 import { Router } from "routes";
-import Fade from "@material-ui/core/Fade";
 import {
   adaptAddressToFormFields,
   isShippingAddressSet

--- a/src/components/CheckoutActions/CheckoutActions.js
+++ b/src/components/CheckoutActions/CheckoutActions.js
@@ -72,8 +72,8 @@ export default class CheckoutActions extends Component {
     cartStore.setStripeToken(stripeToken);
   }
 
-  placeOrder = async () => {
-    const { authStore, cart, cartStore, placeOrderWithStripeCard } = this.props;
+  buildOrder = () => {
+    const { cart, cartStore } = this.props;
     const cartId = cartStore.hasAccountCart ? cartStore.accountCartId : cartStore.anonymousCartId;
     const { checkout, email, shop } = cart;
     const fulfillmentGroups = checkout.fulfillmentGroups.map((group) => {
@@ -105,8 +105,14 @@ export default class CheckoutActions extends Component {
       shopId: shop._id
     };
 
-    this.setState({ placingOrder: true });
+    this.setState({ placingOrder: true }, () => {
+      this.placeOrder(order)
+    });
 
+  }
+
+  placeOrder = async (order) => {
+    const { authStore, cartStore, placeOrderWithStripeCard } = this.props;
     const { data, error } = await placeOrderWithStripeCard(order);
 
     // If success
@@ -204,7 +210,7 @@ export default class CheckoutActions extends Component {
         label: "Review and place order",
         status: "incomplete",
         component: FinalReviewCheckoutAction,
-        onSubmit: this.placeOrder,
+        onSubmit: this.buildOrder,
         props: {
           checkoutSummary
         }

--- a/src/components/CheckoutActions/CheckoutActions.js
+++ b/src/components/CheckoutActions/CheckoutActions.js
@@ -142,7 +142,6 @@ export default class CheckoutActions extends Component {
         fullScreen
         open={isPlacingOrder}
         onClose={this.handleClose}
-        TransitionComponent={(props) => <Fade in={true} {...props} />}
       >
         <PageLoading delay={0} message="Placing your order..."/>
       </Dialog>

--- a/src/components/CheckoutActions/CheckoutActions.js
+++ b/src/components/CheckoutActions/CheckoutActions.js
@@ -106,9 +106,8 @@ export default class CheckoutActions extends Component {
     };
 
     this.setState({ placingOrder: true }, () => {
-      this.placeOrder(order)
+      this.placeOrder(order);
     });
-
   }
 
   placeOrder = async (order) => {

--- a/src/components/MiniCart/MiniCart.js
+++ b/src/components/MiniCart/MiniCart.js
@@ -90,11 +90,15 @@ export default class MiniCart extends Component {
   }
 
   handleClick = () => Router.pushRoute("/");
-  handleCheckoutButtonClick = () => Router.pushRoute("/cart/checkout");
+
+  handleCheckoutButtonClick = () => {
+    this.handleLeavePopper();
+    Router.pushRoute("/cart/checkout");
+  }
 
   handlePopperClose = () => {
     const { closeCart } = this.props.uiStore;
-    closeCart();
+    closeCart(0);
   }
 
   handleEnterPopper = () => {

--- a/src/components/PageLoading/PageLoading.js
+++ b/src/components/PageLoading/PageLoading.js
@@ -23,11 +23,13 @@ const styles = () => ({
 class PageLoading extends Component {
   static propTypes = {
     classes: PropTypes.object,
+    delay: PropTypes.number,
     message: PropTypes.string,
     theme: PropTypes.object
   };
 
   static defaultProps = {
+    delay: 800,
     message: null
   }
 
@@ -36,11 +38,13 @@ class PageLoading extends Component {
   }
 
   componentDidMount() {
+    const { delay } = this.props;
+
     this.timeout = setTimeout(() => {
       this.setState({
         delayIsDone: true
       });
-    }, 800);
+    }, delay);
   }
 
   componentWillUnmount() {

--- a/src/components/PageLoading/PageLoading.js
+++ b/src/components/PageLoading/PageLoading.js
@@ -119,7 +119,7 @@ class PageLoading extends Component {
 
     return (
       <Typography variant="body1" className={classes.message}>{message}</Typography>
-    )
+    );
   }
 
   render() {

--- a/src/components/ProductDetailAddToCart/ProductDetailAddToCart.js
+++ b/src/components/ProductDetailAddToCart/ProductDetailAddToCart.js
@@ -107,8 +107,7 @@ export default class ProductDetailAddToCart extends Component {
     classes: PropTypes.object,
     onClick: PropTypes.func,
     uiStore: PropTypes.shape({
-      closeCartPopover: PropTypes.func,
-      openCartPopover: PropTypes.func
+      openCartWithTimeout: PropTypes.func
     }).isRequired
   };
 
@@ -135,13 +134,9 @@ export default class ProductDetailAddToCart extends Component {
     // Reset cart quantity to 1 after items are added to cart
     this.setState({ addToCartQuantity: 1 });
 
-    // Open cart popover on addToCart
-    uiStore.openCartPopover();
+    // Open cart popper on addToCart
+    uiStore.openCartWithTimeout();
 
-    // Close cart popover after 3 seconds
-    setTimeout(() => {
-      uiStore.closeCartPopover();
-    }, 3000);
   }
 
   handleQuantityInputChange = (event) => {

--- a/src/components/ProductDetailAddToCart/ProductDetailAddToCart.js
+++ b/src/components/ProductDetailAddToCart/ProductDetailAddToCart.js
@@ -136,7 +136,6 @@ export default class ProductDetailAddToCart extends Component {
 
     // Open cart popper on addToCart
     uiStore.openCartWithTimeout();
-
   }
 
   handleQuantityInputChange = (event) => {

--- a/src/containers/cart/withCart.js
+++ b/src/containers/cart/withCart.js
@@ -57,11 +57,10 @@ export default function withCart(Component) {
 
       // Update the anonymousCartId if necessary
       cartStore.setAnonymousCartCredentialsFromLocalStorage();
-
     }
 
     /**
-     * Clears an authenticated user's cart, this method is 
+     * Clears an authenticated user's cart, this method is
      * called after successfully placing on order.
      * @name clearAuthenticatedUsersCart
      * @summary Called when an authenticated user's cart needs to be cleared.

--- a/src/containers/cart/withCart.js
+++ b/src/containers/cart/withCart.js
@@ -57,6 +57,34 @@ export default function withCart(Component) {
 
       // Update the anonymousCartId if necessary
       cartStore.setAnonymousCartCredentialsFromLocalStorage();
+
+    }
+
+    /**
+     * Clears an authenticated user's cart, this method is 
+     * called after successfully placing on order.
+     * @name clearAuthenticatedUsersCart
+     * @summary Called when an authenticated user's cart needs to be cleared.
+     * @private
+     * @returns {undefined} No return
+     */
+    clearAuthenticatedUsersCart = () => {
+      const {
+        authStore,
+        client: { cache },
+        shop
+      } = this.props;
+
+      if (authStore.isAuthenticated) {
+        cache.writeQuery({
+          query: accountCartByAccountIdQuery,
+          data: { cart: null },
+          variables: {
+            accountId: authStore.accountId,
+            shopId: shop._id
+          }
+        });
+      }
     }
 
     /**
@@ -447,6 +475,7 @@ export default function withCart(Component) {
                     }}
                     onChangeCartItemsQuantity={this.handleChangeCartItemsQuantity}
                     onRemoveCartItems={this.handleRemoveCartItems}
+                    clearAuthenticatedUsersCart={this.clearAuthenticatedUsersCart}
                     refetchCart={refetchCart}
                     setEmailOnAnonymousCart={this.handleSetEmailOnAnonymousCart}
                   />

--- a/src/containers/order/withPlaceStripeOrder.js
+++ b/src/containers/order/withPlaceStripeOrder.js
@@ -2,7 +2,6 @@ import React from "react";
 import PropTypes from "prop-types";
 import { withApollo } from "react-apollo";
 import { inject, observer } from "mobx-react";
-import { Router } from "routes";
 import { placeOrderWithStripeCardPayment } from "./mutations.gql";
 
 /**
@@ -13,7 +12,7 @@ import { placeOrderWithStripeCardPayment } from "./mutations.gql";
  */
 export default (Component) => (
   @withApollo
-  @inject("authStore", "cartStore", "uiStore", "routingStore")
+  @inject("authStore", "cartStore", "routingStore")
   @observer
   class WithPlaceStripeOrder extends React.Component {
     static propTypes = {
@@ -31,7 +30,7 @@ export default (Component) => (
     }
 
     handlePlaceOrderWithStripeCard = async (order) => {
-      const { authStore, cartStore, uiStore, client: apolloClient } = this.props;
+      const { authStore, cartStore, client: apolloClient } = this.props;
       const { fulfillmentGroups } = order;
       const { stripeToken: { billingAddress } } = cartStore;
 

--- a/src/containers/order/withPlaceStripeOrder.js
+++ b/src/containers/order/withPlaceStripeOrder.js
@@ -13,7 +13,7 @@ import { placeOrderWithStripeCardPayment } from "./mutations.gql";
  */
 export default (Component) => (
   @withApollo
-  @inject("authStore", "cartStore", "routingStore")
+  @inject("authStore", "cartStore", "uiStore", "routingStore")
   @observer
   class WithPlaceStripeOrder extends React.Component {
     static propTypes = {
@@ -31,7 +31,7 @@ export default (Component) => (
     }
 
     handlePlaceOrderWithStripeCard = async (order) => {
-      const { authStore, cartStore, client: apolloClient } = this.props;
+      const { authStore, cartStore, uiStore, client: apolloClient } = this.props;
       const { fulfillmentGroups } = order;
       const { stripeToken: { billingAddress } } = cartStore;
 
@@ -63,6 +63,7 @@ export default (Component) => (
       // If success
       if (data && !error) {
         const { placeOrderWithStripeCardPayment: { orders, token } } = data;
+        uiStore.closeCart();
 
         // Clear anonymous cart
         if (!authStore.isAuthenticated) {

--- a/src/lib/stores/CartStore.js
+++ b/src/lib/stores/CartStore.js
@@ -31,7 +31,7 @@ class CartStore {
   @observable accountCartId = null;
 
   /**
-   * Is the cart currently in the process of being reconcoled
+   * Is the cart currently in the process of being reconciled
    *
    * @type Boolean
    */

--- a/src/lib/stores/UIStore.js
+++ b/src/lib/stores/UIStore.js
@@ -24,14 +24,6 @@ class UIStore {
   @observable isCartOpen = false;
 
   /**
-   * Is the cart popover open or closed
-   *
-   * @type Boolean
-   * @default false
-   */
-  @observable isCartPopoverOpen = false;
-
-  /**
    * Is the menu drawer open or closed
    *
    * @type Boolean
@@ -146,14 +138,6 @@ class UIStore {
 
   @action toggleCartOpen() {
     this.isCartOpen = !this.isCartOpen;
-  }
-
-  @action openCartPopover() {
-    this.isCartPopoverOpen = true;
-  }
-
-  @action closeCartPopover() {
-    this.isCartPopoverOpen = false;
   }
 
   @action closeMenuDrawer() {

--- a/src/pages/checkoutComplete.js
+++ b/src/pages/checkoutComplete.js
@@ -77,6 +77,7 @@ const styles = (theme) => ({
 class CheckoutComplete extends Component {
   static propTypes = {
     classes: PropTypes.object,
+    clearAuthenticatedUsersCart: PropTypes.func.isRequired,
     client: PropTypes.object.isRequired,
     hasMoreCartItems: PropTypes.bool,
     isLoading: PropTypes.bool,
@@ -99,7 +100,9 @@ class CheckoutComplete extends Component {
     clearAuthenticatedUsersCart();
   }
 
-  handleCartEmptyClick = () => Router.pushRoute("/");
+  handleCartEmptyClick = () => {
+    Router.pushRoute("/");
+  }
 
   renderFulfillmentGroups() {
     const { classes, order, isLoading } = this.props;

--- a/src/pages/checkoutComplete.js
+++ b/src/pages/checkoutComplete.js
@@ -1,13 +1,15 @@
 import React, { Component, Fragment } from "react";
 import PropTypes from "prop-types";
 import { Router } from "routes";
-import { observer } from "mobx-react";
+import { inject, observer } from "mobx-react";
 import Helmet from "react-helmet";
 import { withStyles } from "@material-ui/core/styles";
 import Typography from "@material-ui/core/Typography";
 import withOrder from "containers/order/withOrder";
 import OrderFulfillmentGroups from "components/OrderFulfillmentGroups";
 import withCart from "containers/cart/withCart";
+import { withApollo } from "react-apollo";
+import { accountCartByAccountIdQuery } from "../containers/cart/queries.gql";
 
 const styles = (theme) => ({
   sectionHeader: {
@@ -70,20 +72,23 @@ const styles = (theme) => ({
   }
 });
 
+@withApollo
 @withOrder
 @withCart
+@inject("authStore", "uiStore")
 @observer
 @withStyles(styles, { withTheme: true })
 class CheckoutComplete extends Component {
   static propTypes = {
+    authStore: PropTypes.object.isRequired,
     classes: PropTypes.object,
+    client: PropTypes.object.isRequired,
     hasMoreCartItems: PropTypes.bool,
     isLoading: PropTypes.bool,
     loadMoreCartItems: PropTypes.func,
     onChangeCartItemsQuantity: PropTypes.func,
     onRemoveCartItems: PropTypes.func,
     order: PropTypes.object,
-    refetchCart: PropTypes.func.isRequired,
     shop: PropTypes.shape({
       name: PropTypes.string.isRequired,
       description: PropTypes.string
@@ -91,38 +96,46 @@ class CheckoutComplete extends Component {
     theme: PropTypes.object.isRequired
   };
 
-  state = {}
+  state = {};
 
   componentDidMount() {
-    const { refetchCart } = this.props;
+    const {
+      authStore,
+      client: { cache },
+      shop
+    } = this.props;
 
-    refetchCart();
+    if (authStore.isAuthenticated) {
+      // Clear user's cart
+      cache.writeQuery({
+        query: accountCartByAccountIdQuery,
+        data: { cart: null },
+        variables: {
+          accountId: authStore.accountId,
+          shopId: shop._id
+        }
+      });
+    }
   }
 
-  handleCartEmptyClick = () => Router.pushRoute("/")
+  handleCartEmptyClick = () => Router.pushRoute("/");
 
   renderFulfillmentGroups() {
-    const {
-      classes,
-      order,
-      isLoading
-    } = this.props;
+    const { classes, order, isLoading } = this.props;
 
     if (isLoading) return null;
 
     return (
       <div className={classes.flexContainer}>
         <div className={classes.fulfillmentGroups}>
-          <OrderFulfillmentGroups
-            order={order}
-          />
+          <OrderFulfillmentGroups order={order} />
         </div>
       </div>
     );
   }
 
   render() {
-    const { classes, shop, order } = this.props;
+    const { classes, order, shop } = this.props;
 
     return (
       <Fragment>
@@ -134,13 +147,17 @@ class CheckoutComplete extends Component {
           <div className={classes.orderDetails}>
             <section className={classes.section}>
               <header className={classes.sectionHeader}>
-                <Typography className={classes.title} variant="title">{"Thank you for your order"}</Typography>
-                <Typography variant="body1">{"Your order ID is"} <strong>{order && order._id}</strong></Typography>
-                <Typography variant="body1">{"We've sent a confirmation email to"} <strong>{order && order.email}</strong></Typography>
+                <Typography className={classes.title} variant="title">
+                  {"Thank you for your order"}
+                </Typography>
+                <Typography variant="body1">
+                  {"Your order ID is"} <strong>{order && order._id}</strong>
+                </Typography>
+                <Typography variant="body1">
+                  {"We've sent a confirmation email to"} <strong>{order && order.email}</strong>
+                </Typography>
               </header>
-              <div className={classes.checkoutContent}>
-                {this.renderFulfillmentGroups()}
-              </div>
+              <div className={classes.checkoutContent}>{this.renderFulfillmentGroups()}</div>
             </section>
           </div>
         </div>

--- a/src/pages/checkoutComplete.js
+++ b/src/pages/checkoutComplete.js
@@ -1,15 +1,13 @@
 import React, { Component, Fragment } from "react";
 import PropTypes from "prop-types";
 import { Router } from "routes";
-import { inject, observer } from "mobx-react";
+import { observer } from "mobx-react";
 import Helmet from "react-helmet";
 import { withStyles } from "@material-ui/core/styles";
 import Typography from "@material-ui/core/Typography";
 import withOrder from "containers/order/withOrder";
 import OrderFulfillmentGroups from "components/OrderFulfillmentGroups";
 import withCart from "containers/cart/withCart";
-import { withApollo } from "react-apollo";
-import { accountCartByAccountIdQuery } from "../containers/cart/queries.gql";
 
 const styles = (theme) => ({
   sectionHeader: {
@@ -72,15 +70,12 @@ const styles = (theme) => ({
   }
 });
 
-@withApollo
-@withOrder
 @withCart
-@inject("authStore", "uiStore")
+@withOrder
 @observer
 @withStyles(styles, { withTheme: true })
 class CheckoutComplete extends Component {
   static propTypes = {
-    authStore: PropTypes.object.isRequired,
     classes: PropTypes.object,
     client: PropTypes.object.isRequired,
     hasMoreCartItems: PropTypes.bool,
@@ -99,23 +94,9 @@ class CheckoutComplete extends Component {
   state = {};
 
   componentDidMount() {
-    const {
-      authStore,
-      client: { cache },
-      shop
-    } = this.props;
+    const { clearAuthenticatedUsersCart } = this.props;
 
-    if (authStore.isAuthenticated) {
-      // Clear user's cart
-      cache.writeQuery({
-        query: accountCartByAccountIdQuery,
-        data: { cart: null },
-        variables: {
-          accountId: authStore.accountId,
-          shopId: shop._id
-        }
-      });
-    }
+    clearAuthenticatedUsersCart();
   }
 
   handleCartEmptyClick = () => Router.pushRoute("/");


### PR DESCRIPTION
Resolves #323 
Impact: minor
Type: bugfix

### Summary
The `MiniCart` popper would occasionally be rendered on the order completed page. This PR fixes that and clears the cart cache on the client instead of querying the server.

## Testing
1. Place an order
2. Verify cart popper is not rendered at the bottom of the page, and that the cart has been cleared.
