### PR TITLE
fix: PDP Mobile re-org

### DIFF
--- a/src/components/ProductDetail/ProductDetail.js
+++ b/src/components/ProductDetail/ProductDetail.js
@@ -253,10 +253,8 @@ class ProductDetail extends Component {
         <Fragment>
           <div className={classes.section}>
             <ProductDetailTitle pageTitle={product.pageTitle} title={product.title} />
-            <ProductDetailInfo
-              priceRange={productPrice.displayPrice}
-              vendor={product.vendor}
-            />
+            <ProductDetailInfo vendor={product.vendor} />
+            <ProductDetailInfo priceRange={productPrice.displayPrice} />
           </div>
 
           <div className={classes.section}>

--- a/src/components/ProductDetail/ProductDetail.js
+++ b/src/components/ProductDetail/ProductDetail.js
@@ -3,7 +3,6 @@ import PropTypes from "prop-types";
 import { withStyles } from "@material-ui/core/styles";
 import Grid from "@material-ui/core/Grid";
 import withWidth, { isWidthUp, isWidthDown } from "@material-ui/core/withWidth";
-import Hidden from "@material-ui/core/Hidden";
 import { inject, observer } from "mobx-react";
 import track from "lib/tracking/track";
 import Breadcrumbs from "components/Breadcrumbs";

--- a/src/components/ProductDetail/ProductDetail.js
+++ b/src/components/ProductDetail/ProductDetail.js
@@ -2,7 +2,7 @@ import React, { Component, Fragment } from "react";
 import PropTypes from "prop-types";
 import { withStyles } from "@material-ui/core/styles";
 import Grid from "@material-ui/core/Grid";
-import withWidth, { isWidthUp } from "@material-ui/core/withWidth";
+import withWidth, { isWidthUp, isWidthDown } from "@material-ui/core/withWidth";
 import Hidden from "@material-ui/core/Hidden";
 import { inject, observer } from "mobx-react";
 import track from "lib/tracking/track";
@@ -217,7 +217,8 @@ class ProductDetail extends Component {
       routingStore: { tag },
       tags,
       theme,
-      uiStore: { pdpSelectedOptionId, pdpSelectedVariantId }
+      uiStore: { pdpSelectedOptionId, pdpSelectedVariantId },
+      width
     } = this.props;
 
     // Set the default media as the top-level product's media
@@ -247,37 +248,61 @@ class ProductDetail extends Component {
 
     const productPrice = this.determineProductPrice();
 
+    // Phone size
+    if (isWidthDown("sm", width)) {
+      return (
+        <Fragment>
+          <div className={classes.section}>
+            <ProductDetailTitle pageTitle={product.pageTitle} title={product.title} />
+            <ProductDetailInfo
+              priceRange={productPrice.displayPrice}
+              vendor={product.vendor}
+            />
+          </div>
+
+          <div className={classes.section}>
+            <MediaGallery mediaItems={pdpMediaItems} />
+          </div>
+
+          <div className={classes.section}>
+            <VariantList
+              onSelectOption={this.handleSelectOption}
+              onSelectVariant={this.handleSelectVariant}
+              product={product}
+              selectedOptionId={pdpSelectedOptionId}
+              selectedVariantId={pdpSelectedVariantId}
+              currencyCode={currencyCode}
+              variants={product.variants}
+            />
+            <ProductDetailAddToCart onClick={this.handleAddToCartClick} />
+          </div>
+
+          <div className={classes.section}>
+            <ProductDetailInfo
+              description={product.description}
+            />
+          </div>
+        </Fragment>
+      );
+    }
+
     return (
       <Fragment>
         <Grid container spacing={theme.spacing.unit * 5}>
-          <Hidden smUp>
-            <ProductDetailTitle
-              pageTitle={product.pageTitle}
-              title={product.title}
-              classes={classes.title}
-              variant="display1"
-            />
-          </Hidden>
-          <Hidden xsDown>
-            <Grid item className={classes.breadcrumbGrid} xs={12}>
-              <Breadcrumbs isPDP={true} tag={tag} tags={tags} product={product} />
-            </Grid>
-          </Hidden>
+          <Grid item className={classes.breadcrumbGrid} xs={12}>
+            <Breadcrumbs isPDP={true} tag={tag} tags={tags} product={product} />
+          </Grid>
           <Grid item xs={12} sm={6}>
             <div className={classes.section}>
               <MediaGallery mediaItems={pdpMediaItems} />
             </div>
-            <Hidden xsDown>
-              <div className={classes.section}>
-                <TagGrid tags={product.tags.nodes} />
-              </div>
-            </Hidden>
+            <div className={classes.section}>
+              <TagGrid tags={product.tags.nodes} />
+            </div>
           </Grid>
 
           <Grid item xs={12} sm={6}>
-            <Hidden xsDown>
-              <ProductDetailTitle pageTitle={product.pageTitle} title={product.title} />
-            </Hidden>
+            <ProductDetailTitle pageTitle={product.pageTitle} title={product.title} />
             <ProductDetailInfo
               priceRange={productPrice.displayPrice}
               description={product.description}

--- a/src/components/ProductDetail/__snapshots__/ProductDetail.test.js.snap
+++ b/src/components/ProductDetail/__snapshots__/ProductDetail.test.js.snap
@@ -8,10 +8,10 @@ exports[`basic snapshot 1`] = `
     className="MuiGrid-item-4 MuiGrid-grid-xs-12-43 SkProductDetail-breadcrumbGrid-2"
   >
     <div
-      className="SkBreadcrumbs-container-238"
+      className="SkBreadcrumbs-container-100"
     >
       <a
-        className="SkLink-anchor-241"
+        className="SkLink-anchor-103"
         href="/"
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -19,14 +19,14 @@ exports[`basic snapshot 1`] = `
         tabIndex={0}
       >
         <span
-          className="SkBreadcrumbs-breadcrumbLink-239"
+          className="SkBreadcrumbs-breadcrumbLink-101"
         >
           Home
         </span>
       </a>
       <svg
         aria-hidden="true"
-        className="MuiSvgIcon-root-206 SkBreadcrumbs-breadcrumbIcon-240"
+        className="MuiSvgIcon-root-104 SkBreadcrumbs-breadcrumbIcon-102"
         focusable="false"
         role="presentation"
         viewBox="0 0 24 24"
@@ -36,7 +36,7 @@ exports[`basic snapshot 1`] = `
         />
       </svg>
       <a
-        className="SkLink-anchor-241"
+        className="SkLink-anchor-103"
         href="/tag/tag-a"
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -44,14 +44,14 @@ exports[`basic snapshot 1`] = `
         tabIndex={0}
       >
         <span
-          className="SkBreadcrumbs-breadcrumbLink-239"
+          className="SkBreadcrumbs-breadcrumbLink-101"
         >
           Tag A
         </span>
       </a>
       <svg
         aria-hidden="true"
-        className="MuiSvgIcon-root-206 SkBreadcrumbs-breadcrumbIcon-240"
+        className="MuiSvgIcon-root-104 SkBreadcrumbs-breadcrumbIcon-102"
         focusable="false"
         role="presentation"
         viewBox="0 0 24 24"
@@ -61,7 +61,7 @@ exports[`basic snapshot 1`] = `
         />
       </svg>
       <a
-        className="SkLink-anchor-241"
+        className="SkLink-anchor-103"
         href="/product/example-product"
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -69,7 +69,7 @@ exports[`basic snapshot 1`] = `
         tabIndex={0}
       >
         <span
-          className="SkBreadcrumbs-breadcrumbLink-239"
+          className="SkBreadcrumbs-breadcrumbLink-101"
         >
           Reaction Sample Product
         </span>
@@ -83,20 +83,20 @@ exports[`basic snapshot 1`] = `
       className="SkProductDetail-section-1"
     >
       <div
-        className="MuiGrid-container-3 SkMediaGallery-root-100"
+        className="MuiGrid-container-3 SkMediaGallery-root-113"
       >
         <div
           className="MuiGrid-item-4 MuiGrid-grid-xs-12-43 MuiGrid-grid-sm-12-57"
         >
           <div
-            className="SkMediaGallery-featured-101"
+            className="SkMediaGallery-featured-114"
           >
             <div
-              className="SkImg-imgWrapper-103 "
+              className="SkImg-imgWrapper-116 "
             >
               <img
                 alt=""
-                className="SkImg-img-105 SkImg-imgLoading-107 "
+                className="SkImg-img-118 SkImg-imgLoading-120 "
                 src="/resources/placeholder.gif"
               />
             </div>
@@ -108,7 +108,7 @@ exports[`basic snapshot 1`] = `
               className="MuiGrid-item-4 MuiGrid-grid-xs-3-34 MuiGrid-grid-sm-2-47"
             >
               <button
-                className="MuiButtonBase-root-110 SkMediaGalleryItem-root-109"
+                className="MuiButtonBase-root-123 SkMediaGalleryItem-root-122"
                 onBlur={[Function]}
                 onClick={[Function]}
                 onFocus={[Function]}
@@ -124,16 +124,16 @@ exports[`basic snapshot 1`] = `
                 type="button"
               >
                 <div
-                  className="SkImg-imgWrapper-103 "
+                  className="SkImg-imgWrapper-116 "
                 >
                   <img
                     alt=""
-                    className="SkImg-img-105 SkImg-imgLoading-107 "
+                    className="SkImg-img-118 SkImg-imgLoading-120 "
                     src="/resources/placeholder.gif"
                   />
                 </div>
                 <span
-                  className="MuiTouchRipple-root-113"
+                  className="MuiTouchRipple-root-126"
                 />
               </button>
             </div>
@@ -141,7 +141,7 @@ exports[`basic snapshot 1`] = `
               className="MuiGrid-item-4 MuiGrid-grid-xs-3-34 MuiGrid-grid-sm-2-47"
             >
               <button
-                className="MuiButtonBase-root-110 SkMediaGalleryItem-root-109"
+                className="MuiButtonBase-root-123 SkMediaGalleryItem-root-122"
                 onBlur={[Function]}
                 onClick={[Function]}
                 onFocus={[Function]}
@@ -157,16 +157,16 @@ exports[`basic snapshot 1`] = `
                 type="button"
               >
                 <div
-                  className="SkImg-imgWrapper-103 "
+                  className="SkImg-imgWrapper-116 "
                 >
                   <img
                     alt=""
-                    className="SkImg-img-105 SkImg-imgLoading-107 "
+                    className="SkImg-img-118 SkImg-imgLoading-120 "
                     src="/resources/placeholder.gif"
                   />
                 </div>
                 <span
-                  className="MuiTouchRipple-root-113"
+                  className="MuiTouchRipple-root-126"
                 />
               </button>
             </div>
@@ -174,7 +174,7 @@ exports[`basic snapshot 1`] = `
               className="MuiGrid-item-4 MuiGrid-grid-xs-3-34 MuiGrid-grid-sm-2-47"
             >
               <button
-                className="MuiButtonBase-root-110 SkMediaGalleryItem-root-109"
+                className="MuiButtonBase-root-123 SkMediaGalleryItem-root-122"
                 onBlur={[Function]}
                 onClick={[Function]}
                 onFocus={[Function]}
@@ -190,16 +190,16 @@ exports[`basic snapshot 1`] = `
                 type="button"
               >
                 <div
-                  className="SkImg-imgWrapper-103 "
+                  className="SkImg-imgWrapper-116 "
                 >
                   <img
                     alt=""
-                    className="SkImg-img-105 SkImg-imgLoading-107 "
+                    className="SkImg-img-118 SkImg-imgLoading-120 "
                     src="/resources/placeholder.gif"
                   />
                 </div>
                 <span
-                  className="MuiTouchRipple-root-113"
+                  className="MuiTouchRipple-root-126"
                 />
               </button>
             </div>
@@ -207,7 +207,7 @@ exports[`basic snapshot 1`] = `
               className="MuiGrid-item-4 MuiGrid-grid-xs-3-34 MuiGrid-grid-sm-2-47"
             >
               <button
-                className="MuiButtonBase-root-110 SkMediaGalleryItem-root-109"
+                className="MuiButtonBase-root-123 SkMediaGalleryItem-root-122"
                 onBlur={[Function]}
                 onClick={[Function]}
                 onFocus={[Function]}
@@ -223,16 +223,16 @@ exports[`basic snapshot 1`] = `
                 type="button"
               >
                 <div
-                  className="SkImg-imgWrapper-103 "
+                  className="SkImg-imgWrapper-116 "
                 >
                   <img
                     alt=""
-                    className="SkImg-img-105 SkImg-imgLoading-107 "
+                    className="SkImg-img-118 SkImg-imgLoading-120 "
                     src="/resources/placeholder.gif"
                   />
                 </div>
                 <span
-                  className="MuiTouchRipple-root-113"
+                  className="MuiTouchRipple-root-126"
                 />
               </button>
             </div>
@@ -240,7 +240,7 @@ exports[`basic snapshot 1`] = `
               className="MuiGrid-item-4 MuiGrid-grid-xs-3-34 MuiGrid-grid-sm-2-47"
             >
               <button
-                className="MuiButtonBase-root-110 SkMediaGalleryItem-root-109"
+                className="MuiButtonBase-root-123 SkMediaGalleryItem-root-122"
                 onBlur={[Function]}
                 onClick={[Function]}
                 onFocus={[Function]}
@@ -256,16 +256,16 @@ exports[`basic snapshot 1`] = `
                 type="button"
               >
                 <div
-                  className="SkImg-imgWrapper-103 "
+                  className="SkImg-imgWrapper-116 "
                 >
                   <img
                     alt=""
-                    className="SkImg-img-105 SkImg-imgLoading-107 "
+                    className="SkImg-img-118 SkImg-imgLoading-120 "
                     src="/resources/placeholder.gif"
                   />
                 </div>
                 <span
-                  className="MuiTouchRipple-root-113"
+                  className="MuiTouchRipple-root-126"
                 />
               </button>
             </div>
@@ -273,7 +273,7 @@ exports[`basic snapshot 1`] = `
               className="MuiGrid-item-4 MuiGrid-grid-xs-3-34 MuiGrid-grid-sm-2-47"
             >
               <button
-                className="MuiButtonBase-root-110 SkMediaGalleryItem-root-109"
+                className="MuiButtonBase-root-123 SkMediaGalleryItem-root-122"
                 onBlur={[Function]}
                 onClick={[Function]}
                 onFocus={[Function]}
@@ -289,16 +289,16 @@ exports[`basic snapshot 1`] = `
                 type="button"
               >
                 <div
-                  className="SkImg-imgWrapper-103 "
+                  className="SkImg-imgWrapper-116 "
                 >
                   <img
                     alt=""
-                    className="SkImg-img-105 SkImg-imgLoading-107 "
+                    className="SkImg-img-118 SkImg-imgLoading-120 "
                     src="/resources/placeholder.gif"
                   />
                 </div>
                 <span
-                  className="MuiTouchRipple-root-113"
+                  className="MuiTouchRipple-root-126"
                 />
               </button>
             </div>
@@ -306,7 +306,7 @@ exports[`basic snapshot 1`] = `
               className="MuiGrid-item-4 MuiGrid-grid-xs-3-34 MuiGrid-grid-sm-2-47"
             >
               <button
-                className="MuiButtonBase-root-110 SkMediaGalleryItem-root-109"
+                className="MuiButtonBase-root-123 SkMediaGalleryItem-root-122"
                 onBlur={[Function]}
                 onClick={[Function]}
                 onFocus={[Function]}
@@ -322,16 +322,16 @@ exports[`basic snapshot 1`] = `
                 type="button"
               >
                 <div
-                  className="SkImg-imgWrapper-103 "
+                  className="SkImg-imgWrapper-116 "
                 >
                   <img
                     alt=""
-                    className="SkImg-img-105 SkImg-imgLoading-107 "
+                    className="SkImg-img-118 SkImg-imgLoading-120 "
                     src="/resources/placeholder.gif"
                   />
                 </div>
                 <span
-                  className="MuiTouchRipple-root-113"
+                  className="MuiTouchRipple-root-126"
                 />
               </button>
             </div>
@@ -339,7 +339,7 @@ exports[`basic snapshot 1`] = `
               className="MuiGrid-item-4 MuiGrid-grid-xs-3-34 MuiGrid-grid-sm-2-47"
             >
               <button
-                className="MuiButtonBase-root-110 SkMediaGalleryItem-root-109"
+                className="MuiButtonBase-root-123 SkMediaGalleryItem-root-122"
                 onBlur={[Function]}
                 onClick={[Function]}
                 onFocus={[Function]}
@@ -355,16 +355,16 @@ exports[`basic snapshot 1`] = `
                 type="button"
               >
                 <div
-                  className="SkImg-imgWrapper-103 "
+                  className="SkImg-imgWrapper-116 "
                 >
                   <img
                     alt=""
-                    className="SkImg-img-105 SkImg-imgLoading-107 "
+                    className="SkImg-img-118 SkImg-imgLoading-120 "
                     src="/resources/placeholder.gif"
                   />
                 </div>
                 <span
-                  className="MuiTouchRipple-root-113"
+                  className="MuiTouchRipple-root-126"
                 />
               </button>
             </div>
@@ -377,7 +377,7 @@ exports[`basic snapshot 1`] = `
     >
       <section>
         <h2
-          className="MuiTypography-root-120 MuiTypography-title-126 SkTagGrid-title-242"
+          className="MuiTypography-root-135 MuiTypography-title-141 SkTagGrid-title-133"
         >
           Tags
         </h2>
@@ -388,7 +388,7 @@ exports[`basic snapshot 1`] = `
             className="MuiGrid-item-4"
           >
             <a
-              className="SkLink-anchor-241"
+              className="SkLink-anchor-103"
               href="/tag/shoes"
               onClick={[Function]}
               onKeyDown={[Function]}
@@ -396,14 +396,14 @@ exports[`basic snapshot 1`] = `
               tabIndex={0}
             >
               <div
-                className="MuiChip-root-244 SkTagGrid-chip-243"
+                className="MuiChip-root-161 SkTagGrid-chip-134"
                 onKeyDown={[Function]}
                 onKeyUp={[Function]}
                 role="button"
                 tabIndex={-1}
               >
                 <span
-                  className="MuiChip-label-263"
+                  className="MuiChip-label-180"
                 >
                   Shoes
                 </span>
@@ -414,7 +414,7 @@ exports[`basic snapshot 1`] = `
             className="MuiGrid-item-4"
           >
             <a
-              className="SkLink-anchor-241"
+              className="SkLink-anchor-103"
               href="/tag/shop"
               onClick={[Function]}
               onKeyDown={[Function]}
@@ -422,14 +422,14 @@ exports[`basic snapshot 1`] = `
               tabIndex={0}
             >
               <div
-                className="MuiChip-root-244 SkTagGrid-chip-243"
+                className="MuiChip-root-161 SkTagGrid-chip-134"
                 onKeyDown={[Function]}
                 onKeyUp={[Function]}
                 role="button"
                 tabIndex={-1}
               >
                 <span
-                  className="MuiChip-label-263"
+                  className="MuiChip-label-180"
                 >
                   Shop
                 </span>
@@ -447,7 +447,7 @@ exports[`basic snapshot 1`] = `
       className="MuiGrid-item-4 MuiGrid-grid-sm-12-57"
     >
       <h1
-        className="MuiTypography-root-120 MuiTypography-display2-123 MuiTypography-gutterBottom-138"
+        className="MuiTypography-root-135 MuiTypography-display2-138 MuiTypography-gutterBottom-153"
       >
         Reaction Sample Product
       </h1>
@@ -456,17 +456,17 @@ exports[`basic snapshot 1`] = `
       className="MuiGrid-item-4 MuiGrid-grid-sm-12-57"
     >
       <div
-        className="MuiTypography-root-120 MuiTypography-title-126 MuiTypography-gutterBottom-138"
+        className="MuiTypography-root-135 MuiTypography-title-141 MuiTypography-gutterBottom-153"
       >
         $12.99 - $19.99
       </div>
       <p
-        className="MuiTypography-root-120 MuiTypography-body1-129"
+        className="MuiTypography-root-135 MuiTypography-body1-144"
       >
         Example Manufacturer
       </p>
       <p
-        className="MuiTypography-root-120 MuiTypography-body1-129"
+        className="MuiTypography-root-135 MuiTypography-body1-144"
       >
         Sign in as administrator to edit.
 You can clone this product from the product grid.
@@ -479,13 +479,13 @@ Details can be added below the image for more specific product information.
       </p>
     </div>
     <div
-      className="SkVariantList-variantsContainer-146"
+      className="SkVariantList-variantsContainer-186"
     >
       <div
-        className="SkVariantList-variantItem-147"
+        className="SkVariantList-variantItem-187"
       >
         <button
-          className="MuiButtonBase-root-110 SkVariantItem-variantButton-149 SkVariantItem-activeVariant-150"
+          className="MuiButtonBase-root-123 SkVariantItem-variantButton-189 SkVariantItem-activeVariant-190"
           onBlur={[Function]}
           onClick={[Function]}
           onFocus={[Function]}
@@ -501,18 +501,18 @@ Details can be added below the image for more specific product information.
           type="button"
         >
           <span
-            className="MuiTypography-root-120 MuiTypography-body1-129"
+            className="MuiTypography-root-135 MuiTypography-body1-144"
           >
             Sample Variant
           </span>
           <span
-            className="MuiTypography-root-120 MuiTypography-body1-129"
+            className="MuiTypography-root-135 MuiTypography-body1-144"
           >
             $12.99 - $19.99
           </span>
         </button>
         <div
-          className="SkVariantList-alert-148"
+          className="SkVariantList-alert-188"
         >
           <div
             className="BadgeOverlay__Overlay-gvAWwt cDasYZ"
@@ -520,10 +520,10 @@ Details can be added below the image for more specific product information.
         </div>
       </div>
       <div
-        className="SkVariantList-variantItem-147"
+        className="SkVariantList-variantItem-187"
       >
         <button
-          className="MuiButtonBase-root-110 SkVariantItem-variantButton-149"
+          className="MuiButtonBase-root-123 SkVariantItem-variantButton-189"
           onBlur={[Function]}
           onClick={[Function]}
           onFocus={[Function]}
@@ -539,40 +539,40 @@ Details can be added below the image for more specific product information.
           type="button"
         >
           <span
-            className="MuiTypography-root-120 MuiTypography-body1-129"
+            className="MuiTypography-root-135 MuiTypography-body1-144"
           >
             Sample Variant 2
           </span>
           <span
-            className="MuiTypography-root-120 MuiTypography-body1-129"
+            className="MuiTypography-root-135 MuiTypography-body1-144"
           >
             $12.99 - $19.99
           </span>
         </button>
       </div>
       <div
-        className="SkDivider-container-151"
+        className="SkDivider-container-191"
       >
         <hr
-          className="SkDivider-item-153"
+          className="SkDivider-item-193"
         />
         <span
-          className="MuiTypography-root-120 MuiTypography-body1-129 SkDivider-label-152"
+          className="MuiTypography-root-135 MuiTypography-body1-144 SkDivider-label-192"
         >
           Available Options
         </span>
         <hr
-          className="SkDivider-item-153"
+          className="SkDivider-item-193"
         />
       </div>
       <div
-        className="MuiGrid-container-3 MuiGrid-spacing-xs-8-25 SkOptionsList-root-154"
+        className="MuiGrid-container-3 MuiGrid-spacing-xs-8-25 SkOptionsList-root-194"
       >
         <div
           className="MuiGrid-item-4"
         >
           <button
-            className="MuiButtonBase-root-110 SkProductDetailOption-optionButton-157"
+            className="MuiButtonBase-root-123 SkProductDetailOption-optionButton-197"
             onBlur={[Function]}
             onClick={[Function]}
             onFocus={[Function]}
@@ -588,13 +588,13 @@ Details can be added below the image for more specific product information.
             type="button"
           >
             <span
-              className="MuiTypography-root-120 MuiTypography-body1-129 SkProductDetailOption-optionText-158"
+              className="MuiTypography-root-135 MuiTypography-body1-144 SkProductDetailOption-optionText-198"
             >
               Red
             </span>
           </button>
           <div
-            className="SkOptionsList-alert-155"
+            className="SkOptionsList-alert-195"
           >
             <div
               className="BadgeOverlay__Overlay-gvAWwt gJVwBl"
@@ -605,7 +605,7 @@ Details can be added below the image for more specific product information.
           className="MuiGrid-item-4"
         >
           <button
-            className="MuiButtonBase-root-110 SkProductDetailOption-optionButton-157"
+            className="MuiButtonBase-root-123 SkProductDetailOption-optionButton-197"
             onBlur={[Function]}
             onClick={[Function]}
             onFocus={[Function]}
@@ -621,7 +621,7 @@ Details can be added below the image for more specific product information.
             type="button"
           >
             <span
-              className="MuiTypography-root-120 MuiTypography-body1-129 SkProductDetailOption-optionText-158"
+              className="MuiTypography-root-135 MuiTypography-body1-144 SkProductDetailOption-optionText-198"
             >
               Green
             </span>
@@ -633,35 +633,35 @@ Details can be added below the image for more specific product information.
       className="MuiGrid-container-3"
     >
       <div
-        className="MuiGrid-item-4 MuiGrid-grid-xs-12-43 SkProductDetailAddToCart-quantityGrid-164"
+        className="MuiGrid-item-4 MuiGrid-grid-xs-12-43 SkProductDetailAddToCart-quantityGrid-204"
       >
         <div
-          className="SkDivider-container-151"
+          className="SkDivider-container-191"
         >
           <hr
-            className="SkDivider-item-153"
+            className="SkDivider-item-193"
           />
           <hr
-            className="SkDivider-item-153"
+            className="SkDivider-item-193"
           />
         </div>
         <span
-          className="MuiTypography-root-120 MuiTypography-body1-129 SkProductDetailAddToCart-quantityTypography-167"
+          className="MuiTypography-root-135 MuiTypography-body1-144 SkProductDetailAddToCart-quantityTypography-207"
         >
           Quantity
         </span>
         <div
-          className="MuiFormControl-root-168"
+          className="MuiFormControl-root-208"
         >
           <div
-            className="MuiInputBase-root-185 MuiInput-root-172 SkProductDetailAddToCart-quantityContainer-163 MuiInputBase-formControl-186 MuiInput-formControl-173 MuiInputBase-adornedStart-189 MuiInputBase-adornedEnd-190"
+            className="MuiInputBase-root-225 MuiInput-root-212 SkProductDetailAddToCart-quantityContainer-203 MuiInputBase-formControl-226 MuiInput-formControl-213 MuiInputBase-adornedStart-229 MuiInputBase-adornedEnd-230"
             onClick={[Function]}
           >
             <div
-              className="MuiInputAdornment-root-202"
+              className="MuiInputAdornment-root-242"
             >
               <button
-                className="MuiButtonBase-root-110 SkProductDetailAddToCart-incrementButton-162"
+                className="MuiButtonBase-root-123 SkProductDetailAddToCart-incrementButton-202"
                 color="default"
                 onBlur={[Function]}
                 onClick={[Function]}
@@ -680,7 +680,7 @@ Details can be added below the image for more specific product information.
               >
                 <svg
                   aria-hidden="true"
-                  className="MuiSvgIcon-root-206 SkProductDetailAddToCart-quantitySvg-166"
+                  className="MuiSvgIcon-root-104 SkProductDetailAddToCart-quantitySvg-206"
                   focusable="false"
                   role="presentation"
                   viewBox="0 0 24 24"
@@ -690,13 +690,13 @@ Details can be added below the image for more specific product information.
                   />
                 </svg>
                 <span
-                  className="MuiTouchRipple-root-113"
+                  className="MuiTouchRipple-root-126"
                 />
               </button>
             </div>
             <input
               aria-invalid={false}
-              className="MuiInputBase-input-195 MuiInput-input-180 SkProductDetailAddToCart-quantityInput-165 MuiInputBase-inputAdornedStart-200 MuiInputBase-inputAdornedEnd-201"
+              className="MuiInputBase-input-235 MuiInput-input-220 SkProductDetailAddToCart-quantityInput-205 MuiInputBase-inputAdornedStart-240 MuiInputBase-inputAdornedEnd-241"
               disabled={false}
               id="addToCartQuantityInput"
               onBlur={[Function]}
@@ -707,10 +707,10 @@ Details can be added below the image for more specific product information.
               value={1}
             />
             <div
-              className="MuiInputAdornment-root-202"
+              className="MuiInputAdornment-root-242"
             >
               <button
-                className="MuiButtonBase-root-110 SkProductDetailAddToCart-incrementButton-162"
+                className="MuiButtonBase-root-123 SkProductDetailAddToCart-incrementButton-202"
                 color="default"
                 onBlur={[Function]}
                 onClick={[Function]}
@@ -729,7 +729,7 @@ Details can be added below the image for more specific product information.
               >
                 <svg
                   aria-hidden="true"
-                  className="MuiSvgIcon-root-206 SkProductDetailAddToCart-quantitySvg-166"
+                  className="MuiSvgIcon-root-104 SkProductDetailAddToCart-quantitySvg-206"
                   focusable="false"
                   role="presentation"
                   viewBox="0 0 24 24"
@@ -739,7 +739,7 @@ Details can be added below the image for more specific product information.
                   />
                 </svg>
                 <span
-                  className="MuiTouchRipple-root-113"
+                  className="MuiTouchRipple-root-126"
                 />
               </button>
             </div>
@@ -750,7 +750,7 @@ Details can be added below the image for more specific product information.
         className="MuiGrid-item-4 MuiGrid-grid-xs-12-43"
       >
         <button
-          className="MuiButtonBase-root-110 SkProductDetailAddToCart-addToCartButton-160"
+          className="MuiButtonBase-root-123 SkProductDetailAddToCart-addToCartButton-200"
           onBlur={[Function]}
           onClick={[Function]}
           onFocus={[Function]}
@@ -766,40 +766,40 @@ Details can be added below the image for more specific product information.
           type="button"
         >
           <span
-            className="MuiTypography-root-120 MuiTypography-body1-129 SkProductDetailAddToCart-addToCartText-161"
+            className="MuiTypography-root-135 MuiTypography-body1-144 SkProductDetailAddToCart-addToCartText-201"
           >
             Add to cart
           </span>
           <span
-            className="MuiTouchRipple-root-113"
+            className="MuiTouchRipple-root-126"
           />
         </button>
       </div>
     </div>
     <div
-      className="HiddenCss-mdUp-230"
+      className="HiddenCss-mdUp-261"
     >
       <div
-        className="SkCartPopover-container-215 SkCartPopover-isContainerHidden-217"
+        className="SkCartPopover-container-246 SkCartPopover-isContainerHidden-248"
       >
         <div
-          className="MuiGrid-container-3 MuiGrid-spacing-xs-24-27 SkCartPopover-gridContainer-216"
+          className="MuiGrid-container-3 MuiGrid-spacing-xs-24-27 SkCartPopover-gridContainer-247"
         >
           <div
-            className="MuiGrid-item-4 MuiGrid-grid-xs-12-43 SkCartPopover-containerItem-219"
+            className="MuiGrid-item-4 MuiGrid-grid-xs-12-43 SkCartPopover-containerItem-250"
           >
             <img
               alt="Item Title"
-              className="SkCartPopover-addedToCartImg-220"
+              className="SkCartPopover-addedToCartImg-251"
               src="//placehold.it/100"
             />
             <span
-              className="MuiTypography-root-120 MuiTypography-body1-129 SkCartPopover-addedToCartText-222"
+              className="MuiTypography-root-135 MuiTypography-body1-144 SkCartPopover-addedToCartText-253"
             >
               10
                "
               <span
-                className="SkCartPopover-addedToCartItemName-221"
+                className="SkCartPopover-addedToCartItemName-252"
               >
                 Item Title
               </span>


### PR DESCRIPTION
Resolves #284
Impact: **minor**
Type: **bugfix**

## Issue

The mobile view of the PDP page has the components displayed in a different order.

## Solution

Add a mobile-only layout to the PDP with the components in the correct order. Keep in mind this PR is just a re-organization of the components, not a restyling of them. Issues have been created to address the [Media Gallery](#377) and [Variant List](#376).

![](https://user-images.githubusercontent.com/3673236/45986081-252c1d00-c01e-11e8-948a-c96f8d3e9c9b.png)

## Breaking changes

none

## Testing
1. Open a PDP page
2. Check that the desktop layout remains untouched
3. Resize to the viewport to a Mobile phone size
4. Check that the design is in the correct order
