### PR TITLE
fix(414): Fullname is not saved or displayed

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@material-ui/core": "^3.1.0",
-    "@reactioncommerce/components": "0.51.2",
+    "@reactioncommerce/components": "0.54.1",
     "@reactioncommerce/components-context": "^1.0.0",
     "@segment/snippet": "^4.3.1",
     "apollo-cache-inmemory": "^1.1.11",

--- a/src/components/CheckoutActions/CheckoutActions.js
+++ b/src/components/CheckoutActions/CheckoutActions.js
@@ -17,10 +17,7 @@ import trackCheckout from "lib/tracking/trackCheckout";
 import trackOrder from "lib/tracking/trackOrder";
 import trackCheckoutStep from "lib/tracking/trackCheckoutStep";
 import { decodeOpaqueId } from "lib/utils/decoding";
-import {
-  adaptAddressToFormFields,
-  isShippingAddressSet
-} from "lib/utils/cartUtils";
+import { isShippingAddressSet } from "lib/utils/cartUtils";
 
 const {
   CHECKOUT_STARTED,
@@ -114,15 +111,7 @@ export default class CheckoutActions extends Component {
 
   setShippingAddress = async (address) => {
     const { checkoutMutations: { onSetShippingAddress } } = this.props;
-
-    // Omit firstName, lastName props as they are not in AddressInput type
-    // The address form and GraphQL endpoint need to be made consistent
-    const { firstName, lastName, ...rest } = address;
-    const { data, error } = await onSetShippingAddress({
-      fullName: `${address.firstName} ${address.lastName}`,
-      ...rest
-    });
-
+    const { data, error } = await onSetShippingAddress({ address });
 
     if (data && !error) {
       // track successfully setting a shipping address
@@ -292,12 +281,11 @@ export default class CheckoutActions extends Component {
     const fulfillmentGroup = fulfillmentGroups[0];
 
     let shippingAddress = { data: { shippingAddress: null } };
-    // Adapt shipping address to match fields in the AddressForm component.
-    // fullName is split into firstName and lastName
+
     if (shippingAddressSet) {
       shippingAddress = {
         data: {
-          shippingAddress: adaptAddressToFormFields(fulfillmentGroup.data.shippingAddress)
+          shippingAddress: fulfillmentGroup.data.shippingAddress
         }
       };
     }

--- a/src/components/CheckoutActions/CheckoutActions.js
+++ b/src/components/CheckoutActions/CheckoutActions.js
@@ -111,7 +111,7 @@ export default class CheckoutActions extends Component {
 
   setShippingAddress = async (address) => {
     const { checkoutMutations: { onSetShippingAddress } } = this.props;
-    const { data, error } = await onSetShippingAddress({ address });
+    const { data, error } = await onSetShippingAddress(address);
 
     if (data && !error) {
       // track successfully setting a shipping address

--- a/src/components/OrderFulfillmentGroup/OrderFulfillmentGroup.js
+++ b/src/components/OrderFulfillmentGroup/OrderFulfillmentGroup.js
@@ -97,9 +97,9 @@ class OrderFulfillmentGroup extends Component {
       const { data: { shippingAddress } } = fulfillmentGroup;
       const address = (
         <Typography variant="body2">
-          {(shippingAddress.firstName || shippingAddress.lastName) && (
+          {(shippingAddress.fullName) && (
             <span>
-              {shippingAddress.firstName} {shippingAddress.lastName}
+              {shippingAddress.fullName}
               <br />
             </span>
           )}

--- a/src/lib/theme/components.js
+++ b/src/lib/theme/components.js
@@ -39,6 +39,7 @@ import Price from "@reactioncommerce/components/Price/v1";
 import ProfileImage from "@reactioncommerce/components/ProfileImage/v1";
 import ProgressiveImage from "@reactioncommerce/components/ProgressiveImage/v1";
 import QuantityInput from "@reactioncommerce/components/QuantityInput/v1";
+import RegionInput from "@reactioncommerce/components/RegionInput/v1";
 import Select from "@reactioncommerce/components/Select/v1";
 import SelectableItem from "@reactioncommerce/components/SelectableItem/v1";
 import SelectableList from "@reactioncommerce/components/SelectableList/v1";
@@ -82,6 +83,7 @@ export default {
   ProfileImage,
   ProgressiveImage,
   QuantityInput,
+  RegionInput,
   Select,
   spinner,
   SelectableItem,

--- a/src/lib/utils/cartUtils.js
+++ b/src/lib/utils/cartUtils.js
@@ -13,26 +13,3 @@ export function isShippingAddressSet(fulfillmentGroups) {
 
   return groupWithoutAddress;
 }
-
-/**
- * Filters an address object so that it only contain props that have a corresponding form field.
- *
- * @param {Object} address - a shipping address object
- * @returns {Object} The filtered shipping address object
- */
-export function adaptAddressToFormFields(address) {
-  const { fullName, address1, address2, city, country, phone, postal, region } = address;
-  const [firstName, lastName] = fullName.split(" ");
-
-  return {
-    address1,
-    address2,
-    city,
-    country,
-    firstName,
-    lastName,
-    phone,
-    postal,
-    region
-  };
-}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1022,10 +1022,10 @@
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@reactioncommerce/components-context/-/components-context-1.0.0.tgz#587764cf0d1b0312c786b8e4657379de02e13845"
 
-"@reactioncommerce/components@0.51.2":
-  version "0.51.2"
-  resolved "https://registry.yarnpkg.com/@reactioncommerce/components/-/components-0.51.2.tgz#74df7ee026e6f1f0f25383779d453f330db73a98"
-  integrity sha512-/CaJGcCGVNM6CPJ4YxSxN0+9Qp3B3LTuxfC29xpLRInH1fQf4J3KZw8EKEUT7Pz9pjIedTIoQKTV1NsdKmEMhw==
+"@reactioncommerce/components@0.54.1":
+  version "0.54.1"
+  resolved "https://registry.yarnpkg.com/@reactioncommerce/components/-/components-0.54.1.tgz#43ac04565c7bc3a199cc12dc9896cf69bd10952c"
+  integrity sha512-YHPmtPNnTPyebvsnXk9wAaiWtUzQaO9FL+ANmub8Tf5t/Zx9a6fgTJcZPVOb4BR3VZg2nryys7xN+ultAVBduQ==
   dependencies:
     "@material-ui/core" "^3.1.0"
     lodash.debounce "^4.0.8"


### PR DESCRIPTION
Resolves #414 
Impact: **minor**
Type: **bugfix**

## Issue
- Shipping address form is not saving `fullName`
- Shipping address form is not displaying `fullName`

## Solution
- Submit `fullName` instead of `firstName` and `lastName`
- Display `fullName`
- Upgrades `@reactioncommerce/components`
- Remove `adaptAddressToFormFields` function - No longer needed

## Testing
1. Fill out the form
2. Look for the name to be displayed in both the form and the completed CheckoutAction