### PR TITLE
chore : integrate ssr test + broken link checker to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -201,10 +201,40 @@ jobs:
           name: Integration Test
           command: |
             docker run \
+              -e URL=${STAGING_URL} \
               --env-file docker-cache/.env \
               --name reactionapp_next_starterkit_int \
-              "$DOCKER_REPOSITORY:$CIRCLE_SHA1" \
-              -e URL=${STAGING_URL} \ 
+              "$DOCKER_REPOSITORY:$CIRCLE_SHA1" \ 
+              yarn run test:integration
+      - run:
+          name: Copy test artifacts from Remote Docker
+          command: |
+            docker cp \
+              reactionapp_next_starterkit:/usr/local/src/reaction-app/reports \
+              reports
+      - store_test_results:
+          path: reports/junit
+      - store_artifacts:
+          path: reports
+
+  e2e-test:
+    <<: *defaults
+    steps:
+      - setup_remote_docker
+      - attach_workspace:
+          at: docker-cache
+      - run:
+          name: Load Docker Image
+          command: |
+            docker load < docker-cache/docker-image.tar
+      - run:
+          name: Integration Test
+          command: |
+            docker run -t \
+              -e URL=${STAGING_URL} \
+              --env-file docker-cache/.env \
+              --name reactionapp_next_starterkit_int \
+              "$DOCKER_REPOSITORY:$CIRCLE_SHA1" \ 
               yarn run test:integration
       # - run:
       #     name: Install Broken Link Checker
@@ -280,3 +310,7 @@ workflows:
           filters:
             branches:
               only: /^develop$/
+      # - e2e-test:
+      #     requires: 
+      #       - deploy-to-ecs
+            

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -200,7 +200,12 @@ jobs:
       - run:
           name: Integration Test
           command: |
-            docker run -e URL=${STAGING_URL} --env-file docker-cache/.env --name reaction_app_next_starterkit "$DOCKER_REPOSITORY:$CIRCLE_SHA1" yarn run test:integration
+            docker run \ 
+            -e URL=${STAGING_URL} \
+            --env-file docker-cache/.env \
+            --name reaction_app_next_starterkit \
+            "$DOCKER_REPOSITORY:$CIRCLE_SHA1" \
+            yarn run test:integration
       - run:
           name: Copy test artifacts from Remote Docker
           command: |
@@ -225,11 +230,12 @@ jobs:
       - run:
           name: Integration Test
           command: |
-            docker run -t \
-              --env-file docker-cache/.env \
-              --name reactionapp_next_starterkit_int \
-              "$DOCKER_REPOSITORY:$CIRCLE_SHA1" \ 
-              yarn run test:integration
+            docker run \ 
+            -e URL=${STAGING_URL} \
+            --env-file docker-cache/.env \
+            --name reaction_app_next_starterkit \
+            "$DOCKER_REPOSITORY:$CIRCLE_SHA1" \
+            yarn run test:integration
       # - run:
       #     name: Install Broken Link Checker
       #     command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -201,11 +201,11 @@ jobs:
           name: Integration Test
           command: |
             docker run \ 
-            -e URL=${STAGING_URL} \
-            --env-file docker-cache/.env \
-            --name reaction_app_next_starterkit \
-            "$DOCKER_REPOSITORY:$CIRCLE_SHA1" \
-            yarn run test:integration
+              -e URL=${STAGING_URL} \
+              --env-file docker-cache/.env \
+              --name reaction_app_next_starterkit \
+              "$DOCKER_REPOSITORY:$CIRCLE_SHA1" \
+              yarn run test:integration
       - run:
           name: Copy test artifacts from Remote Docker
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -204,7 +204,8 @@ jobs:
               --env-file docker-cache/.env \
               --name reactionapp_next_starterkit_int \
               "$DOCKER_REPOSITORY:$CIRCLE_SHA1" \
-              URL=${STAGING_URL} yarn run test:integration
+              -e URL=${STAGING_URL} \ 
+              yarn run test:integration
       # - run:
       #     name: Install Broken Link Checker
       #     command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -230,16 +230,6 @@ jobs:
           name: Broken Link Test
           command: |
             ./node_modules/.bin/blc ${STAGING_URL} -ro -filter=3 -e
-      - run:
-          name: Copy test artifacts from Remote Docker
-          command: |
-            docker cp \
-              reactionapp_next_starterkit:/usr/local/src/reaction-app/reports \
-              reports
-      - store_test_results:
-          path: reports/junit
-      - store_artifacts:
-          path: reports
 
   snyk-security:
     <<: *defaults
@@ -298,5 +288,5 @@ workflows:
               only: /^develop$/
       - e2e-test:
           requires: 
-            - docker-build
+            - deploy-to-ecs
             

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -204,7 +204,7 @@ jobs:
               --env-file docker-cache/.env \
               --name reactionapp_next_starterkit_int \
               "$DOCKER_REPOSITORY:$CIRCLE_SHA1" \
-              yarn run test:integration
+              URL=${STAGING_URL} yarn run test:integration
       # - run:
       #     name: Install Broken Link Checker
       #     command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -200,12 +200,7 @@ jobs:
       - run:
           name: Integration Test
           command: |
