### PR TITLE
fix: Add proper isMounted checking

### DIFF
--- a/src/components/CheckoutActions/CheckoutActions.js
+++ b/src/components/CheckoutActions/CheckoutActions.js
@@ -67,6 +67,7 @@ export default class CheckoutActions extends Component {
   };
 
   componentDidMount() {
+    this._isMounted = true;
     const { cart } = this.props;
     // Track start of checkout process
     this.trackCheckoutStarted({ cart, action: CHECKOUT_STARTED });
@@ -90,6 +91,10 @@ export default class CheckoutActions extends Component {
     ) {
       this.handleValidationErrors();
     }
+  }
+
+  componentWillUnmount() {
+    this._isMounted = false;
   }
 
   @trackCheckoutStep()
@@ -136,11 +141,13 @@ export default class CheckoutActions extends Component {
       // The next step will automatically be expanded, so lets track that
       this.trackAction(this.buildData({ action: CHECKOUT_STEP_VIEWED, step: 2 }));
 
-      this.setState({
-        actionAlerts: {
-          1: {}
-        }
-      });
+      if (this._isMounted) {
+        this.setState({
+          actionAlerts: {
+            1: {}
+          }
+        });
+      }
     }
   };
 
@@ -273,17 +280,19 @@ export default class CheckoutActions extends Component {
       // Send user to order confirmation page
       Router.pushRoute("checkoutComplete", { orderId: orders[0].referenceId, token });
     } catch (error) {
-      this.setState({
-        hasPaymentError: true,
-        isPlacingOrder: false,
-        actionAlerts: {
-          3: {
-            alertType: "error",
-            title: "Payment method failed",
-            message: error.toString().replace("Error: GraphQL error:", "")
+      if (this._isMounted) {
+        this.setState({
+          hasPaymentError: true,
+          isPlacingOrder: false,
+          actionAlerts: {
+            3: {
+              alertType: "error",
+              title: "Payment method failed",
+              message: error.toString().replace("Error: GraphQL error:", "")
+            }
           }
-        }
-      });
+        });
+      }
     }
   };
 

--- a/src/containers/address/withAddressValidation.js
+++ b/src/containers/address/withAddressValidation.js
@@ -28,12 +28,22 @@ export default function withAddressValidation(Comp) {
       validationErrors: []
     };
 
+    componentDidMount() {
+      this._isMounted = true;
+    }
+
+    componentWillUnmount() {
+      this._isMounted = false;
+    }
+
     set addressValidationResults({ submittedAddress, validationResults: { suggestedAddresses, validationErrors } }) {
-      this.setState({
-        suggestedAddresses: suggestedAddresses.map(this.xformValidSuggestions),
-        submittedAddress,
-        validationErrors
-      });
+      if (this._isMounted) {
+        this.setState({
+          suggestedAddresses: suggestedAddresses.map(this.xformValidSuggestions),
+          submittedAddress,
+          validationErrors
+        });
+      }
     }
 
     xformValidSuggestions = (address) => ({


### PR DESCRIPTION
Resolves #451 
Impact: **minor**
Type: **fix|enhancement**

## Issue
Trying to set state asynchronously, sometimes you may run into a warning stating that you can't call `setState`, or `forceUpdate` on a non-mounted component.

## Solution
1. Search for `this.setState` and `this.forceUpdate`.
2. For any that are in a callback/then, or after an await, add isMounted check as described [here](https://docs.reactioncommerce.com/docs/react-best-practices#setting-state-asynchronously)


## Breaking changes
N/A

## Testing
- This is more of a code review and test to confirm that no regression is created for the components touched