### PR TITLE
fix(config): add canonicalUrl to publicRuntimeConfig

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -26,6 +26,7 @@ const initExport = {
    * const { serverRuntimeConfig, publicRuntimeConfig } = getConfig();
    */
   publicRuntimeConfig: {
+    canonicalUrl: process.env.CANONICAL_URL,
     graphqlUrl: process.env.EXTERNAL_GRAPHQL_URL,
     segmentAnalytics: {
       skipMinimize: process.env.SEGMENT_ANALYTICS_SKIP_MINIMIZE === "true", // Convert to a Boolean


### PR DESCRIPTION
Resolves #416 
Impact: **minor**
Type: **bugfix**

## Issue
`canonicalURL` is accessible from server-side, but not client side.

## Solution
Add `canonicalURL` to `publicRuntimeConfig`

```diff
 publicRuntimeConfig: {
+    canonicalUrl: process.env.CANONICAL_URL,
     graphqlUrl: process.env.EXTERNAL_GRAPHQL_URL,
```

## Testing
1. Add these to any page:

```
import getConfig from "next/config";

const { publicRuntimeConfig } = getConfig();

console.log(publicRuntimeConfig)` 
```
