### PR TITLE
Support for Google Site Verification

### DIFF
--- a/src/containers/googleSiteVerificationToken/googleSiteVerificationToken.gql
+++ b/src/containers/googleSiteVerificationToken/googleSiteVerificationToken.gql
@@ -1,0 +1,3 @@
+query siteVerificationTokenQuery {
+  siteVerificationToken
+}

--- a/src/containers/googleSiteVerificationToken/withGoogleSiteVerificationToken.js
+++ b/src/containers/googleSiteVerificationToken/withGoogleSiteVerificationToken.js
@@ -1,0 +1,35 @@
+import React from "react";
+import { Query } from "react-apollo";
+import hoistNonReactStatic from "hoist-non-react-statics";
+import siteVerificationTokenQuery from "./googleSiteVerificationToken.gql";
+
+/**
+ * withGoogleSiteVerificationToken higher order query component for fetching Google site verification token
+ * @name withGoogleSiteVerificationToken
+ * @param {React.Component} Component to decorate and apply
+ * @returns {React.Component} - component decorated with Google site verification token as props
+ */
+export default function withGoogleSiteVerificationToken(Component) {
+  class GoogleSiteVerification extends React.Component {
+    render() {
+      return (
+        <Query query={siteVerificationTokenQuery}>
+          {({ loading: loadingSiteVerificationToken, data }) => {
+            const { siteVerificationToken } = data || {};
+            return (
+              <Component
+                {...this.props}
+                isLoading={loadingSiteVerificationToken}
+                siteVerificationToken={siteVerificationToken}
+              />
+            );
+          }}
+        </Query>
+      );
+    }
+  }
+
+  hoistNonReactStatic(GoogleSiteVerification, Component);
+
+  return GoogleSiteVerification;
+}

--- a/src/pages/product.js
+++ b/src/pages/product.js
@@ -3,10 +3,12 @@ import PropTypes from "prop-types";
 import Helmet from "react-helmet";
 import withCart from "containers/cart/withCart";
 import withCatalogItemProduct from "containers/catalog/withCatalogItemProduct";
+import withGoogleSiteVerificationToken from "containers/googleSiteVerificationToken/withGoogleSiteVerificationToken";
 import ProductDetail from "components/ProductDetail";
 import PageLoading from "components/PageLoading";
 import ErrorPage from "./_error";
 
+@withGoogleSiteVerificationToken
 @withCart
 @withCatalogItemProduct
 class ProductDetailPage extends Component {
@@ -29,6 +31,7 @@ class ProductDetailPage extends Component {
         code: PropTypes.string.isRequired
       })
     }),
+    siteVerificationToken: PropTypes.string,
     tags: PropTypes.shape({
       edges: PropTypes.arrayOf(PropTypes.object).isRequired
     })
@@ -104,13 +107,17 @@ class ProductDetailPage extends Component {
   }
 
   render() {
-    const { product, shop } = this.props;
+    const { product, shop, siteVerificationToken } = this.props;
+    const metaTags = [{ name: "description", content: product && product.description }];
+    if (siteVerificationToken) {
+      metaTags.push({ name: "google-site-verification", content: siteVerificationToken });
+    }
 
     return (
       <Fragment>
         <Helmet
           title={`${product && product.title} | ${shop && shop.name}`}
-          meta={[{ name: "description", content: product && product.description }]}
+          meta={metaTags}
           script={[{ type: "application/ld+json", innerHTML: this.buildJSONLd() }]}
         />
         {this.renderMainArea()}


### PR DESCRIPTION
Resolves #411
Impact: **minor**
Type: **feature**

## Issue
Google site verification requires a meta tag to be present in the home page of a site.

## Solution
I created a plugin in Reaction to allow shop owner to set up the Google site verification token that is provided in the Google Search Console. The token is made available to the storefront through a graphql query.

In the storefront, I added an HOC to the `product` page to query for the site verification token and render it in a header meta tag.

## Breaking changes
None

## Testing
1. Make sure that `google-webtools` plugin is present in the Meteor app and a site verification token is entered in the shop dashboard panel.
2. Load the storefront's homepage and verify that a meta tag for `google-site-verification` is present.
