### PR TITLE
feat(tlp): add Featured as the default sort on tag listing page

### DIFF
--- a/src/components/SortBySelector/SortBySelector.js
+++ b/src/components/SortBySelector/SortBySelector.js
@@ -4,6 +4,10 @@ import Select from "components/Select";
 
 const SORT_BY = [
   {
+    name: "Featured",
+    value: "featured-desc"
+  },
+  {
     name: "Newest",
     value: "updatedAt-desc"
   },

--- a/src/components/SortBySelector/SortBySelector.test.js
+++ b/src/components/SortBySelector/SortBySelector.test.js
@@ -16,3 +16,17 @@ test("basic snapshot", () => {
   const tree = component.toJSON();
   expect(tree).toMatchSnapshot();
 });
+
+test("basic snapshot - with featured sorting", () => {
+  const component = renderer.create((
+    <MuiThemeProvider theme={theme}>
+      <SortBySelector
+        sortBy={"featured-desc"}
+        onChange={() => true}
+      />
+    </MuiThemeProvider>
+  ));
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});
+

--- a/src/components/SortBySelector/__snapshots__/SortBySelector.test.js.snap
+++ b/src/components/SortBySelector/__snapshots__/SortBySelector.test.js.snap
@@ -1,5 +1,48 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`basic snapshot - with featured sorting 1`] = `
+<div
+  className="MuiInputBase-root-26 MuiInput-root-13 SkSelect-input-5"
+  onClick={[Function]}
+>
+  <div
+    className="MuiSelect-root-6"
+  >
+    <div
+      aria-haspopup="true"
+      aria-pressed="false"
+      className="MuiSelect-select-7 MuiSelect-selectMenu-10 SkSelect-selectMenu-3 MuiInputBase-input-36 MuiInput-input-21"
+      id="select-sortBy"
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      role="button"
+      tabIndex={0}
+    >
+      Featured
+    </div>
+    <input
+      id="sort-by"
+      name="sortBy"
+      type="hidden"
+      value="featured-desc"
+    />
+    <svg
+      aria-hidden="true"
+      className="MuiSvgIcon-root-43 MuiSelect-icon-12"
+      focusable="false"
+      role="presentation"
+      viewBox="0 0 24 24"
+    >
+      <path
+        d="M7 10l5 5 5-5z"
+      />
+    </svg>
+  </div>
+</div>
+`;
+
 exports[`basic snapshot 1`] = `
 <div
   className="MuiInputBase-root-26 MuiInput-root-13 SkSelect-input-5"

--- a/src/lib/stores/UIStore.js
+++ b/src/lib/stores/UIStore.js
@@ -70,7 +70,7 @@ class UIStore {
    *
    * @type string
    */
-  @observable sortBy = "featured-desc";
+  @observable sortBy = "updatedAt-desc";
 
   /**
    * The sort by currency code

--- a/src/lib/stores/UIStore.js
+++ b/src/lib/stores/UIStore.js
@@ -70,7 +70,7 @@ class UIStore {
    *
    * @type string
    */
-  @observable sortBy = "updatedAt-desc";
+  @observable sortBy = "featured-desc";
 
   /**
    * The sort by currency code

--- a/src/pages/tag.js
+++ b/src/pages/tag.js
@@ -160,7 +160,7 @@ export default class TagGridPage extends Component {
           pageSize={pageSize}
           setPageSize={this.setPageSize}
           setSortBy={this.setSortBy}
-          sortBy={sortBy}
+          sortBy={"featured-desc"}
         />
       </Fragment>
     );

--- a/src/pages/tag.js
+++ b/src/pages/tag.js
@@ -124,7 +124,7 @@ export default class TagGridPage extends Component {
       uiStore
     } = this.props;
     const pageSize = routingStore.query && routingStore.query.limit ? parseInt(routingStore.query.limit, 10) : uiStore.pageSize;
-    const sortBy = routingStore.query && routingStore.query.sortby ? routingStore.query.sortby : uiStore.sortBy;
+    const sortBy = routingStore.query && routingStore.query.sortby ? routingStore.query.sortby : "featured-desc";
 
     if (!tag) {
       return (
@@ -160,7 +160,7 @@ export default class TagGridPage extends Component {
           pageSize={pageSize}
           setPageSize={this.setPageSize}
           setSortBy={this.setSortBy}
-          sortBy={"featured-desc"}
+          sortBy={sortBy}
         />
       </Fragment>
     );

--- a/src/pages/tag.js
+++ b/src/pages/tag.js
@@ -124,7 +124,7 @@ export default class TagGridPage extends Component {
       uiStore
     } = this.props;
     const pageSize = routingStore.query && routingStore.query.limit ? parseInt(routingStore.query.limit, 10) : uiStore.pageSize;
-    const sortBy = routingStore.query && routingStore.query.sortby ? routingStore.query.sortby : "featured-desc";
+    const sortBy = routingStore.query && routingStore.query.sortby ? routingStore.query.sortby : uiStore.sortBy;
 
     if (!tag) {
       return (


### PR DESCRIPTION
closes #500 

- add `featured-desc` as an option in the tag listing page dropdown.
- add `featured-desc` as the default option in the tag listing page's `catalogItems` query, via the `UIStore.sortBy` variable.
- add snapshot test

## Dependency

Depends on https://github.com/reactioncommerce/reaction/pull/4980 being merged to `develop`

## Testing

- Check the Testing instructions from https://github.com/reactioncommerce/reaction/pull/4980
- Test that the Dropdown shows Features
- Test that clicking Featured in the Dropdown changes the sort
- Test that the default sort on first load is Featured