### PR TITLE
chore: update components lib to 0.39.3 for grid loop fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@material-ui/core": "^3.1.0",
-    "@reactioncommerce/components": "0.39.1",
+    "@reactioncommerce/components": "0.39.2",
     "@reactioncommerce/components-context": "^1.0.0",
     "@segment/snippet": "^4.3.1",
     "apollo-cache-inmemory": "^1.1.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -943,9 +943,9 @@
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@reactioncommerce/components-context/-/components-context-1.0.0.tgz#587764cf0d1b0312c786b8e4657379de02e13845"
 
-"@reactioncommerce/components@0.39.1":
-  version "0.39.1"
-  resolved "https://registry.yarnpkg.com/@reactioncommerce/components/-/components-0.39.1.tgz#1fe5f7e1797d4f5c6c6b6ee0c9000fa39e150a6b"
+"@reactioncommerce/components@0.39.2":
+  version "0.39.2"
+  resolved "https://registry.yarnpkg.com/@reactioncommerce/components/-/components-0.39.2.tgz#50d6b07258d4b905dc3f1885b9ef71e162a293c2"
   dependencies:
     "@material-ui/core" "^3.1.0"
     lodash.debounce "^4.0.8"


### PR DESCRIPTION
Resolves 302 from the component library: https://github.com/reactioncommerce/reaction-component-library/issues/302
Impact: **major**
Type: **bugfix**

## Description
This PR simply updates the component library version to 0.39.3, resolving an infinite loop discovered in the `CatalogGridItem` component.

## Testing
1. Load the homepage
2. Confirm no CPU spike while app is just sitting idle.
