### PR TITLE
feat: add server req/res debug options

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,6 @@
 CANONICAL_URL=http://localhost:4000
+DEBUG_REQUEST_HEADERS=false
+DEBUG_RESPONSE_HEADERS=false
 ENABLE_SPA_ROUTING=true
 EXTERNAL_GRAPHQL_URL=http://localhost:3000/graphql-alpha
 INTERNAL_GRAPHQL_URL=http://reaction.api.reaction.localhost:3000/graphql-alpha

--- a/src/config.js
+++ b/src/config.js
@@ -29,6 +29,8 @@ if (process.env.IS_BUILDING_NEXTJS) {
    */
   module.exports = envalid.cleanEnv(process.env, {
     CANONICAL_URL: url(),
+    DEBUG_REQUEST_HEADERS: bool({ default: false }),
+    DEBUG_RESPONSE_HEADERS: bool({ default: false }),
     ENABLE_SPA_ROUTING: bool({ default: true }), // must explicitly set to false to disable
     EXTERNAL_GRAPHQL_URL: url(),
     INTERNAL_GRAPHQL_URL: url(),

--- a/src/lib/apollo/withApolloClient.js
+++ b/src/lib/apollo/withApolloClient.js
@@ -3,10 +3,10 @@ import PropTypes from "prop-types";
 import { ApolloProvider, getDataFromTree } from "react-apollo";
 import hoistNonReactStatic from "hoist-non-react-statics";
 import Head from "next/head";
+import getConfig from "next/config";
 import rootMobxStores from "lib/stores";
 import logger from "../logger";
 import initApollo from "./initApollo";
-import getConfig from "next/config";
 
 const { serverRuntimeConfig } = getConfig();
 

--- a/src/lib/apollo/withApolloClient.js
+++ b/src/lib/apollo/withApolloClient.js
@@ -6,6 +6,9 @@ import Head from "next/head";
 import rootMobxStores from "lib/stores";
 import logger from "../logger";
 import initApollo from "./initApollo";
+import getConfig from "next/config";
+
+const { serverRuntimeConfig } = getConfig();
 
 /**
  * Get the display name of a component
@@ -28,6 +31,16 @@ export default function withApolloClient(WrappedComponent) {
     static async getInitialProps(ctx) {
       const { Component, router, ctx: { req, res, query, pathname } } = ctx;
       const requestPath = req && req.get("request-path");
+
+      if (!process.browser && serverRuntimeConfig.debugRequestHeaders) {
+        logger.info("Request header:");
+        req && logger.dir(req.headers);
+      }
+
+      if (!process.browser && serverRuntimeConfig.debugResponseHeaders) {
+        logger.info("Response header:");
+        res && logger.dir(res.headers);
+      }
 
       // Provide the `url` prop data in case a GraphQL query uses it
       rootMobxStores.routingStore.updateRoute({ query, pathname, route: router.route });

--- a/src/lib/logger/index.js
+++ b/src/lib/logger/index.js
@@ -13,6 +13,10 @@ const logger = {
     console.info(chalk.cyan(message));
   },
 
+  dir(object) {
+    console.dir(object, { depth: null });
+  },
+
   warn(message) {
     console.warn(chalk.yellow(message));
   },

--- a/src/next.config.js
+++ b/src/next.config.js
@@ -8,7 +8,9 @@ module.exports = {
    * const { serverRuntimeConfig } = getConfig();
    */
   serverRuntimeConfig: {
-    graphqlUrl: appConfig.INTERNAL_GRAPHQL_URL
+    graphqlUrl: appConfig.INTERNAL_GRAPHQL_URL,
+    debugRequestHeaders: appConfig.DEBUG_REQUEST_HEADERS,
+    debugResponseHeaders: appConfig.DEBUG_RESPONSE_HEADERS
   },
   /**
    * `publicRuntimeConfig` is available in browser code, even when run on the server


### PR DESCRIPTION
Impact: **minor**
Type: **feature**

## Issue

Add debug options to help with identifying request/response headers in environments like staging.

## Solution

- Add env flags to enable debugging for req/res
- Log the req/res when available

## Breaking changes

none

## Testing

New env vars
```
DEBUG_REQUEST_HEADERS=false
DEBUG_RESPONSE_HEADERS=false
```

1. Copy above env vars to `.env` 
2. Set one or both to true
3. Load a page on the starter-kit
4. See messages logged starting with `Request header:` or `Response header:` followed by some output or `undefined`.
