### PR TITLE
fix: Remove unused scopes and grant_type

### DIFF
--- a/bin/create-hydra-client.js
+++ b/bin/create-hydra-client.js
@@ -22,14 +22,12 @@ const bodyEncoded = JSON.stringify({
   client_secret: process.env.OAUTH2_CLIENT_SECRET,
   grant_types: [
     "authorization_code",
-    "refresh_token",
-    "client_credentials",
-    "implicit"
+    "refresh_token"
   ],
   jwks: {},
   redirect_uris: [process.env.OAUTH2_REDIRECT_URL],
-  response_types: ["token", "code", "id_token"],
-  scope: "openid offline",
+  response_types: ["token", "code"],
+  scope: "offline",
   subject_type: "public",
   token_endpoint_auth_method: "client_secret_post"
 });

--- a/src/server.js
+++ b/src/server.js
@@ -30,7 +30,7 @@ passport.use("oauth2", new OAuth2Strategy({
   clientSecret: process.env.OAUTH2_CLIENT_SECRET,
   callbackURL: process.env.OAUTH2_REDIRECT_URL,
   state: true,
-  scope: ["offline", "openid"]
+  scope: ["offline"]
 }, (accessToken, refreshToken, profile, cb) => {
   cb(null, { accessToken, profile });
 }));


### PR DESCRIPTION
Related to reactioncommerce/reaction#4733
and #350
Impact: **minor**

## Issue
Our initial Hydra bootstrap settings contains some extra fields that are not in use. These are: (i) the `openid` scope that leads to the issuance of and `id_token` (ii) Extra OAuth 2 Grant Types for the starterkit client.

## Solution
- Remove the scope for id-token. This can be added back intentionally when we decide how we want to use the id-token across our system. Prevent possible leak of tokens. Prevent confusion around what the scopes are for.
- Remove the unused grant types, and limit to only the ones of use.


## Breaking changes
N/A - Previous functionality works as before


## Testing
NB: There is a current bug in Starterkit's Component library version. Set the version to `"@reactioncommerce/components": "0.43.0",` in your package.json.
1. Run this branch against the Hydra service with no client for starterkit yet. If necessary, you can remove the existing one with `$ docker-compose run --rm -e "HYDRA_ADMIN_URL=http://hydra:4445" hydra clients delete reaction-next-starterkit`
2. Starting the app should (re)create the Hydra client with the new configuration
3. Run your `reaction` service with this PR branch reactioncommerce/reaction#4733
3. Confirm that your login works as usual

Reference Links:
- Hydra Doc about the openid scope: [Link](https://www.ory.sh/docs/guides/master/hydra/4-install/#install-and-run-ory-hydra) (search for OpenID)
- OAuth 2.0 Grant Types: https://oauth.net/2/grant-types/
- Video explaining differences between OAuth 2 & OpenID Connect: [Link](https://www.youtube.com/watch?v=996OiexHze0)
