### PR TITLE
feat: Add dev utilities to the docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,16 +54,21 @@ LABEL maintainer="Reaction Commerce <engineering@reactioncommerce.com>" \
       com.reactioncommerce.docker.git.sha1=$GIT_SHA1 \
       com.reactioncommerce.docker.license=$LICENSE
 
+# Get versions to pin with this command:
+# apk list bash curl less vim | cut -d " " -f 1 | sed 's/-/=/' | xargs
+RUN apk --no-cache add bash=4.4.19-r1 curl=7.61.1-r1 less=530-r0 vim=8.1.0115-r0
+SHELL ["/bin/bash", "-o", "pipefail", "-o", "errexit", "-u", "-c"]
+
 # Because Docker Compose uses a volume for node_modules and volumes are owned
 # by root by default, we have to initially create node_modules here with correct owner.
 # Without this Yarn cannot write packages into node_modules later, when running in a container.
-RUN mkdir -p "/usr/local/src/node_modules" && chown node "/usr/local/src" && chown node "/usr/local/src/node_modules"
-RUN mkdir -p "/usr/local/src/reaction-app/node_modules" && chown node "/usr/local/src/reaction-app" && chown node "/usr/local/src/reaction-app/node_modules"
+RUN mkdir -p "/usr/local/src/node_modules"; chown node "/usr/local/src"; chown node "/usr/local/src/node_modules"
+RUN mkdir -p "/usr/local/src/reaction-app/node_modules"; chown node "/usr/local/src/reaction-app"; chown node "/usr/local/src/reaction-app/node_modules"
 
 # Same for Yarn cache folder. Without this Yarn will warn that it's going to use
 # a fallback cache dir instead because the one in config is not writable.
-RUN mkdir -p "/home/node/.cache/yarn" && chown node "/home/node/.cache/yarn"
-RUN mkdir -p "/home/node/.cache/yarn-offline-mirror" && chown node "/home/node/.cache/yarn-offline-mirror"
+RUN mkdir -p "/home/node/.cache/yarn"; chown node "/home/node/.cache/yarn"
+RUN mkdir -p "/home/node/.cache/yarn-offline-mirror"; chown node "/home/node/.cache/yarn-offline-mirror"
 
 WORKDIR $APP_SOURCE_DIR/..
 COPY --chown=node package.json yarn.lock $APP_SOURCE_DIR/../
@@ -74,8 +79,7 @@ COPY --chown=node package.json yarn.lock $APP_SOURCE_DIR/../
 # The project directory will be mounted during development. Therefore, we'll
 # install dependencies into an external directory (one level up.) This works
 # because Node traverses up the fs to find node_modules.
-RUN set -ex; \
-  if [ "$BUILD_ENV" = "production" ]; then \
+RUN if [ "$BUILD_ENV" = "production" ]; then \
     yarn install \
       --frozen-lockfile \
       --ignore-scripts \
@@ -107,8 +111,7 @@ COPY --chown=node . $APP_SOURCE_DIR
 # our tools use "/home/node" as the HOME dir.
 USER node
 
-RUN set -ex; \
-  if [ "$BUILD_ENV" = "production" ]; then \
+RUN if [ "$BUILD_ENV" = "production" ]; then \
     yarn build; \
   fi;
 


### PR DESCRIPTION
Impact: **minor**
Type: **feature**

## Issue

Our docker image was pretty slim. It was hard to debug and troubleshoot issues in there with docker networking, connected services, config files, etc.

## Solution

I've added some packages

- essential development/debugging/troubleshooting tools
  -  `vim` text editor
  -  `curl`  http client
- developer convenience packages 
  - `less` non-medieval pager 
  - `bash` shell with baseline features like tab completion, history

I've also set the shell for the `Dockerfile` itself to "bash strict mode". It will exit if any command fails, which is usually the correct behavior, and avoids needing to specify `set -e` in every `RUN` line and also eliminates the need to use `&&` as a command separator (`;` is fine with this `SHELL` setting).

## Breaking changes

I don't believe any of these changes are breaking.


## Testing

- Make sure `docker-compose up --build` works and the app runs correctly
