### PR TITLE
refactor: unsplit first and last name fields in Checkout saving

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@material-ui/core": "^3.1.0",
-    "@reactioncommerce/components": "0.44.0",
+    "@reactioncommerce/components": "0.45.2",
     "@reactioncommerce/components-context": "^1.0.0",
     "@segment/snippet": "^4.3.1",
     "apollo-cache-inmemory": "^1.1.11",

--- a/src/components/CheckoutActions/CheckoutActions.js
+++ b/src/components/CheckoutActions/CheckoutActions.js
@@ -46,12 +46,8 @@ export default class CheckoutActions extends Component {
   setShippingAddress = (address) => {
     const { checkoutMutations: { onSetShippingAddress } } = this.props;
 
-    // Omit firstName, lastName props as they are not in AddressInput type
-    // The address form and GraphQL endpoint need to be made consistent
-    const { firstName, lastName, ...rest } = address;
     return onSetShippingAddress({
-      fullName: `${address.firstName} ${address.lastName}`,
-      ...rest
+      address
     });
   }
 

--- a/src/components/CheckoutActions/CheckoutActions.js
+++ b/src/components/CheckoutActions/CheckoutActions.js
@@ -46,9 +46,7 @@ export default class CheckoutActions extends Component {
   setShippingAddress = (address) => {
     const { checkoutMutations: { onSetShippingAddress } } = this.props;
 
-    return onSetShippingAddress({
-      address
-    });
+    return onSetShippingAddress(address);
   }
 
   setShippingMethod = (shippingMethod) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1022,9 +1022,10 @@
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@reactioncommerce/components-context/-/components-context-1.0.0.tgz#587764cf0d1b0312c786b8e4657379de02e13845"
 
-"@reactioncommerce/components@0.44.0":
-  version "0.44.0"
-  resolved "https://registry.yarnpkg.com/@reactioncommerce/components/-/components-0.44.0.tgz#6dbec9c716623f45f82a78c640dfb6bfad374035"
+"@reactioncommerce/components@0.45.2":
+  version "0.45.2"
+  resolved "https://registry.yarnpkg.com/@reactioncommerce/components/-/components-0.45.2.tgz#b9295eb2e549b0cf8c840f0b16899edb805d8411"
+  integrity sha512-QxVGnokhXTyzuQkg5CGhKqIr1l+4ECRUkGtYt9TYbIJ9jy4dQAR5Dfld+4ZWdLsEj63YylLW+LaNH4mON0be1A==
   dependencies:
     "@material-ui/core" "^3.1.0"
     lodash.debounce "^4.0.8"


### PR DESCRIPTION
Impact: **minor**
Type: **refactor**

## Issue
The way we save names is a little funky. We have our forms split into `firstName` and `lastName` fields, but we save names inside the data as `fullName`. We do this by combining the `firstName` and `lastName` fields inside the starterkit.

## Solution
We need to update the form to accept a single `fullName` field, instead of two fields which are combined into a single field. This update fixes the issue in the starterkits mutation of the data. An update to the component library will also be made to make the fields into a single field.

## Breaking changes
I don't expect any breaking changes, as the two fields are combined into the single field anyway on the backend.

## Testing
See that fullName data is saved correctly in `cart.shippings.address.fullName` one the Component library PR is merged.