### PR TITLE
Add tracking for "Product Added" Segment event

### DIFF
--- a/docs/tracking-events.md
+++ b/docs/tracking-events.md
@@ -211,9 +211,9 @@ class ProductListPage extends Component {
 
 ```
 
-## Track a Product Viewed event
+## Track a Product Viewed or Product Added event
 
-Tracking the `Product Viewed` Segment event provided HOC `trackProductViewed`.
+Tracking for the `Product Viewed` and `Product Added` Segment events is provided by the `trackProduct` HOC.
 
 See `src/components/ProductDetail/ProductDetail.js` for the full example.
 
@@ -222,7 +222,7 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import withCatalogItemProduct from "containers/catalog/withCatalogItemProduct";
 import track from "lib/tracking/track";
-import trackProductViewed from "lib/tracking/trackProductViewed";
+import trackProduct from "lib/tracking/trackProduct";
 
 @withCatalogItemProduct // Product for page with route of `/product/:slugOrId/:variantId?`
 @track()
@@ -238,11 +238,15 @@ class ProductDetailPage extends Component {
     this.selectVariant(product.variants[0]);
   }
 
-  // expects the prop `product`, with `variant` and `optionId` as function params
-  @trackProductViewed()
   selectVariant(variant, optionId) {
     // Do something with selected variant / option
+
+    this.trackAction(variant, optionId, "Product Viewed");
   }
+
+  // expects the prop `product`, and `variant`, `optionId`, and `action` as function params
+  @trackProduct()
+  trackAction(variant, optionId, action) {}
 
   render() {
     return (

--- a/docs/tracking-events.md
+++ b/docs/tracking-events.md
@@ -244,9 +244,11 @@ class ProductDetailPage extends Component {
     this.trackAction({ variant, optionId, action: "Product Viewed" });
   }
 
-  // Expects the prop `product`, and an object with the following keys `variant`, `optionId`, and `action` as a function arg. The `product` prop is provided by the `ProductDetailPage` component.
+  // Expects the prop `product`, and an object with the following keys: 
+  // `variant`, `optionId`, and `action` as a function arg. 
+  // The `product` prop is provided by the `ProductDetailPage` component.
   @trackProduct()
-  trackAction(functionArgs) {}
+  trackAction() {}
 
   render() {
     return (

--- a/docs/tracking-events.md
+++ b/docs/tracking-events.md
@@ -223,6 +223,7 @@ import PropTypes from "prop-types";
 import withCatalogItemProduct from "containers/catalog/withCatalogItemProduct";
 import track from "lib/tracking/track";
 import trackProduct from "lib/tracking/trackProduct";
+import TRACKING from "lib/tracking/constants";
 
 @withCatalogItemProduct // Product for page with route of `/product/:slugOrId/:variantId?`
 @track()
@@ -241,7 +242,7 @@ class ProductDetailPage extends Component {
   selectVariant(variant, optionId) {
     // Do something with selected variant / option
 
-    this.trackAction({ variant, optionId, action: "Product Viewed" });
+    this.trackAction({ variant, optionId, action: TRACKING.PRODUCT_VIEWED });
   }
 
   // Expects the prop `product`, and an object with the following keys: 

--- a/docs/tracking-events.md
+++ b/docs/tracking-events.md
@@ -241,12 +241,12 @@ class ProductDetailPage extends Component {
   selectVariant(variant, optionId) {
     // Do something with selected variant / option
 
-    this.trackAction(variant, optionId, "Product Viewed");
+    this.trackAction({ variant, optionId, action: "Product Viewed" });
   }
 
-  // expects the prop `product`, and `variant`, `optionId`, and `action` as function params
+  // Expects the prop `product`, and an object with the following keys `variant`, `optionId`, and `action` as a function arg. The `product` prop is provided by the `ProductDetailPage` component.
   @trackProduct()
-  trackAction(variant, optionId, action) {}
+  trackAction(functionArgs) {}
 
   render() {
     return (

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "react-dom": "16.4.2",
     "react-helmet": "^5.2.0",
     "react-stripe-elements": "^2.0.1",
-    "react-tracking": "^5.2.1",
+    "react-tracking": "^5.4.1",
     "reacto-form": "^0.0.2",
     "request": "^2.88.0",
     "styled-components": "^3.4.9"

--- a/src/components/ProductDetail/ProductDetail.js
+++ b/src/components/ProductDetail/ProductDetail.js
@@ -90,7 +90,7 @@ class ProductDetail extends Component {
   }
 
   @trackProduct()
-  trackAction(variant, optionId, action) {} // eslint-disable no-unused-vars
+  trackAction(variant, optionId, action) {} // eslint-disable-line no-unused-vars
 
   /**
    * @name handleSelectVariant

--- a/src/components/ProductDetail/ProductDetail.js
+++ b/src/components/ProductDetail/ProductDetail.js
@@ -79,7 +79,7 @@ class ProductDetail extends Component {
       selectOptionId = variant.options[0]._id;
     }
 
-    this.trackAction(variant, optionId, "Product Viewed");
+    this.trackAction({ variant, optionId, action: "Product Viewed" });
 
     uiStore.setPDPSelectedVariantId(variantId, selectOptionId);
 
@@ -90,7 +90,7 @@ class ProductDetail extends Component {
   }
 
   @trackProduct()
-  trackAction(variant, optionId, action) {} // eslint-disable-line no-unused-vars
+  trackAction(functionArgs) {} // eslint-disable-line no-unused-vars
 
   /**
    * @name handleSelectVariant
@@ -151,15 +151,15 @@ class ProductDetail extends Component {
         // depending on the type of user, either authenticated or anonymous.
         const { cart } = data.createCart || data.addCartItems;
 
-        this.trackAction(
-          {
+        this.trackAction({
+          variant: {
             ...selectedVariant,
             cart_id: cart._id, // eslint-disable-line camelcase
             quantity
           },
-          selectedOption ? selectedOption._id : null,
-          "Product Added"
-        );
+          optionId: selectedOption ? selectedOption._id : null,
+          action: "Product Added"
+        });
       }
     }
 

--- a/src/components/ProductDetail/ProductDetail.js
+++ b/src/components/ProductDetail/ProductDetail.js
@@ -8,6 +8,7 @@ import { inject, observer } from "mobx-react";
 import track from "lib/tracking/track";
 import Breadcrumbs from "components/Breadcrumbs";
 import trackProduct from "lib/tracking/trackProduct";
+import TRACKING from "lib/tracking/constants";
 import ProductDetailAddToCart from "components/ProductDetailAddToCart";
 import ProductDetailTitle from "components/ProductDetailTitle";
 import VariantList from "components/VariantList";
@@ -79,7 +80,7 @@ class ProductDetail extends Component {
       selectOptionId = variant.options[0]._id;
     }
 
-    this.trackAction({ variant, optionId, action: "Product Viewed" });
+    this.trackAction({ variant, optionId, action: TRACKING.PRODUCT_VIEWED });
 
     uiStore.setPDPSelectedVariantId(variantId, selectOptionId);
 
@@ -90,7 +91,7 @@ class ProductDetail extends Component {
   }
 
   @trackProduct()
-  trackAction(functionArgs) {} // eslint-disable-line no-unused-vars
+  trackAction() {}
 
   /**
    * @name handleSelectVariant
@@ -158,7 +159,7 @@ class ProductDetail extends Component {
             quantity
           },
           optionId: selectedOption ? selectedOption._id : null,
-          action: "Product Added"
+          action: TRACKING.PRODUCT_ADDED
         });
       }
     }

--- a/src/containers/cart/withCart.js
+++ b/src/containers/cart/withCart.js
@@ -175,7 +175,7 @@ export default function withCart(Component) {
       // Run the mutation function provided as a param.
       // It may take the form of `createCart` or `addCartItems` depending on the
       // availability of a cart for either an anonymous or logged-in account.
-      await mutation({
+      return mutation({
         variables: {
           input
         }
@@ -430,9 +430,9 @@ export default function withCart(Component) {
                 {(mutationFunction) => (
                   <Component
                     {...this.props}
-                    addItemsToCart={async (items) => {
-                      await this.handleAddItemsToCart(mutationFunction, { items }, !cart);
-                    }}
+                    addItemsToCart={async (items) => (
+                      this.handleAddItemsToCart(mutationFunction, { items }, !cart)
+                    )}
                     cart={processedCartData}
                     checkoutMutations={{
                       onSetFulfillmentOption: this.handleSetFulfillmentOption,

--- a/src/containers/cart/withCart.js
+++ b/src/containers/cart/withCart.js
@@ -430,7 +430,7 @@ export default function withCart(Component) {
                 {(mutationFunction) => (
                   <Component
                     {...this.props}
-                    addItemsToCart={async (items) => (
+                    addItemsToCart={(items) => (
                       this.handleAddItemsToCart(mutationFunction, { items }, !cart)
                     )}
                     cart={processedCartData}

--- a/src/lib/tracking/constants.js
+++ b/src/lib/tracking/constants.js
@@ -1,0 +1,5 @@
+export default {
+  PRODUCT_VIEWED: "Product Viewed",
+  PRODUCT_ADDED: "Product Added",
+  PRODUCT_REMOVED: "Product Removed"
+};

--- a/src/lib/tracking/trackProduct.js
+++ b/src/lib/tracking/trackProduct.js
@@ -11,13 +11,7 @@ import getVariantTrackingData from "./utils/getVariantTrackingData";
 export default (options) => (
   track(({ product, router }, state, functionArgs) => {
     let data = {};
-    let variant = null;
-    let optionId = null;
-    let action = "Product Viewed";
-
-    if (functionArgs) {
-      [variant, optionId, action] = functionArgs;
-    }
+    const { variant, optionId, action } = functionArgs[0];
 
     // If product data is provided as a prop, then process the data for tracking
     if (product) {

--- a/src/lib/tracking/trackProduct.js
+++ b/src/lib/tracking/trackProduct.js
@@ -3,36 +3,39 @@ import getProductTrackingData from "./utils/getProductTrackingData";
 import getVariantTrackingData from "./utils/getVariantTrackingData";
 
 /**
- * trackProductViewed higher tracks a product
- * @name trackProductViewed
+ * trackProduct HOC tracks a product
+ * @name trackProduct
  * @param {Object} options options to supply to tracking HOC
  * @returns {React.Component} - component
  */
 export default (options) => (
   track(({ product, router }, state, functionArgs) => {
     let data = {};
+    let variant = null;
+    let optionId = null;
+    let action = "Product Viewed";
+
+    if (functionArgs) {
+      [variant, optionId, action] = functionArgs;
+    }
 
     // If product data is provided as a prop, then process the data for tracking
     if (product) {
       data = {
-        action: "Product Viewed",
+        action,
         ...getProductTrackingData(product)
       };
 
-      if (functionArgs) {
-        const [variant, optionId] = functionArgs;
-
-        // Add variant data if available
-        if (variant) {
-          data = {
-            ...data,
-            ...getVariantTrackingData({
-              variant, // Object representing a variant. (Required)
-              optionId, // Selected option of the provided variant, if available. (Optional)
-              product // Full product document for additional data. (Optional)
-            })
-          };
-        }
+      // Add variant data if available
+      if (variant) {
+        data = {
+          ...data,
+          ...getVariantTrackingData({
+            variant, // Object representing a variant. (Required)
+            optionId, // Selected option of the provided variant, if available. (Optional)
+            product // Full product document for additional data. (Optional)
+          })
+        };
       }
 
       // If the router is provided as a prop, set the url of the product to the current path

--- a/src/lib/tracking/trackProduct.js
+++ b/src/lib/tracking/trackProduct.js
@@ -11,7 +11,7 @@ import getVariantTrackingData from "./utils/getVariantTrackingData";
 export default (options) => (
   track(({ product, router }, state, functionArgs) => {
     let data = {};
-    const { variant, optionId, action } = functionArgs[0];
+    const { variant, optionId, action } = (functionArgs && functionArgs[0]) || [];
 
     // If product data is provided as a prop, then process the data for tracking
     if (product) {
@@ -25,9 +25,9 @@ export default (options) => (
         data = {
           ...data,
           ...getVariantTrackingData({
+            product, // Full product document for additional data. (Optional)
             variant, // Object representing a variant. (Required)
-            optionId, // Selected option of the provided variant, if available. (Optional)
-            product // Full product document for additional data. (Optional)
+            optionId // Selected option of the provided variant, if available. (Optional)
           })
         };
       }

--- a/src/lib/tracking/trackProduct.test.js
+++ b/src/lib/tracking/trackProduct.test.js
@@ -1,14 +1,14 @@
 import dispatch from "./dispatch";
-import trackProductViewed from "./trackProductViewed";
+import trackProduct from "./trackProduct";
 
 jest.mock("./dispatch", () => jest.fn());
 
-test("component decorated with trackProductViewed should dispatch tracking events", () => {
+test("component decorated with trackProduct should dispatch tracking events", () => {
   const props = { props: 1 };
   const context = { context: 1 };
   const trackingContext = { dispatch };
 
-  @trackProductViewed(trackingContext)
+  @trackProduct(trackingContext)
   class TestComponent {
     static displayName = "TestComponent"
   }

--- a/src/lib/tracking/utils/getVariantTrackingData.js
+++ b/src/lib/tracking/utils/getVariantTrackingData.js
@@ -55,10 +55,17 @@ export default function getVariantTrackingData({ product, variant, optionId }) {
     }
   }
 
+  // If a cart_id is provided, then added it to tracking object
+  let cart = {};
+  if (data.cart_id) {
+    cart = { cart_id: data.cart_id }; // eslint-disable-line camelcase
+  }
+
   return {
+    ...cart,
     variant: data._id,
     price,
-    quantity: 1,
+    quantity: data.quantity || 1,
     position: data.index,
     value: price,
     image_url: imageURL, // eslint-disable-line camelcase

--- a/src/lib/tracking/utils/getVariantTrackingData.js
+++ b/src/lib/tracking/utils/getVariantTrackingData.js
@@ -7,12 +7,15 @@ import routes from "routes";
  * @param {Object} data.product Parent product of the selected variant
  * @param {Object} data.variant Object of the selected variant
  * @param {Object} [data.optionId] Id of the selected option
- * @returns {Object} Data sutable for trackign a variant
+ * @returns {Object} Data suitable for tracking a variant
  */
 export default function getVariantTrackingData({ product, variant, optionId }) {
-  let data = variant;
+  let data = { ...variant };
+  // If a cart_id is provided, then added it to tracking object
+  const cartId = data.cart_id ? { cart_id: data.cart_id } : {}; // eslint-disable-line camelcase
   let imageURL;
   let price;
+  const quantity = data.quantity || 1;
   let url;
 
   // If an option id is provided, use the option instead of the top level variant
@@ -55,17 +58,11 @@ export default function getVariantTrackingData({ product, variant, optionId }) {
     }
   }
 
-  // If a cart_id is provided, then added it to tracking object
-  let cart = {};
-  if (data.cart_id) {
-    cart = { cart_id: data.cart_id }; // eslint-disable-line camelcase
-  }
-
   return {
-    ...cart,
+    ...cartId,
     variant: data._id,
     price,
-    quantity: data.quantity || 1,
+    quantity,
     position: data.index,
     value: price,
     image_url: imageURL, // eslint-disable-line camelcase

--- a/src/pages/cart.js
+++ b/src/pages/cart.js
@@ -5,7 +5,6 @@ import { inject, observer } from "mobx-react";
 import Grid from "@material-ui/core/Grid";
 import Typography from "@material-ui/core/Typography";
 import { withStyles } from "@material-ui/core/styles";
-import trackProductViewed from "lib/tracking/trackProductViewed";
 import CartEmptyMessage from "@reactioncommerce/components/CartEmptyMessage/v1";
 import CartSummary from "@reactioncommerce/components/CartSummary/v1";
 import withCart from "containers/cart/withCart";
@@ -39,7 +38,6 @@ const styles = (theme) => ({
   }
 });
 
-@trackProductViewed()
 @withStyles(styles)
 @withCart
 @inject("uiStore")

--- a/yarn.lock
+++ b/yarn.lock
@@ -2927,6 +2927,10 @@ deepmerge@^2.0.1:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-2.1.0.tgz#511a54fff405fc346f0240bb270a3e9533a31102"
 
+deepmerge@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-2.1.1.tgz#e862b4e45ea0555072bf51e7fd0d9845170ae768"
+
 default-require-extensions@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/default-require-extensions/-/default-require-extensions-1.0.0.tgz#f37ea15d3e13ffd9b437d33e1a75b5fb97874cb8"
@@ -4278,6 +4282,12 @@ hoist-non-react-statics@2.5.5:
 hoist-non-react-statics@^2.3.1, hoist-non-react-statics@^2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.0.tgz#d2ca2dfc19c5a91c5a6615ce8e564ef0347e2a40"
+
+hoist-non-react-statics@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.0.1.tgz#fba3e7df0210eb9447757ca1a7cb607162f0a364"
+  dependencies:
+    react-is "^16.3.2"
 
 home-or-tmp@^2.0.0:
   version "2.0.0"
@@ -7139,12 +7149,12 @@ react-test-renderer@^16.0.0-0, react-test-renderer@^16.3.1:
     prop-types "^15.6.0"
     react-is "^16.3.2"
 
-react-tracking@^5.2.1:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/react-tracking/-/react-tracking-5.2.1.tgz#3eb0e580fd740252aa7ce9d8fb0e9e9408921a44"
+react-tracking@^5.4.1:
+  version "5.4.1"
+  resolved "https://registry.yarnpkg.com/react-tracking/-/react-tracking-5.4.1.tgz#2a85793326aadefa9c3955332181279904fa72c4"
   dependencies:
-    deepmerge "^2.0.1"
-    hoist-non-react-statics "^2.3.1"
+    deepmerge "^2.1.1"
+    hoist-non-react-statics "^3.0.1"
 
 react-transition-group@^2.2.1:
   version "2.3.1"


### PR DESCRIPTION
Resolves #360 
Impact: minor
Type: feature

## Summary
Add tracking for "Product Added" Segment event.

## Testing
1. Click on a product to enter the product's details page
2. Verify that a "Product Viewed" event was recorded in the Segment dashboard
4. Increment a product's quantity to an arbitrary number
3. Click the "Add to cart" button
4. Verify a "Product Added" was recorded in the Segment dashboard. The event should include the correct quantity and cartId.
5. Login
6. Repeat steps 1-4,


