### PR TITLE
fix: Fix error when clicking links when ENABLE_SPA_LINKS=false

### DIFF
--- a/src/routes.js
+++ b/src/routes.js
@@ -4,7 +4,7 @@ const getConfig = require("next/config").default;
 if (process.browser) {
   const { publicRuntimeConfig } = getConfig();
 
-  const wrap = (method) => (route, params, options) => {
+  const wrap = (method) => (route, params, options = {}) => {
     const { byName, urls: { as, href } } = routes.findAndGetUrls(route, params);
 
     // Force full page loads


### PR DESCRIPTION
Resolves #441
Impact: **minor**
Type: **bugfix**

## Issue

Some links do not work when `ENABLE_SPA_LINKS=false`

## Solution

Set a default value for `options`.

## Breaking changes

None.

## Testing

1. Set `ENABLE_SPA_LINKS=false` in `.env`
1. Start the app
1. Click on a tag
1. you should be navigated to that tag
