### PR TITLE
Fixed MiniCart popper occasionally being drawn at the wrong position.

### DIFF
--- a/src/components/MiniCart/MiniCart.js
+++ b/src/components/MiniCart/MiniCart.js
@@ -27,7 +27,7 @@ const styles = ({ palette, zIndex }) => ({
     display: "flex",
     justifyContent: "center",
     alignItems: "center",
-    width: 320,
+    width: 360,
     height: 320,
     border: palette.borders.default
   },


### PR DESCRIPTION
Resolves reactioncommerce/reaction-component-library#299
Impact: **minor**
Type: **bugfix|style**

## Issue
Cart popper occasionally gets aligned too far right. It seems to fix itself after the first open, so seems to be related to on-load style differences like some other recent issues.

## Solution
The empty cart's width was set to `320px`, but the width of the populated cart is `360px`. Because the cart is initially empty on-load, if you happen to open the MiniCart before it populates it will start at `320px` and then resize to `360px`, but keeping the same `translate3d` x value.

Making the empty cart be the same width as the populated cart fixed the issue.

## Testing
1. Add some items to your cart
2. Refresh any page
3. Try to open the MiniCart popper before the page finishes loading and before the cart has populated