### PR TITLE
fix: show tax total in all summaries

### DIFF
--- a/src/components/CheckoutSummary/CheckoutSummary.js
+++ b/src/components/CheckoutSummary/CheckoutSummary.js
@@ -84,6 +84,7 @@ class CheckoutSummary extends Component {
       const {
         fulfillmentTotal,
         itemTotal,
+        taxTotal,
         total
       } = cart.checkout.summary;
 
@@ -93,6 +94,7 @@ class CheckoutSummary extends Component {
             isDense
             displayShipping={fulfillmentTotal && fulfillmentTotal.displayAmount}
             displaySubtotal={itemTotal && itemTotal.displayAmount}
+            displayTax={taxTotal && taxTotal.displayAmount}
             displayTotal={total && total.displayAmount}
             itemsQuantity={cart.totalItemQuantity}
           />

--- a/src/components/OrderSummary/OrderSummary.js
+++ b/src/components/OrderSummary/OrderSummary.js
@@ -60,6 +60,7 @@ class OrderSummary extends Component {
       const {
         fulfillmentTotal,
         itemTotal,
+        taxTotal,
         total
       } = fulfillmentGroup.summary;
 
@@ -69,6 +70,7 @@ class OrderSummary extends Component {
             isDense
             displayShipping={fulfillmentTotal && fulfillmentTotal.displayAmount}
             displaySubtotal={itemTotal && itemTotal.displayAmount}
+            displayTax={taxTotal && taxTotal.displayAmount}
             displayTotal={total && total.displayAmount}
           />
         </OrderSummaryContainer>

--- a/src/pages/cart.js
+++ b/src/pages/cart.js
@@ -140,13 +140,14 @@ class CartPage extends Component {
     const { cart, classes } = this.props;
 
     if (cart && cart.checkout && cart.checkout.summary && Array.isArray(cart.items) && cart.items.length) {
-      const { fulfillmentTotal, itemTotal, total } = cart.checkout.summary;
+      const { fulfillmentTotal, itemTotal, taxTotal, total } = cart.checkout.summary;
 
       return (
         <Grid item xs={12} md={3}>
           <CartSummary
             displayShipping={fulfillmentTotal && fulfillmentTotal.displayAmount}
             displaySubtotal={itemTotal && itemTotal.displayAmount}
+            displayTax={taxTotal && taxTotal.displayAmount}
             displayTotal={total && total.displayAmount}
             itemsQuantity={cart.totalItemQuantity}
           />


### PR DESCRIPTION
Impact: **minor**
Type: **bugfix**

## Issue
Only 1 of the 4 places where `CartSummary` is used was showing the `taxTotal` amount. The others always showed `-`.

## Solution
Now all summaries show the tax amount

## Breaking changes
n/a

## Testing

Must be tested against `refactor-aldeed-split-tax-rates-plugin` branch of Reaction API until it is merged.

1. Configure and enable a tax service in Reaction operator UI.
2. Configure a product variant to be taxable and have a taxable tax code.
3. Add that product variant to your cart in starter kit storefront.
4. Go to checkout and enter a shipping address.
5. Verify that a tax amount shows in the summary on the right
6. Go to `/cart` and verify that a tax amount shows there.
7. Go back to checkout and finish checking out. Verify that a tax amount shows on the order summary after the order is placed.
