### PR TITLE
fix(340): catch Stripe Payment error and save error message

### DIFF
--- a/src/components/CheckoutActions/CheckoutActions.js
+++ b/src/components/CheckoutActions/CheckoutActions.js
@@ -258,7 +258,7 @@ export default class CheckoutActions extends Component {
           3: {
             alertType: "error",
             title: "Payment method failed",
-            message: error.toString()
+            message: error.toString().replace("Error: GraphQL error:", "")
           }
         }
       });

--- a/src/components/CheckoutActions/CheckoutActions.js
+++ b/src/components/CheckoutActions/CheckoutActions.js
@@ -238,18 +238,17 @@ export default class CheckoutActions extends Component {
       const { id } = decodeOpaqueId(orders[0]._id);
       Router.pushRoute("checkoutComplete", { orderId: id, token });
     } catch (error) {
-      window.alert(error);
       const alert = {
         alertType: "error",
         title: "Payment method failed",
         message: error
-      }
+      };
+      window.alert(alert);
       this.setState({ isPlacingOrder: false });
     }
   }
 
-  handleClose = (event) => {
-    console.log("handle close", event)
+  handleClose = () => {
     // TODO: Open CheckoutAction to Step 3
   }
 

--- a/src/components/CheckoutActions/CheckoutActions.js
+++ b/src/components/CheckoutActions/CheckoutActions.js
@@ -61,6 +61,7 @@ export default class CheckoutActions extends Component {
       3: null,
       4: null
     },
+    hasPaymentError: false,
     isPlacingOrder: false
   }
 
@@ -243,17 +244,17 @@ export default class CheckoutActions extends Component {
       const { id } = decodeOpaqueId(orders[0]._id);
       Router.pushRoute("checkoutComplete", { orderId: id, token });
     } catch (error) {
+      console.log(error);
       this.setState({
+        hasPaymentError: true,
         isPlacingOrder: false,
         actionAlerts: {
           3: {
             alertType: "error",
             title: "Payment method failed",
-            message: error.message
+            message: error.toString()
           }
         }
-        // get the Payment step to open
-        // set CurrentActions[2].isActive == true
       });
     }
   }
