### PR TITLE
Fix incorrect logger.debug

### DIFF
--- a/src/lib/apollo/withApolloClient.js
+++ b/src/lib/apollo/withApolloClient.js
@@ -71,7 +71,8 @@ export default function withApolloClient(WrappedComponent) {
             // In server, if a 401 Unauthorized error occurred, redirect to /signin.
             // This will re-authenticate without showing a login page and a new token is issued.
             if (error.networkError.response.status === 401 && res) {
-              logger.debug("Received 401 error from the GraphQL API due to invalid or expired authentication credentials. Triggering token refresh via redirect flow");
+              // eslint-disable-next-line no-console
+              console.log("Received 401 error from the GraphQL API due to invalid or expired authentication credentials. Triggering token refresh via redirect flow");
               res.writeHead(302, { Location: "/signin" });
               res.end();
               return {};

--- a/src/lib/apollo/withApolloClient.js
+++ b/src/lib/apollo/withApolloClient.js
@@ -34,7 +34,15 @@ export default function withApolloClient(WrappedComponent) {
       // Provide the `url` prop data in case a GraphQL query uses it
       rootMobxStores.routingStore.updateRoute({ query, pathname });
 
-      const user = req && req.session && req.session.passport && req.session.passport.user && JSON.parse(req.session.passport.user);
+      let user;
+      try {
+        const userString = req && req.session && req.session.passport && req.session.passport.user;
+        user = JSON.parse(userString);
+      } catch (error) {
+        // eslint-disable-next-line no-console
+        console.log("Error parsing user object. Check passport session configuration", error);
+      }
+
       const apollo = initApollo({ cookies: req && req.cookies }, { accessToken: user && user.accessToken });
 
       ctx.ctx.apolloClient = apollo;


### PR DESCRIPTION
Resolves: NA
Impact: **minor**
Type: **bugfix**

## Issue
`const logger = require("lib/logger");`
`logger.debug("")` ==> debug is not a function


## Solution
In the express app, the exported [Logger](https://github.com/reactioncommerce/reaction-next-starterkit/blob/develop/src/lib/logger/index.js) is custom and only has `error` and `appStarted` methods. It is different from https://github.com/reactioncommerce/logger.

Solution: Switch to plain console.log instead.


## Testing
1. On token expiration (which is when the incorrect logger was being called), you should see the message printed and not see an error similar to:
```
[Network error]: SyntaxError: Unexpected token U in JSON at position 0
TypeError: _logger__WEBPACK_IMPORTED_MODULE_8___default.a.debug is not a function
    at Function._callee$ (webpack:///lib/apollo/withApolloClient.js:74:1)
    at tryCatch (/usr/local/src/node_modules/@babel/runtime/node_modules/regenerator-runtime/runtime.js:62:40)
    at Generator.invoke [as _invoke] (/usr/local/src/node_modules/@babel/runtime/node_modules/regenerator-runtime/runtime.js:288:22)
    at Generator.prototype.(anonymous function) [as throw] (/usr/local/src/node_modules/@babel/runtime/node_modules/regenerator-runtime/runtime.js:114:21)
    at asyncGeneratorStep (/usr/local/src/reaction-app/src/.next/server/static/development/pages/_app.js:12511:28)
    at _throw (/usr/local/src/reaction-app/src/.next/server/static/development/pages/_app.js:12537:13)
    at process._tickCallback (internal/process/next_tick.js:68:7)
```

### Extra Update
Also, we have a JSON.parse() that should be wrapped in a try/catch block to prevent exception failure. This PR also wraps that in a try/catch block. To test, just confirm that usual app usage works without errors. 
