### PR TITLE
feat: Setup sitemap routes to get data from GQL server

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -8,6 +8,7 @@ const config = require("./config");
 const logger = require("./lib/logger");
 const router = require("./routes");
 const { configureAuthForServer } = require("./serverAuth");
+const { sitemapRoutesHandler } = require("./sitemapRoutesHandler");
 
 // First create the NextJS app.
 // Note that only `config` can be used here because the NextJS `getConfig()` does not
@@ -39,6 +40,7 @@ app
 
     configureAuthForServer(server);
 
+    server.use(sitemapRoutesHandler);
     // Setup next routes
     const routeHandler = router.getRequestHandler(app);
     server.use(routeHandler);

--- a/src/sitemapRoutesHandler.js
+++ b/src/sitemapRoutesHandler.js
@@ -1,0 +1,51 @@
+const fetch = require("isomorphic-fetch");
+const config = require("./config");
+const logger = require("./lib/logger");
+
+/**
+ * @summary processes requests for sitemaps
+ * @param {Object} req - the request object
+ * @param {Object} res - the response object
+ * @param {Object} next - the next middleware function
+ * @returns {undefined}
+ */
+function sitemapRoutesHandler(req, res, next) {
+  if (req.originalUrl.startsWith("/sitemap") === false) {
+    return next();
+  }
+
+  res.setHeader("Content-Type", "text/xml");
+
+  const shopUrl = `${req.protocol}://${req.get("host")}`;
+  const handle = req.originalUrl.replace("/", "");
+
+  const query = `
+    { sitemap(handle: "${handle}", shopUrl: "${shopUrl}") {
+      shopId
+      xml
+    } }
+  `;
+
+  return fetch(config.INTERNAL_GRAPHQL_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ query })
+  })
+    .then((response) => response.json())
+    .then((response) => {
+      if (response.data.sitemap && response.data.sitemap.xml) {
+        res.statusCode = 200;
+        return res.end(response.data.sitemap.xml);
+      }
+
+      res.statusCode = 404;
+      return res.end();
+    })
+    .catch((error) => {
+      logger.error(`GraphQL query error in 'sitemapRoutesHandler': ${error}`);
+      res.statusCode = 500;
+      return res.end();
+    });
+}
+
+module.exports = { sitemapRoutesHandler };


### PR DESCRIPTION
Part of: reactioncommerce/reaction#4927
Impact: **major**
Type: **feature**

## Issue
Get Sitemap  data from GQL API and make it available on sitemap*.xml routes

## Testing
Same as reactioncommerce/reaction#4927, pasted below:
- Start reaction on this branch
- Generate Sitemaps by going to the "Shop" admin panel. Under "Options" tab, click "Refresh Sitemap"
- Start the starterkit app with this branch ([feat-4796-impactmass-sitemap-endpoint](https://github.com/reactioncommerce/reaction-next-starterkit/tree/feat-4796-impactmass-sitemap-endpoint)).
- Visit `{starterkitdomain}/sitemap.xml` e.g http://localhost:4000/sitemap.xml 
- You should see the sitemap xml on the page