@@ -280,7 +281,7 @@ export default class CheckoutActions extends Component {
 
     const { cartStore: { stripeToken } } = this.props;
     const { checkout: { fulfillmentGroups, summary }, items } = this.props.cart;
-    const { actionAlerts } = this.state;
+    const { actionAlerts, hasPaymentError } = this.state;
     const shippingAddressSet = isShippingAddressSet(fulfillmentGroups);
     const fulfillmentGroup = fulfillmentGroups[0];
 
@@ -349,7 +350,7 @@ export default class CheckoutActions extends Component {
         activeLabel: "Enter payment information",
         completeLabel: "Payment information",
         incompleteLabel: "Payment information",
-        status: stripeToken ? "complete" : "incomplete",
+        status: stripeToken && !hasPaymentError ? "complete" : "incomplete",
         component: StripePaymentCheckoutAction,
         onSubmit: this.setPaymentMethod,
         props: {

--- a/src/components/CheckoutActions/CheckoutActions.js
+++ b/src/components/CheckoutActions/CheckoutActions.js
@@ -167,6 +167,13 @@ export default class CheckoutActions extends Component {
     // Store stripe token in MobX store
     cartStore.setStripeToken(stripeToken);
 
+    this.setState({
+      hasPaymentError: false,
+      actionAlerts: {
+        3: { }
+      }
+    });
+
     // Track successfully setting a payment method
     this.trackAction({
       step: 3,
@@ -244,7 +251,6 @@ export default class CheckoutActions extends Component {
       const { id } = decodeOpaqueId(orders[0]._id);
       Router.pushRoute("checkoutComplete", { orderId: id, token });
     } catch (error) {
-      console.log(error);
       this.setState({
         hasPaymentError: true,
         isPlacingOrder: false,

--- a/src/components/CheckoutActions/CheckoutActions.js
+++ b/src/components/CheckoutActions/CheckoutActions.js
@@ -238,14 +238,19 @@ export default class CheckoutActions extends Component {
       const { id } = decodeOpaqueId(orders[0]._id);
       Router.pushRoute("checkoutComplete", { orderId: id, token });
     } catch (error) {
-      const errorMessage = error;
-      window.alert(errorMessage);
+      window.alert(error);
+      const alert = {
+        alertType: "error",
+        title: "Payment method failed",
+        message: error
+      }
       this.setState({ isPlacingOrder: false });
     }
   }
 
-  handleClose = () => {
-    // TODO: if an error occurs, then close dialog
+  handleClose = (event) => {
+    console.log("handle close", event)
+    // TODO: Open CheckoutAction to Step 3
   }
 
   renderPlacingOrderOverlay = () => {
@@ -254,6 +259,8 @@ export default class CheckoutActions extends Component {
     return (
       <Dialog
         fullScreen
+        disableBackdropClick={true}
+        disableEscapeKeyDown={true}
         open={isPlacingOrder}
         onClose={this.handleClose}
       >

--- a/src/components/CheckoutActions/CheckoutActions.js
+++ b/src/components/CheckoutActions/CheckoutActions.js
@@ -215,10 +215,9 @@ export default class CheckoutActions extends Component {
 
   placeOrder = async (order) => {
     const { authStore, cartStore, placeOrderWithStripeCard } = this.props;
-    const { data, error } = await placeOrderWithStripeCard(order);
 
-    // If success
-    if (data && !error) {
+    try {
+      const { data } = await placeOrderWithStripeCard(order);
       const { placeOrderWithStripeCardPayment: { orders, token } } = data;
 
       this.trackAction({
@@ -238,9 +237,11 @@ export default class CheckoutActions extends Component {
       // Send user to order confirmation page
       const { id } = decodeOpaqueId(orders[0]._id);
       Router.pushRoute("checkoutComplete", { orderId: id, token });
+    } catch (error) {
+      const errorMessage = error;
+      window.alert(errorMessage);
+      this.setState({ isPlacingOrder: false });
     }
-
-    // TODO: if an error occurred, notify user
   }
 
   handleClose = () => {

--- a/src/lib/theme/components.js
+++ b/src/lib/theme/components.js
@@ -30,6 +30,7 @@ import CheckoutActionComplete from "@reactioncommerce/components/CheckoutActionC
 import CheckoutActionIncomplete from "@reactioncommerce/components/CheckoutActionIncomplete/v1";
 import ErrorsBlock from "@reactioncommerce/components/ErrorsBlock/v1";
 import Field from "@reactioncommerce/components/Field/v1";
+import InlineAlert from "@reactioncommerce/components/InlineAlert/v1";
 import Link from "components/Link";
 import MiniCartSummary from "@reactioncommerce/components/MiniCartSummary/v1";
 import PhoneNumberInput from "@reactioncommerce/components/PhoneNumberInput/v1";
@@ -64,6 +65,7 @@ export default {
   CheckoutActionIncomplete,
   ErrorsBlock,
   Field,
+  InlineAlert,
   Link,
   iconAmericanExpress,
   iconClear,

--- a/src/lib/theme/components.js
+++ b/src/lib/theme/components.js
@@ -16,6 +16,7 @@ import iconMastercard from "@reactioncommerce/components/svg/iconMastercard";
 import iconVisa from "@reactioncommerce/components/svg/iconVisa";
 import spinner from "@reactioncommerce/components/svg/spinner";
 import AddressForm from "@reactioncommerce/components/AddressForm/v1";
+import AddressReview from "@reactioncommerce/components/AddressReview/v1";
 import BadgeOverlay from "@reactioncommerce/components/BadgeOverlay/v1";
 import Button from "@reactioncommerce/components/Button/v1";
 import CartItem from "@reactioncommerce/components/CartItem/v1";
@@ -51,6 +52,7 @@ const AddressFormWithLocales = withLocales(AddressForm);
 
 export default {
   AddressForm: AddressFormWithLocales,
+  AddressReview,
   BadgeOverlay,
   Button,
   CartItem,

--- a/src/pages/_document.js
+++ b/src/pages/_document.js
@@ -106,7 +106,7 @@ class HTMLDocument extends Document {
         <Main />
         <NextScript />
         {scripts.map((script, index) => (script.innerHTML ? /* eslint-disable-next-line */
-                <script async key={index} type={script.type} dangerouslySetInnerHTML={{ __html: script.innerHTML }} /> : <script async key={index} {...script} />))}
+          <script async key={index} type={script.type} dangerouslySetInnerHTML={{ __html: script.innerHTML }} /> : <script async key={index} {...script} />))}
       </body>
     </html>;
   }


### PR DESCRIPTION
Resolves #340 
Impact: **major**
Type: **feature**

## Issue
- Issue: A customer does not know if a payment failed, and is stuck at the page when errors occur. 
- Feature: After a customer saves an invalid credit card and clicks Check Out, the customer should be taken back to the Cart page on Step 3, Payment, and an InlineAlert should appear with the error message.

## Solution

- [x] - Catch Stripe payment error message
- [x] - Pass an `alert` object to CheckoutActions:
- [x] - Add `InlineAlert` to app
- [x] - Take user back to Step 3 and display InlineAlert
- [x] - Reset the payment form


## Testing
1. Test these Stripe cards pre-configured with errors: https://stripe.com/docs/testing#cards-responses