### PR TITLE
chore: Add logger messages for 401 error

### DIFF
--- a/src/lib/apollo/withApolloClient.js
+++ b/src/lib/apollo/withApolloClient.js
@@ -68,7 +68,12 @@ export default function withApolloClient(WrappedComponent) {
           // Handle them in components via the data.error prop:
           // http://dev.apollodata.com/react/api-queries.html#graphql-query-data-error
           if (error.networkError) {
-            logger.error(`Unable to access the GraphQL API. Is it running and accessible at ${serverRuntimeConfig.graphqlUrl} from the Storefront UI server?`);
+            if (error.networkError.response && error.networkError.response.status === 401) {
+              logger.error("Error: Unable to access the GraphQL API due to invalid or expired authentication credentials.");
+              logger.error("Background token refresh is currently work-in-progress. To resolve this error, clear the browser cookies or manually go to the sign in page");
+            } else {
+              logger.error(`Unable to access the GraphQL API. Is it running and accessible at ${serverRuntimeConfig.graphqlUrl} from the Storefront UI server?`);
+            }
           } else {
             logger.error("Error while running `getDataFromTree`:", error);
           }

--- a/src/server.js
+++ b/src/server.js
@@ -91,6 +91,9 @@ app
     server.get("/logout/:userId", (req, res) => {
       const { id } = decodeOpaqueId(req.params.userId);
       request(`${process.env.OAUTH2_IDP_HOST_URL}logout?userId=${id}`, (error) => {
+        if (error) {
+          logger.error(`Error from OAUTH2_IDP_HOST_URL logout endpoint: ${error}. Check the HOST server settings`);
+        }
         if (!error) {
           req.logout();
           res.redirect(req.get("Referer") || "/");


### PR DESCRIPTION
Resolves: NA
Impact: **minor**
Type: **chore**

## Issue
When loading the app after a previous authenticated session and the auth token is expired, the app shows a blank screen. The starterkit server logs shows an error about other failures but not explicit about the 401. 

Looking in the browser network tab can help, as the 401 can be seen there.
The Reaction API service logs shows the `Bearer token is not active` error; but it helps to have it logged here too.

## Solution
Add proper logs that reflect the actual problem (pending when automatic refresh is resolved #350)

## Testing
@Akarshit adding you as reviewer because you ran into this recently. There's really nothing to test other than confirming that the logged message helps to know the actual issue (and prevents getting stuck).
