### PR TITLE
fix: Duplicated initials in logged in indicator

### DIFF
--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -63,18 +63,7 @@ class Header extends Component {
   // See https://github.com/reactioncommerce/reaction/issues/4646
   get splitNames() {
     const { viewer: { name } } = this.props;
-    const firstName =
-      name &&
-      name
-        .split(" ")
-        .slice(0, -1)
-        .join(" ");
-    const lastName =
-      name &&
-      name
-        .split(" ")
-        .slice(-1)
-        .join(" ");
+    const [firstName, lastName] = name.split(" ");
 
     return {
       firstName,


### PR DESCRIPTION
Impact: minor
Type: bugfix

## Issue
if a user only provide a first name, then the logged in indicator would display duplicate initials


## Testing
1. Log in as admin@localhost, the default credentials
2. Verify the logged in indicator displays only one A, which corresponds to the user name Admin

