### PR TITLE
fix: SSR issues with product grids and PDP pages

### DIFF
--- a/src/components/ProductDetail/ProductDetail.js
+++ b/src/components/ProductDetail/ProductDetail.js
@@ -42,7 +42,7 @@ const styles = (theme) => ({
  * @param {Object} props Component props
  * @returns {React.Component} React component node that represents a product detail view
  */
-@withWidth()
+@withWidth({ initialWidth: "md" })
 @withStyles(styles, { withTheme: true, name: "SkProductDetail" })
 @inject("routingStore", "uiStore")
 @track()

--- a/src/containers/catalog/withCatalogItems.js
+++ b/src/containers/catalog/withCatalogItems.js
@@ -4,6 +4,7 @@ import { inject, observer } from "mobx-react";
 import { Query } from "react-apollo";
 import hoistNonReactStatic from "hoist-non-react-statics";
 import { pagination, paginationVariablesFromUrlParams } from "lib/helpers/pagination";
+import withTag from "containers/tags/withTag";
 import catalogItemsQuery from "./catalogItems.gql";
 
 /**
@@ -13,9 +14,8 @@ import catalogItemsQuery from "./catalogItems.gql";
  * @returns {React.Component} - component decorated with primaryShopId and catalog as props
  */
 export default function withCatalogItems(Component) {
-  @inject("primaryShopId")
-  @inject("routingStore")
-  @inject("uiStore")
+  @withTag
+  @inject("primaryShopId", "routingStore", "uiStore")
   @observer
   class CatalogItems extends React.Component {
     static propTypes = {
@@ -25,9 +25,9 @@ export default function withCatalogItems(Component) {
     };
 
     render() {
-      const { primaryShopId, routingStore, uiStore } = this.props;
+      const { primaryShopId, routingStore, uiStore, tag } = this.props;
       const [sortBy, sortOrder] = uiStore.sortBy.split("-");
-      const tagIds = routingStore.tag._id ? [routingStore.tag._id] : undefined;
+      const tagIds = tag && [tag._id];
       const variables = {
         shopId: primaryShopId,
         ...paginationVariablesFromUrlParams(routingStore.query, { defaultPageLimit: uiStore.pageSize }),


### PR DESCRIPTION
Resolves #405
Impact: **critical**
Type: **bugfix**

## Issue

SSR was partially broken on the PDP and grid pages.

- Grid: tag pages displaying incorrect products
- PDP: No product detail, only a navbar

## Solution

**Product Grids**

Use the `@withTag` decorator to load tag info sooner for use in the query for catalog items

**PDP**

Set an initial width for the `@withWidth()` decorator so it renders on the server

## Breaking changes

None.

## Testing
1. Disable javascript
2. Navigate between the homepage and the tag grids
3. Ensure expected content is on each. (shirts under /tag/shirts, accessories under tag/accessories, etc)
4. Click into a PDP page
5. Ensure it renders the desired product

---

1. Enable Javascript
2. Navigate the app as in steps 2-6 above, and ensure the pages render as expected
