### PR TITLE
Add tracking for "Product Removed" + "Cart Viewed" events

### DIFF
--- a/src/components/MiniCart/MiniCart.js
+++ b/src/components/MiniCart/MiniCart.js
@@ -83,9 +83,17 @@ export default class MiniCart extends Component {
   }
 
   state = {
-    open: false,
     anchorElement: null
   };
+
+  componentDidUpdate() {
+    const { cart, uiStore: { isCartOpen } } = this.props;
+
+    // Track a cart view event
+    if ((cart && Array.isArray(cart.items) && cart.items.length) && isCartOpen) {
+      this.trackAction({ cartItems: cart.items, cartId: cart._id, action: TRACKING.CART_VIEWED });
+    }
+  }
 
   anchorElement = null
 

--- a/src/containers/cart/fragments.gql
+++ b/src/containers/cart/fragments.gql
@@ -159,6 +159,12 @@ fragment CartItemConnectionFragment on CartItemConnection {
         _id
       }
       title
+      productTags {
+        nodes {
+          name
+        }
+      }
+      productVendor
       variantTitle
       optionTitle
       updatedAt

--- a/src/containers/cart/withCart.js
+++ b/src/containers/cart/withCart.js
@@ -228,7 +228,7 @@ export default function withCart(Component) {
     handleRemoveCartItems = (itemIds) => {
       const { cartStore, client: apolloClient } = this.props;
 
-      apolloClient.mutate({
+      return apolloClient.mutate({
         mutation: removeCartItemsMutation,
         variables: {
           input: {

--- a/src/lib/tracking/constants.js
+++ b/src/lib/tracking/constants.js
@@ -1,4 +1,5 @@
 export default {
+  CART_VIEWED: "Cart Viewed",
   PRODUCT_VIEWED: "Product Viewed",
   PRODUCT_ADDED: "Product Added",
   PRODUCT_REMOVED: "Product Removed"

--- a/src/lib/tracking/trackCartItems.js
+++ b/src/lib/tracking/trackCartItems.js
@@ -1,0 +1,36 @@
+import track from "./track";
+import getCartItemTrackingData from "./utils/getCartItemTrackingData";
+
+/**
+ * trackCartItems HOC tracks an items in the cart
+ * @name trackCartItem
+ * @param {Object} options options to supply to tracking HOC
+ * @returns {React.Component} - component
+ */
+export default (options) => (
+  track((state, functionArgs) => {
+    const { cartItems, action } = (functionArgs && functionArgs[0]) || [];
+    let data = {};
+
+    if (cartItems) {
+      if (Array.isArray(cartItems)) {
+        const products = [];
+        cartItems.forEach((item) => {
+          products.push(getCartItemTrackingData(item));
+        });
+        data = {
+          products
+        };
+      } else {
+        data = {
+          ...getCartItemTrackingData(cartItems)
+        };
+      }
+    }
+
+    return {
+      action,
+      ...data
+    };
+  }, options)
+);

--- a/src/lib/tracking/trackCartItems.js
+++ b/src/lib/tracking/trackCartItems.js
@@ -8,7 +8,7 @@ import getCartItemTrackingData from "./utils/getCartItemTrackingData";
  * @returns {React.Component} - component
  */
 export default (options) => (
-  track((state, functionArgs) => {
+  track(({ router }, state, functionArgs) => {
     const { cartItems, action } = (functionArgs && functionArgs[0]) || [];
     let data = {};
 

--- a/src/lib/tracking/trackCartItems.js
+++ b/src/lib/tracking/trackCartItems.js
@@ -9,23 +9,28 @@ import getCartItemTrackingData from "./utils/getCartItemTrackingData";
  */
 export default (options) => (
   track(({ router }, state, functionArgs) => {
-    const { cartItems, action } = (functionArgs && functionArgs[0]) || [];
+    const { cartItems, cartId, action } = (functionArgs && functionArgs[0]) || [];
     let data = {};
 
-    if (cartItems) {
-      if (Array.isArray(cartItems)) {
-        const products = [];
-        cartItems.forEach((item) => {
-          products.push(getCartItemTrackingData(item));
-        });
-        data = {
-          products
-        };
-      } else {
-        data = {
-          ...getCartItemTrackingData(cartItems)
-        };
+    if (Array.isArray(cartItems)) {
+      const products = [];
+      cartItems.forEach((item) => {
+        products.push(getCartItemTrackingData(item));
+      });
+
+      data = {
+        cart_id: cartId, // eslint-disable-line camelcase
+        products
+      };
+
+      // If the router is provided as a prop, set the url of the product to the current path
+      if (router) {
+        data.url = router.asPath;
       }
+    } else {
+      data = {
+        ...getCartItemTrackingData(cartItems)
+      };
     }
 
     return {

--- a/src/lib/tracking/utils/getCartItemTrackingData.js
+++ b/src/lib/tracking/utils/getCartItemTrackingData.js
@@ -1,0 +1,34 @@
+import routes from "routes";
+import { decodeOpaqueId } from "lib/utils/decoding";
+
+/**
+ * Transform a CartItem object into a partial representation of the Segment product schema
+ * @name getCartItemTrackingData
+ * @param {Object} cartItem Object of the `CartItem` type
+ * @returns {Object} Data suitable for tracking a `CartItem`
+ */
+export default function getCartItemTrackingData(cartItem) {
+  const variant = { ...cartItem };
+  let url;
+
+  const { id } = decodeOpaqueId(variant._id);
+  const route = routes.findAndGetUrls("product", { slugOrId: variant.productSlug || id });
+
+  if (route && route.urls) {
+    url = route.urls.as;
+  }
+
+  return {
+    cart_id: variant.cart_id, // eslint-disable-line camelcase
+    product_id: variant.productConfiguration.productVariantId, // eslint-disable-line camelcase
+    sku: variant.sku,
+    category: (variant.productTags.nodes.length && variant.productTags.nodes[0].name) || undefined,
+    name: variant.title,
+    brand: variant.productVendor,
+    variant: variant.title,
+    price: variant.price.amount,
+    quantity: variant.quantity,
+    image_url: variant.imageURLs.original, // eslint-disable-line camelcase
+    url
+  };
+}

--- a/src/lib/tracking/utils/getVariantTrackingData.js
+++ b/src/lib/tracking/utils/getVariantTrackingData.js
@@ -11,7 +11,6 @@ import routes from "routes";
  */
 export default function getVariantTrackingData({ product, variant, optionId }) {
   let data = { ...variant };
-  // If a cart_id is provided, then added it to tracking object
   const cartId = data.cart_id ? { cart_id: data.cart_id } : {}; // eslint-disable-line camelcase
   let imageURL;
   let price;
@@ -60,7 +59,7 @@ export default function getVariantTrackingData({ product, variant, optionId }) {
 
   return {
     ...cartId,
-    variant: data._id,
+    variant: data.title,
     price,
     quantity,
     position: data.index,

--- a/src/lib/utils/decoding.js
+++ b/src/lib/utils/decoding.js
@@ -4,9 +4,13 @@
  * @param {String} opaqueId - A a base64 encoded id
  * @returns {String} - A base64 decoded id
  */
-export function decodeOpaqueId(opaqueId) {
+function decodeOpaqueId(opaqueId) {
   if (opaqueId === undefined || opaqueId === null) return null;
   const unencoded = Buffer.from(opaqueId, "base64").toString("utf8");
   const [namespace, id] = unencoded.split(":");
   return { namespace, id };
 }
+
+module.exports = {
+  decodeOpaqueId
+};

--- a/src/lib/utils/decoding.js
+++ b/src/lib/utils/decoding.js
@@ -1,0 +1,12 @@
+/**
+ * Decode a Base64 encoded id
+ *
+ * @param {String} opaqueId - A a base64 encoded id
+ * @returns {String} - A base64 decoded id
+ */
+export function decodeOpaqueId(opaqueId) {
+  if (opaqueId === undefined || opaqueId === null) return null;
+  const unencoded = Buffer.from(opaqueId, "base64").toString("utf8");
+  const [namespace, id] = unencoded.split(":");
+  return { namespace, id };
+}

--- a/src/pages/cart.js
+++ b/src/pages/cart.js
@@ -12,6 +12,7 @@ import CartItems from "components/CartItems";
 import CheckoutButtons from "components/CheckoutButtons";
 import Link from "components/Link";
 import { Router } from "routes";
+import PageLoading from "components/PageLoading";
 import track from "lib/tracking/track";
 import variantById from "lib/utils/variantById";
 import trackCartItems from "lib/tracking/trackCartItems";
@@ -74,6 +75,15 @@ class CartPage extends Component {
       description: PropTypes.string
     })
   };
+
+  componentDidMount() {
+    const { cart } = this.props;
+
+    // Track a cart view event
+    if (cart && Array.isArray(cart.items) && cart.items.length) {
+      this.trackAction({ cartItems: cart.items, cartId: cart._id, action: TRACKING.CART_VIEWED });
+    }
+  }
 
   handleClick = () => Router.pushRoute("/");
 
@@ -151,7 +161,9 @@ class CartPage extends Component {
   }
 
   render() {
-    const { classes, shop } = this.props;
+    const { cart, classes, shop } = this.props;
+
+    if (!cart) return <PageLoading />;
 
     return (
       <Fragment>

--- a/src/pages/cart.js
+++ b/src/pages/cart.js
@@ -12,8 +12,8 @@ import CartItems from "components/CartItems";
 import CheckoutButtons from "components/CheckoutButtons";
 import Link from "components/Link";
 import { Router } from "routes";
-import variantById from "lib/utils/variantById";
 import track from "lib/tracking/track";
+import variantById from "lib/utils/variantById";
 import trackCartItems from "lib/tracking/trackCartItems";
 import TRACKING from "lib/tracking/constants";
 
@@ -83,6 +83,9 @@ class CartPage extends Component {
     onChangeCartItemsQuantity({ quantity, cartItemId });
   };
 
+  @trackCartItems()
+  trackAction() {}
+
   handleRemoveItem = async (itemId) => {
     const { cart: { items }, onRemoveCartItems } = this.props;
 
@@ -96,9 +99,6 @@ class CartPage extends Component {
       this.trackAction({ cartItems: removedItem, action: TRACKING.PRODUCT_REMOVED });
     }
   };
-
-  @trackCartItems()
-  trackAction() {}
 
   renderCartItems() {
     const { cart, classes, hasMoreCartItems, loadMoreCartItems } = this.props;

--- a/src/server.js
+++ b/src/server.js
@@ -1,3 +1,5 @@
+import { decodeOpaqueId } from "lib/utils/decoding";
+
 const cookieParser = require("cookie-parser");
 const cookieSession = require("cookie-session");
 const express = require("express");
@@ -13,12 +15,6 @@ const router = require("./routes");
 
 const app = nextApp({ dir: appPath, dev });
 const routeHandler = router.getRequestHandler(app);
-const decodeOpaqueId = (opaqueId) => {
-  if (opaqueId === undefined || opaqueId === null) return null;
-  const unencoded = Buffer.from(opaqueId, "base64").toString("utf8");
-  const [namespace, id] = unencoded.split(":");
-  return { namespace, id };
-};
 
 // This is needed to allow custom parameters (e.g loginActions) to be included
 // when requesting authorization. This is setup to allow only loginAction to pass through

--- a/src/server.js
+++ b/src/server.js
@@ -1,5 +1,3 @@
-import { decodeOpaqueId } from "lib/utils/decoding";
-
 const cookieParser = require("cookie-parser");
 const cookieSession = require("cookie-session");
 const express = require("express");
@@ -10,6 +8,7 @@ const logger = require("lib/logger");
 const passport = require("passport");
 const OAuth2Strategy = require("passport-oauth2");
 const refresh = require("passport-oauth2-refresh");
+const { decodeOpaqueId } = require("lib/utils/decoding");
 const { appPath, dev } = require("./config");
 const router = require("./routes");
 


### PR DESCRIPTION
Resolves #371
Impact: minor
Type: feature

## Summary
This PR adds code to track when a user removes an item from their cart and when the user views their cart.

## Testing

1. Configure the starterkit with your segment API key, find configuration details here: https://github.com/reactioncommerce/reaction-next-starterkit/blob/develop/docs/tracking-events.md
2. Open Segment's debug panel for you account
3. Add an item to your cart with a quantity of > 1
4. Navigate to the `/cart` page
5. Verify that a "Cart Viewed" event was logged in Segment's debug panel
6. Hover over cart icon
7. Verify that a "Cart Viewed" event was logged in Segment's debug panel

### Product Removed event
1. Add an item to your cart
2. Navigate to `/cart` page
3. click on "Remove" on an item
4. Verify that a "Product Removed" event was logged in Segment's debug panel

1. Add an item to the cart
2. hover over the cart icon
3. click on "Remove" on an item
4. Verify that a "Product Removed" event was logged in Segment's debug panel