### PR TITLE
Use new `order.referenceId` as displayed order ID

### DIFF
--- a/src/components/CheckoutActions/CheckoutActions.js
+++ b/src/components/CheckoutActions/CheckoutActions.js
@@ -18,7 +18,6 @@ import TRACKING from "lib/tracking/constants";
 import trackCheckout from "lib/tracking/trackCheckout";
 import trackOrder from "lib/tracking/trackOrder";
 import trackCheckoutStep from "lib/tracking/trackCheckoutStep";
-import { decodeOpaqueId } from "lib/utils/decoding";
 import { isShippingAddressSet } from "lib/utils/cartUtils";
 
 const {
@@ -272,8 +271,7 @@ export default class CheckoutActions extends Component {
 
       this.trackOrder({ action: ORDER_COMPLETED, orders });
       // Send user to order confirmation page
-      const { id } = decodeOpaqueId(orders[0]._id);
-      Router.pushRoute("checkoutComplete", { orderId: id, token });
+      Router.pushRoute("checkoutComplete", { orderId: orders[0].referenceId, token });
     } catch (error) {
       this.setState({
         hasPaymentError: true,

--- a/src/containers/cart/withCart.js
+++ b/src/containers/cart/withCart.js
@@ -441,7 +441,7 @@ export default function withCart(Component) {
                       onSetShippingAddress: this.handleSetShippingAddress
                     }}
                     hasMoreCartItems={(pageInfo && pageInfo.hasNextPage) || false}
-                    isLoading={skipQuery ? false : isLoading}
+                    isLoadingCart={skipQuery ? false : isLoading}
                     loadMoreCartItems={() => {
                       fetchMore({
                         variables: {

--- a/src/containers/order/fragments.gql
+++ b/src/containers/order/fragments.gql
@@ -167,6 +167,7 @@ fragment OrderCommon on Order {
     }
     type
   }
+  referenceId
   shop {
     _id
     currency {

--- a/src/containers/order/queries.gql
+++ b/src/containers/order/queries.gql
@@ -1,8 +1,8 @@
 #import "./fragments.gql"
 
 # Get an order
-query orderById($id: ID!, $shopId: ID!, $token: String) {
-  order: orderById(id: $id, shopId: $shopId, token: $token) {
+query orderByReferenceId($id: ID!, $shopId: ID!, $token: String) {
+  order: orderByReferenceId(id: $id, shopId: $shopId, token: $token) {
     ...OrderQueryFragment
   }
 }

--- a/src/containers/order/withOrder.js
+++ b/src/containers/order/withOrder.js
@@ -3,8 +3,7 @@ import PropTypes from "prop-types";
 import { Query, withApollo } from "react-apollo";
 import { inject, observer } from "mobx-react";
 import hoistNonReactStatic from "hoist-non-react-statics";
-import { base64EncodeId } from "lib/utils/encoding";
-import { orderById } from "./queries.gql";
+import { orderByReferenceId } from "./queries.gql";
 
 /**
  * withOrder higher order query component for fetching an order
@@ -42,16 +41,15 @@ export default function withOrder(Component) {
 
     render() {
       const { primaryShopId, routingStore } = this.props;
-      const opaqueId = base64EncodeId(routingStore.query.orderId, "reaction/order");
 
       const variables = {
-        id: opaqueId,
+        id: routingStore.query.orderId,
         shopId: primaryShopId,
         token: routingStore.query.token || null
       };
 
       return (
-        <Query query={orderById} variables={variables}>
+        <Query query={orderByReferenceId} variables={variables}>
           {({ loading: isLoading, data: orderData }) => {
             const { order } = orderData || {};
 

--- a/src/containers/order/withOrder.js
+++ b/src/containers/order/withOrder.js
@@ -58,7 +58,7 @@ export default function withOrder(Component) {
             return (
               <Component
                 {...this.props}
-                isLoading={isLoading}
+                isLoadingOrder={isLoading}
                 order={order}
               />
             );

--- a/src/lib/tracking/trackOrder.js
+++ b/src/lib/tracking/trackOrder.js
@@ -1,4 +1,3 @@
-import { decodeOpaqueId } from "lib/utils/decoding";
 import getCartItemTrackingData from "./utils/getCartItemTrackingData";
 import track from "./track";
 
@@ -16,8 +15,7 @@ export default (options) =>
       orders
     } = (functionArgs && functionArgs[0]) || [];
 
-    const { fulfillmentGroups, _id, shop } = orders[0];
-    const { id } = decodeOpaqueId(_id);
+    const { fulfillmentGroups, referenceId, shop } = orders[0];
     // currently only supporting one fulfillment group
     const { items: { nodes: items }, summary } = fulfillmentGroups[0];
     const products = [];
@@ -29,7 +27,7 @@ export default (options) =>
     const data = {
       action,
       currency: shop.currency.code,
-      order_id: id, // eslint-disable-line camelcase
+      order_id: referenceId, // eslint-disable-line camelcase
       revenue: summary.itemTotal.amount,
       shipping: summary.fulfillmentTotal.amount,
       tax: summary.taxTotal.amount,

--- a/src/pages/checkout.js
+++ b/src/pages/checkout.js
@@ -142,7 +142,7 @@ class Checkout extends Component {
     }),
     classes: PropTypes.object,
     hasMoreCartItems: PropTypes.bool,
-    isLoading: PropTypes.bool,
+    isLoadingCart: PropTypes.bool,
     loadMoreCartItems: PropTypes.func,
     onChangeCartItemsQuantity: PropTypes.func,
     onRemoveCartItems: PropTypes.func,
@@ -287,13 +287,13 @@ class Checkout extends Component {
       classes,
       cart,
       hasMoreCartItems,
-      isLoading,
+      isLoadingCart,
       loadMoreCartItems,
       onRemoveCartItems,
       onChangeCartItemsQuantity
     } = this.props;
 
-    if (isLoading) return null;
+    if (isLoadingCart) return null;
 
     if (!cart || (cart && Array.isArray(cart.items) && cart.items.length === 0)) {
       return (
@@ -345,8 +345,8 @@ class Checkout extends Component {
   }
 
   render() {
-    const { isLoading, cart } = this.props;
-    if (isLoading || !cart) return <PageLoading delay={0} />;
+    const { isLoadingCart, cart } = this.props;
+    if (isLoadingCart || !cart) return <PageLoading delay={0} />;
 
     return (
       <Fragment>

--- a/src/pages/checkoutComplete.js
+++ b/src/pages/checkoutComplete.js
@@ -5,10 +5,10 @@ import { observer } from "mobx-react";
 import Helmet from "react-helmet";
 import { withStyles } from "@material-ui/core/styles";
 import Typography from "@material-ui/core/Typography";
-import withOrder from "containers/order/withOrder";
 import OrderFulfillmentGroups from "components/OrderFulfillmentGroups";
+import PageLoading from "components/PageLoading";
 import withCart from "containers/cart/withCart";
-import { decodeOpaqueId } from "lib/utils/decoding";
+import withOrder from "containers/order/withOrder";
 
 const styles = (theme) => ({
   sectionHeader: {
@@ -81,7 +81,7 @@ class CheckoutComplete extends Component {
     clearAuthenticatedUsersCart: PropTypes.func.isRequired,
     client: PropTypes.object.isRequired,
     hasMoreCartItems: PropTypes.bool,
-    isLoading: PropTypes.bool,
+    isLoadingOrder: PropTypes.bool,
     loadMoreCartItems: PropTypes.func,
     onChangeCartItemsQuantity: PropTypes.func,
     onRemoveCartItems: PropTypes.func,
@@ -106,9 +106,7 @@ class CheckoutComplete extends Component {
   }
 
   renderFulfillmentGroups() {
-    const { classes, order, isLoading } = this.props;
-
-    if (isLoading) return null;
+    const { classes, order } = this.props;
 
     return (
       <div className={classes.flexContainer}>
@@ -120,8 +118,21 @@ class CheckoutComplete extends Component {
   }
 
   render() {
-    const { classes, order, shop } = this.props;
-    const { id } = (order && decodeOpaqueId(order._id)) || {};
+    const { classes, isLoadingOrder, order, shop } = this.props;
+
+    if (isLoadingOrder) return <PageLoading message="Loading order details..." />;
+
+    if (!order) {
+      return (
+        <div className={classes.checkoutContentContainer}>
+          <div className={classes.orderDetails}>
+            <section className={classes.section}>
+              <Typography className={classes.title} variant="title">Order not found</Typography>
+            </section>
+          </div>
+        </div>
+      );
+    }
 
     return (
       <Fragment>
@@ -137,7 +148,7 @@ class CheckoutComplete extends Component {
                   {"Thank you for your order"}
                 </Typography>
                 <Typography variant="body1">
-                  {"Your order ID is:"} <strong>{id}</strong>
+                  {"Your order ID is:"} <strong>{order && order.referenceId}</strong>
                 </Typography>
                 <Typography variant="body1">
                   {"We've sent a confirmation email to:"} <strong>{order && order.email}</strong>


### PR DESCRIPTION
Impact: **minor**
Type: **feature**

## Issue
There was no order ID that was provided by GraphQL that could be displayed to the customer and then also seen as a reference ID by the operator. There was a workaround for this in place, decoding the `Order._id` and showing that.

## Solution
https://github.com/reactioncommerce/reaction/pull/4827 introduces `order.referenceId`. This PR updates the storefront to display that ID on the order completion page.

## Breaking changes
Tied to a change in Reaction API. Will not work with earlier versions of the API anymore.

## Testing
See https://github.com/reactioncommerce/reaction/pull/4827 testing instructions