### PR TITLE
Fix 375: Add metafields to product query

### DIFF
--- a/src/containers/catalog/catalogItemProduct.gql
+++ b/src/containers/catalog/catalogItemProduct.gql
@@ -10,6 +10,14 @@ query catalogItemProductQuery($slugOrId: String!) {
       isLowQuantity
       isSoldOut
       isBackorder
+      metafields {
+        description
+        key
+        namespace
+        scope
+        value
+        valueType
+      }
       pricing {
         currency {
           code
@@ -97,6 +105,14 @@ query catalogItemProductQuery($slugOrId: String!) {
               original
             }
           }
+          metafields {
+            description
+            key
+            namespace
+            scope
+            value
+            valueType
+          }
           primaryImage {
             URLs {
               large
@@ -123,6 +139,14 @@ query catalogItemProductQuery($slugOrId: String!) {
             large
             original
           }
+        }
+        metafields {
+          description
+          key
+          namespace
+          scope
+          value
+          valueType
         }
         primaryImage {
           URLs {

--- a/src/containers/catalog/catalogItems.gql
+++ b/src/containers/catalog/catalogItems.gql
@@ -21,6 +21,14 @@ query catalogItemsQuery($shopId: ID!, $tagIds: [ID] $first: ConnectionLimitInt, 
             isLowQuantity
             isSoldOut
             isBackorder
+            metafields {
+              description
+              key
+              namespace
+              scope
+              value
+              valueType
+            }
             shop {
               currency {
                 code


### PR DESCRIPTION
Resolves #375 
Impact: **minor**
Type: **feature|bugfix|performance|test|style|refactor|docs|chore**

## Issue

Metafields are not available on the product.

## Solution

Add the `metafields` field to the GraphQL queries for the grid and PDP.

## Breaking changes

none

## Testing
1. Add metafields to a product in Reaction. This is the `Details` section of the PDP sidebar edit form.
2. Using the Apollo developer tools on the starterkit...
3. Visit the PDP page and verify that the cache for `CatalogProduct:<some-id>` has the metafields you added.
4. Do the same for the grid.

![timberlands___reaction](https://user-images.githubusercontent.com/42217/46689542-faf96400-cbb4-11e8-8ad3-7a415662a730.png)