### PR TITLE
fix: Fix infinite loader when cart empty

### DIFF
--- a/src/pages/cart.js
+++ b/src/pages/cart.js
@@ -163,8 +163,9 @@ class CartPage extends Component {
 
   render() {
     const { cart, classes, shop } = this.props;
-
-    if (!cart) return <PageLoading delay={0} />;
+    // when a user has no item in cart in a new session, this.props.cart is null
+    // when the app is still loading, this.props.cart is undefined
+    if (typeof cart === "undefined") return <PageLoading delay={0} />;
 
     return (
       <Fragment>


### PR DESCRIPTION
Resolves #465
Impact: **minor**
Type: **bugfix**

## Issue
#465

## Solution
Update check for empty cart used to show <PageLoading />.
When a user has no item in cart in a new session, this.props.cart is null
When the app is still loading, this.props.cart is undefined

The previous check `if (!this.props.cart)` needs to be a bit specific.

## Breaking changes
N/A


## Testing
1. Confirm that cart page now shows properly when there's no item in cart