### PR TITLE
fix: integration test finished before resolving

### DIFF
--- a/tests/integration/ssr.test.js
+++ b/tests/integration/ssr.test.js
@@ -8,12 +8,13 @@ const request = require("request");
 const url = "http://localhost:4000";
 
 describe("NextJS Loading", () => {
-  it("SSR Loads with an HTML Body", () => {
+  it("SSR Loads with an HTML Body", (done) => {
     request(url, (err, resp, body) => {
       if (!err && resp.statusCode === 200) {
         const cheer = cheerio.load(body);
         chai.expect(cheer("#__next").find("div")).to.not.be.empty;
       }
+      done();
     });
   });
 });


### PR DESCRIPTION
Impact: **minor**
Type: **bugfix|test**

## Issue
The SSR integration test wasn't actually testing anything, because of how mocha expects async tests.

## Solution
Used mocha's `done` callback workflow.

## Testing

```shell
docker-compose exec web yarn test:integration
```