### PR TITLE
fix: issue cause by using Router from `next/routes` on the server

### DIFF
--- a/src/lib/stores/RoutingStore.js
+++ b/src/lib/stores/RoutingStore.js
@@ -86,7 +86,11 @@ export default class RoutingStore {
       path = `${this.pathname}?${this.queryString}`;
     }
 
-    Router.pushRoute(path, path, { shallow: true });
+    // Router is only available for the client (browser)
+    if (process.browser) {
+      Router.pushRoute(path, path, { shallow: true });
+    }
+
     return path;
   }
 }


### PR DESCRIPTION
Resolves #348 
Impact: **critical**
Type: **bugfix**

## Issue

Refreshing on pages that use search queries, like the product grid, causes the app to crash due to trying to access `Router` on the server.

## Solution

Use the Router on the client (browser) only by placing it within an "is browser" conditional.

## Breaking changes

none

## Testing

1. With sample data loaded to be able to test other tag grids
2. Navigate to another grid via the menu
3. Page should load
4. Refresh the page manually
5. The page should load properly
6. Ensure query params are properly applied to the page. (number of items per page, the current page, and other filters)

---

1. Disable javascript
1. Ensure query params are properly applied to the page in SSR mode. (number of items per page, the current page, and other filters)