-            docker run \
-              -e URL=${STAGING_URL} \
-              --env-file docker-cache/.env \
-              --name reactionapp_next_starterkit_int \
-              "$DOCKER_REPOSITORY:$CIRCLE_SHA1" \ 
-              yarn run test:integration
+            docker run -e URL=${STAGING_URL} --env-file docker-cache/.env --name reaction_app_next_starterkit "$DOCKER_REPOSITORY:$CIRCLE_SHA1" yarn run test:integration
       - run:
           name: Copy test artifacts from Remote Docker
           command: |
@@ -231,7 +226,6 @@ jobs:
           name: Integration Test
           command: |
             docker run -t \
-              -e URL=${STAGING_URL} \
               --env-file docker-cache/.env \
               --name reactionapp_next_starterkit_int \
               "$DOCKER_REPOSITORY:$CIRCLE_SHA1" \ 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -198,15 +198,6 @@ jobs:
               "$DOCKER_REPOSITORY:$CIRCLE_SHA1" \
               yarn run test:ci
       - run:
-          name: Integration Test
-          command: |
-            docker run \ 
-              -e URL=${STAGING_URL} \
-              --env-file docker-cache/.env \
-              --name reaction_app_next_starterkit \
-              "$DOCKER_REPOSITORY:$CIRCLE_SHA1" \
-              yarn run test:integration
-      - run:
           name: Copy test artifacts from Remote Docker
           command: |
             docker cp \
@@ -230,20 +221,15 @@ jobs:
       - run:
           name: Integration Test
           command: |
-            docker run \ 
-            -e URL=${STAGING_URL} \
-            --env-file docker-cache/.env \
-            --name reaction_app_next_starterkit \
-            "$DOCKER_REPOSITORY:$CIRCLE_SHA1" \
-            yarn run test:integration
-      # - run:
-      #     name: Install Broken Link Checker
-      #     command: |
-      #       yarn add broken-link-checker
-      # - run:
-      #     name: Broken Link Test
-      #     command: |
-      #       ./node_modules/.bin/blc ${STAGING_URL} -ro -filter=3 -e
+            docker run -e URL=${STAGING_URL} --env-file docker-cache/.env --name reaction_app_next_starterkit "$DOCKER_REPOSITORY:$CIRCLE_SHA1" yarn run test:integration
+      - run:
+          name: Install Broken Link Checker
+          command: |
+            yarn add broken-link-checker
+      - run:
+          name: Broken Link Test
+          command: |
+            ./node_modules/.bin/blc ${STAGING_URL} -ro -filter=3 -e
       - run:
           name: Copy test artifacts from Remote Docker
           command: |
@@ -310,7 +296,7 @@ workflows:
           filters:
             branches:
               only: /^develop$/
-      # - e2e-test:
-      #     requires: 
-      #       - deploy-to-ecs
+      - e2e-test:
+          requires: 
+            - docker-build
             

--- a/tests/integration/ssr.test.js
+++ b/tests/integration/ssr.test.js
@@ -6,7 +6,7 @@ const chai = require("chai");
 require("isomorphic-fetch");
 
 // Checks if ENV Url is set within CI, if not use localhost. Configured for both local development and CI.
-const url = process.env.URL ? process.env.URL : 'http://localhost:4000';
+const url = process.env.URL ? process.env.URL : "http://localhost:4000";
 
 describe("NextJS Loading", () => {
   // Skipping this test because it works locally but not on CI. Created issue to solve this soon.

--- a/tests/integration/ssr.test.js
+++ b/tests/integration/ssr.test.js
@@ -5,11 +5,12 @@ const cheerio = require("cheerio");
 const chai = require("chai");
 require("isomorphic-fetch");
 
-const url = "http://localhost:4000";
+// Checks if ENV Url is set within CI, if not use localhost. Configured for both local development and CI.
+const url = process.env.URL ? process.env.URL : 'http://localhost:4000';
 
 describe("NextJS Loading", () => {
   // Skipping this test because it works locally but not on CI. Created issue to solve this soon.
-  it.skip("SSR Loads with an HTML Body", () => fetch(url)
+  it("SSR Loads with an HTML Body", () => fetch(url)
     .then((response) => {
       chai.expect(response.status).to.equal(200);
 


### PR DESCRIPTION
Resolves #456 
Impact: **minor**
Type: **test**

## Issue
- SSR integration test was failing via CI, not locally.
- Broken link checker was turned off due to flaky environments

## Solution
Due to SSR need to be rendered on a browser, it needed a way to test it out.

A solution was to add the SSR / integration step as a dependency on the `ecs-deploy` job in CI with an accompanying staging url environment call. Similar to how future e2e tests will run.

To make sure it can be tested for local development, add a ternary conditional operation that defaults to `localhost:4000` if no env variable is set.

Due to the stability of the staging environment, re-activate the broken link checker. 

Runs as a dependency for the `ecs-deploy` job in CI.

## Testing
1. After successful merge to deploy, validate if tests run in CI
2. Validate able to run locally without declaration of the `URL` variable and default runs via localhost on `starter-kit`


Example CI output : https://circleci.com/gh/reactioncommerce/reaction-next-starterkit/7376