### PR TITLE
Add enhancements to sitemap route handling 

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -44,7 +44,8 @@ if (process.env.IS_BUILDING_NEXTJS) {
     SEGMENT_ANALYTICS_WRITE_KEY: str({ default: "" }),
     SESSION_MAX_AGE_MS: num({ default: 86400000 }), // 24 hours
     SESSION_SECRET: str(),
-    STRIPE_PUBLIC_API_KEY: str({ default: "" })
+    STRIPE_PUBLIC_API_KEY: str({ default: "" }),
+    SITEMAP_TTL: num({ default: 43200 }) // 12 hours
   }, {
     // disable dotenv processing
     dotEnvPath: null,

--- a/src/config.js
+++ b/src/config.js
@@ -45,7 +45,7 @@ if (process.env.IS_BUILDING_NEXTJS) {
     SESSION_MAX_AGE_MS: num({ default: 86400000 }), // 24 hours
     SESSION_SECRET: str(),
     STRIPE_PUBLIC_API_KEY: str({ default: "" }),
-    SITEMAP_TTL: num({ default: 43200 }) // 12 hours
+    SITEMAP_MAX_AGE: num({ default: 43200 }) // 12 hours
   }, {
     // disable dotenv processing
     dotEnvPath: null,

--- a/src/server.js
+++ b/src/server.js
@@ -40,7 +40,9 @@ app
 
     configureAuthForServer(server);
 
-    server.use(sitemapRoutesHandler);
+    // apply to routes starting with "/sitemap" and ending with ".xml"
+    server.use(/^\/sitemap.*\.xml$/, sitemapRoutesHandler);
+
     // Setup next routes
     const routeHandler = router.getRequestHandler(app);
     server.use(routeHandler);

--- a/src/sitemapRoutesHandler.js
+++ b/src/sitemapRoutesHandler.js
@@ -1,6 +1,5 @@
 const fetch = require("isomorphic-fetch");
 const config = require("./config");
-const logger = require("./lib/logger");
 
 /**
  * @summary processes requests for sitemaps
@@ -9,13 +8,7 @@ const logger = require("./lib/logger");
  * @param {Object} next - the next middleware function
  * @returns {undefined}
  */
-function sitemapRoutesHandler(req, res, next) {
-  if (req.originalUrl.startsWith("/sitemap") === false) {
-    return next();
-  }
-
-  res.setHeader("Content-Type", "text/xml");
-
+async function sitemapRoutesHandler(req, res, next) {
   const shopUrl = `${req.protocol}://${req.get("host")}`;
   const handle = req.originalUrl.replace("/", "");
 
@@ -26,26 +19,30 @@ function sitemapRoutesHandler(req, res, next) {
     } }
   `;
 
-  return fetch(config.INTERNAL_GRAPHQL_URL, {
+  const response = await fetch(config.INTERNAL_GRAPHQL_URL, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ query })
-  })
-    .then((response) => response.json())
-    .then((response) => {
-      if (response.data.sitemap && response.data.sitemap.xml) {
-        res.statusCode = 200;
-        return res.end(response.data.sitemap.xml);
-      }
+  });
 
-      res.statusCode = 404;
-      return res.end();
-    })
-    .catch((error) => {
-      logger.error(`GraphQL query error in 'sitemapRoutesHandler': ${error}`);
-      res.statusCode = 500;
-      return res.end();
-    });
+  if (response.status < 200 || response.status > 302) {
+    res.statusCode = response.status;
+    return next(new Error(`GraphQL query error in 'sitemapRoutesHandler': ${response.statusText}`));
+  }
+
+  const json = await response.json();
+
+  if (!json.data || !json.data.sitemap || !json.data.sitemap.xml) {
+    res.statusCode = 404;
+    return next(new Error("Sitemap not found"));
+  }
+
+  res.statusCode = 200;
+  res.set({
+    "Content-Type": "text/xml",
+    "Cache-Control": `public, max-age=${config.SITEMAP_TTL}`
+  });
+  return res.end(json.data.sitemap.xml);
 }
 
 module.exports = { sitemapRoutesHandler };

--- a/src/sitemapRoutesHandler.js
+++ b/src/sitemapRoutesHandler.js
@@ -40,7 +40,7 @@ async function sitemapRoutesHandler(req, res, next) {
   res.statusCode = 200;
   res.set({
     "Content-Type": "text/xml",
-    "Cache-Control": `public, max-age=${config.SITEMAP_TTL}`
+    "Cache-Control": `public, max-age=${config.SITEMAP_MAX_AGE}`
   });
   return res.end(json.data.sitemap.xml);
 }


### PR DESCRIPTION
Resolves NA
Impact: **minor**
Type: **feature+refactor**

## Changes

During an internal PR review, some refactor + updates were suggested that I'm adding here:
- Switch `fetch().then.catch()` to async/await
- Bubble up 404 and 500 errors to the error middleware and let them be handled there
- Add Cache-Control header to cache the sitemap. With max-age default of 12 hours. 
- Use express route pattern matching

## Testing

Testing should be same as the original PR found here https://github.com/reactioncommerce/reaction-next-starterkit/pull/488. You can use reaction's develop branch.
