### PR TITLE
feat Renew access tokens on 401 errors using redirects to auth endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     "next-routes": "^1.4.2",
     "passport": "^0.4.0",
     "passport-oauth2": "^1.4.0",
-    "passport-oauth2-refresh": "^1.1.0",
     "prop-types": "^15.6.2",
     "react": "16.4.2",
     "react-apollo": "^2.1.3",

--- a/src/containers/catalog/withCatalogItemProduct.js
+++ b/src/containers/catalog/withCatalogItemProduct.js
@@ -22,7 +22,7 @@ export default function withCatalogItemProduct(Component) {
       return (
         <Query query={catalogItemProductQuery} variables={{ slugOrId: query.slugOrId }}>
           {({ data, loading }) => {
-            const { catalogItemProduct } = data;
+            const { catalogItemProduct } = data || {};
             const { product } = catalogItemProduct || {};
 
             return (

--- a/src/lib/apollo/initApollo.js
+++ b/src/lib/apollo/initApollo.js
@@ -1,5 +1,6 @@
 import { ApolloClient } from "apollo-client";
 import { ApolloLink } from "apollo-link";
+import { Router } from "routes";
 import { HttpLink } from "apollo-link-http";
 import { setContext } from "apollo-link-context";
 import { onError } from "apollo-link-error";
@@ -39,6 +40,13 @@ const create = (initialState, options) => {
     }
 
     if (networkError) {
+      const errorCode = networkError.response && networkError.response.status;
+      // In browser, if a 401 Unauthorized error occurred, redirect to /signin.
+      // This will re-authenticate the user without showing a login page and a new token is issued.
+      if (errorCode === 401) {
+        if (process && process.browser) Router.pushRoute("/signin");
+      }
+
       // eslint-disable-next-line no-console
       console.error(`[Network error]: ${networkError}`);
     }

--- a/src/lib/apollo/withApolloClient.js
+++ b/src/lib/apollo/withApolloClient.js
@@ -68,6 +68,13 @@ export default function withApolloClient(WrappedComponent) {
           // Handle them in components via the data.error prop:
           // http://dev.apollodata.com/react/api-queries.html#graphql-query-data-error
           if (error.networkError) {
+            // In server, if a 401 Unauthorized error occurred, redirect to /signin.
+            // This will re-authenticate without showing a login page and a new token is issued.
+            if (error.networkError.response.status === 401 && res) {
+              res.writeHead(302, { Location: "/signin" });
+              res.end();
+              return {};
+            }
             logger.error(`Unable to access the GraphQL API. Is it running and accessible at ${serverRuntimeConfig.graphqlUrl} from the Storefront UI server?`);
           } else {
             logger.error("Error while running `getDataFromTree`:", error);

--- a/src/server.js
+++ b/src/server.js
@@ -8,7 +8,6 @@ const { useStaticRendering } = require("mobx-react");
 const logger = require("lib/logger");
 const passport = require("passport");
 const OAuth2Strategy = require("passport-oauth2");
-const refresh = require("passport-oauth2-refresh");
 const { decodeOpaqueId } = require("lib/utils/decoding");
 const { appPath, dev } = require("./config");
 const router = require("./routes");
@@ -33,10 +32,8 @@ passport.use("oauth2", new OAuth2Strategy({
   state: true,
   scope: ["offline"]
 }, (accessToken, refreshToken, profile, cb) => {
-  cb(null, { accessToken, profile });
+  cb(null, { accessToken });
 }));
-
-passport.use("refresh", refresh);
 
 // The value passed to `done` here is stored on the session.
 // We save the full user object in the session.

--- a/yarn.lock
+++ b/yarn.lock
@@ -6614,10 +6614,6 @@ pascalcase@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/pascalcase/-/pascalcase-0.1.1.tgz#b363e55e8006ca6fe21784d2db22bd15d7917f14"
 
-passport-oauth2-refresh@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/passport-oauth2-refresh/-/passport-oauth2-refresh-1.1.0.tgz#4e77702bd64f1ec39ddc4142edec85a4f5086f43"
-
 passport-oauth2@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/passport-oauth2/-/passport-oauth2-1.4.0.tgz#f62f81583cbe12609be7ce6f160b9395a27b86ad"


### PR DESCRIPTION
Resolves #350
Type: feature

## Issue
Renew access tokens on 401 errors by redirecting to re-auth

## Solution
- On 401 errors, redirect to signin endpoint to perform auth and get new access token. Done on both the SSR and browser.


## Breaking changes
None


## Flash of "Not Found"
If going from product grid to a product's detail page and you have an expired token, the app first shows the Not Found component based on this line of code:

https://github.com/reactioncommerce/reaction-next-starterkit/blob/558d94be01491c26c708d8dea98d6e7528a29bdb/src/pages/product.js#L93

The Not Found page is shown while the redirect is happening. Once redirect flow completes, the product component is then displayed properly. I haven't found a way to fix this. 


## Testing
1. Start Starterkit on this branch
2. Run Hydra on master. Set this ENV in the docker-compose yaml before starting the service: ACCESS_TOKEN_LIFESPAN=1m. This will reduce the wait time. The tokens will expire in 60s.
3. Load up a page. Log in (if you are not logged in before). Leave it for a while for the token to expire. 
4. After token expires, perform an action (e.g click to view a product, or add a product to cart).
5. Observe the browser/server console. If a 401 error occurred, confirm that a redirect to /signin starts, and the page is reloaded once the [re]auth is complete.
