### PR TITLE
fix: fix logic for retrying 401s with silent re-auth

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -5,5 +5,5 @@ ignore:
   'npm:chownr:20180731':
     - '*':
         reason: This vulnerability only affects packages used in development, such as webpack, more details at https://github.com/isaacs/chownr/issues/14#issuecomment-421662375
-        expires: 2018-12-30T00:00:00.000Z
+        expires: 2019-01-31T00:00:00.000Z
 patch: {}

--- a/src/components/Profile/ProfileContainer.js
+++ b/src/components/Profile/ProfileContainer.js
@@ -5,7 +5,7 @@ import Profile from "./Profile";
 
 // eslint-disable-next-line react/display-name
 export default () => (
-  <Query query={viewerQuery}>
+  <Query errorPolicy="all" query={viewerQuery}>
     {({ loading, error, data }) => {
       if (loading) return <p>Loading...</p>;
       if (error) return <p>Error</p>;

--- a/src/components/VariantItem/VariantItem.js
+++ b/src/components/VariantItem/VariantItem.js
@@ -63,10 +63,16 @@ class VariantItem extends Component {
 
     const variantPrice = priceByCurrencyCode(currencyCode, pricing);
 
+    const className = classNames(variantButton, {
+      [activeVariant]: isActive
+    }, {
+      [soldOutVariant]: variantInventoryStatus && variantInventoryStatus.type === "SOLD_OUT"
+    });
+
     return (
       <ButtonBase
         disableRipple
-        className={classNames(variantButton, { [activeVariant]: isActive }, { [soldOutVariant]: variantInventoryStatus && variantInventoryStatus.type === "SOLD_OUT" })}
+        className={className}
         onClick={this.onClick}
       >
         <Typography component="span" variant="body1">

--- a/src/containers/account/withViewer.js
+++ b/src/containers/account/withViewer.js
@@ -25,7 +25,7 @@ export default function withViewer(Component) {
       const { authStore } = this.props;
 
       return (
-        <Query query={viewerQuery}>
+        <Query errorPolicy="all" query={viewerQuery}>
           {({ data }) => {
             if (data) {
               authStore.setAccount(data.viewer);

--- a/src/containers/cart/withCart.js
+++ b/src/containers/cart/withCart.js
@@ -388,7 +388,7 @@ export default function withCart(Component) {
       }
 
       return (
-        <Query query={query} variables={variables} skip={skipQuery}>
+        <Query errorPolicy="all" query={query} variables={variables} skip={skipQuery}>
           {({ loading: isLoading, data: cartData, fetchMore, refetch: refetchCart }) => {
             const { cart } = cartData || {};
             const { pageInfo } = (cart && cart.items) || {};

--- a/src/containers/catalog/withCatalogItemProduct.js
+++ b/src/containers/catalog/withCatalogItemProduct.js
@@ -20,7 +20,7 @@ export default function withCatalogItemProduct(Component) {
       const { router: { query } } = this.props;
 
       return (
-        <Query query={catalogItemProductQuery} variables={{ slugOrId: query.slugOrId }}>
+        <Query errorPolicy="all" query={catalogItemProductQuery} variables={{ slugOrId: query.slugOrId }}>
           {({ data, loading }) => {
             const { catalogItemProduct } = data || {};
             const { product } = catalogItemProduct || {};

--- a/src/containers/catalog/withCatalogItems.js
+++ b/src/containers/catalog/withCatalogItems.js
@@ -41,7 +41,7 @@ export default function withCatalogItems(Component) {
       };
 
       return (
-        <Query query={catalogItemsQuery} variables={variables}>
+        <Query errorPolicy="all" query={catalogItemsQuery} variables={variables}>
           {({ data, fetchMore, loading }) => {
             const { catalogItems } = data || {};
 

--- a/src/containers/order/withOrder.js
+++ b/src/containers/order/withOrder.js
@@ -44,7 +44,7 @@ export default function withOrder(Component) {
       };
 
       return (
-        <Query query={orderByReferenceId} variables={variables}>
+        <Query errorPolicy="all" query={orderByReferenceId} variables={variables}>
           {({ loading: isLoading, data: orderData }) => {
             const { order } = orderData || {};
 

--- a/src/containers/shop/withShop.js
+++ b/src/containers/shop/withShop.js
@@ -15,12 +15,12 @@ export default function withShop(Component) {
   class Shop extends React.Component {
     render() {
       return (
-        <Query query={primaryShopIdQuery}>
+        <Query errorPolicy="all" query={primaryShopIdQuery}>
           {({ loading: loadingPrimaryShopId, data }) => {
             const { primaryShopId } = data || {};
 
             return (
-              <Query query={shopQuery} variables={{ shopId: primaryShopId }} skip={loadingPrimaryShopId}>
+              <Query errorPolicy="all" query={shopQuery} variables={{ shopId: primaryShopId }} skip={loadingPrimaryShopId}>
                 {({ loading: loadingShopData, data: shopData }) => {
                   const { shop } = shopData || {};
 

--- a/src/containers/tags/withTag.js
+++ b/src/containers/tags/withTag.js
@@ -23,11 +23,8 @@ export default function withTag(Component) {
       const { router: { query: { slug: tag } } } = this.props;
 
       return (
-        <Query query={tagQuery} variables={{ slugOrId: tag }}>
-          {({ error, data }) => {
-            if (error) {
-              console.error("WithTag query error:", error); // eslint-disable-line no-console
-            }
+        <Query errorPolicy="all" query={tagQuery} variables={{ slugOrId: tag }}>
+          {({ data }) => {
             const tagData = data || {};
 
             return (


### PR DESCRIPTION
Resolves #470 
Impact: **minor**
Type: **bugfix**

## Issue
Due to GraphQL server update to Apollo Server 2.0 as well as subsequent changes in starterkit, the earlier work to silently re-authenticate when a 401 error is detected stopped working.

## Solution
Revamped how we're doing it to be more foolproof.

## Breaking changes
None

## Testing
I recommend testing against https://github.com/reactioncommerce/reaction/pull/4894 or the re-auth from browser will not work.

There are two ways this token refreshing is supposed to work, both of which need to be tested. The setup is the same for both:
- Add `- ACCESS_TOKEN_LIFESPAN=1m` in the `environment` section of reaction-hydra project's `docker-compose.yml` file.
- `dc down` and `dc up -d` reaction-hydra
- Log out of starterkit, and then log back in.

This will force auth tokens to expire after only 1 minute, making it faster to test this.

### Test silent re-auth in browser
1. After waiting at least a minute since you logged in, click something in the app to cause a GraphQL request to happen. Make sure it's something you haven't recently clicked or Apollo will actually be using its cache. If you don't see a `graphql-alpha` request in the browser network log, then keep clicking until you do.
2. You should see a 401 response and "Attempting silent re-auth" message in the browser console, which may immediately disappear. The page may flash and then you should still be logged in, or worst case it should bring you to the login page if it was not able to silently refresh the token.

### Test silent re-auth from NextJS server
1. After waiting at least a minute since you logged in (or since you did the last token refresh test), refresh the page.
2. You should see an "Attempting silent re-auth" message in the NextJS server log. When the page finishes refreshing, you should still be logged in.