### PR TITLE
feat : performance metrics integration with calibre

### DIFF
--- a/.circleci/bin/calibre-deploy.sh
+++ b/.circleci/bin/calibre-deploy.sh
@@ -10,8 +10,9 @@ LOCATION=$2
 
 # Run Snapshot
 # California Snapshot Only (Be more generic as we add more site locations to track)
-if [ $LOCATION="California" ]
+if [ $LOCATION = "California" ]
 then
     ./../node_modules/calibre/bin/linux/calibre site create-snapshot --site reaction-core-"$(echo $LOCATION | tr '[A-Z]' '[a-z]')"
+else
+    echo "No Snapshot Configured for Location"
 fi
-

--- a/.circleci/bin/calibre-deploy.sh
+++ b/.circleci/bin/calibre-deploy.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -e
+
+URL=$1
+LOCATION=$2
+
+# Run One Off Test
+./../node_modules/calibre/bin/linux/calibre test create $URL --location=$LOCATION
+
+# Run Snapshot
+# California Snapshot Only (Be more generic as we add more site locations to track)
+if [ $LOCATION="California" ]
+then
+    ./../node_modules/calibre/bin/linux/calibre site create-snapshot --site reaction-core-"$(echo $LOCATION | tr '[A-Z]' '[a-z]')"
+fi
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -302,7 +302,9 @@ workflows:
           context: reaction-validation
           requires:
             - docker-build
-      - test-metrics
+      - test-metrics:
+          requires: 
+            - deploy-to-ecs
       - snyk-security:
           context: reaction-validation
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -231,6 +231,34 @@ jobs:
           command: |
             ./node_modules/.bin/blc ${STAGING_URL} -ro -filter=3 -e
 
+  test-metrics:
+    <<: *defaults
+    steps:
+      - run:
+          name: Install Calibre CLI
+          command: |
+            sudo npm install calibre
+      - run:
+          name: California
+          command: |
+            ./node_modules/calibre/bin/linux/calibre test create ${STAGING_URL} --location=California --connection=cable
+            ./node_modules/calibre/bin/linux/calibre site create-snapshot --site reaction-starterkit-california
+      - run:
+          name: North Virginia
+          command: |
+            ./node_modules/calibre/bin/linux/calibre test create ${STAGING_URL} --location=NorthVirginia --connection=cable
+            # ./node_modules/calibre/bin/linux/calibre site create-snapshot --site reaction-starterkit-northvirginia
+      - run:
+          name: London
+          command: |
+            ./node_modules/calibre/bin/linux/calibre test create ${STAGING_URL} --location=London --connection=cable
+            # ./node_modules/calibre/bin/linux/calibre site create-snapshot --site reaction-starterkit-london
+      - run:
+          name: Frankfurt
+          command: |
+            ./node_modules/calibre/bin/linux/calibre test create ${STAGING_URL} --location=Frankfurt --connection=cable
+            # ./node_modules/calibre/bin/linux/calibre site create-snapshot --site reaction-starterkit-frankfurt
+
   snyk-security:
     <<: *defaults
     steps:
@@ -276,6 +304,7 @@ workflows:
           context: reaction-validation
           requires:
             - docker-build
+      - test-metrics
       - snyk-security:
           context: reaction-validation
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -304,7 +304,9 @@ workflows:
           context: reaction-validation
           requires:
             - docker-build
-      - test-metrics
+      - test-metrics:
+          requires:
+            - deploy-to-ecs
       - snyk-security:
           context: reaction-validation
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -234,30 +234,28 @@ jobs:
   test-metrics:
     <<: *defaults
     steps:
+      - checkout
       - run:
           name: Install Calibre CLI
           command: |
+            cd ~
             sudo npm install calibre
       - run:
           name: California
           command: |
-            ./node_modules/calibre/bin/linux/calibre test create ${STAGING_URL} --location=California --connection=cable
-            ./node_modules/calibre/bin/linux/calibre site create-snapshot --site reaction-starterkit-california
+            .circleci/bin/calibre-deploy.sh ${STAGING_URL} California
       - run:
           name: North Virginia
           command: |
-            ./node_modules/calibre/bin/linux/calibre test create ${STAGING_URL} --location=NorthVirginia --connection=cable
-            # ./node_modules/calibre/bin/linux/calibre site create-snapshot --site reaction-starterkit-northvirginia
+            .circleci/bin/calibre-deploy.sh ${STAGING_URL} NorthVirginia
       - run:
           name: London
           command: |
-            ./node_modules/calibre/bin/linux/calibre test create ${STAGING_URL} --location=London --connection=cable
-            # ./node_modules/calibre/bin/linux/calibre site create-snapshot --site reaction-starterkit-london
+            .circleci/bin/calibre-deploy.sh ${STAGING_URL} London
       - run:
           name: Frankfurt
           command: |
-            ./node_modules/calibre/bin/linux/calibre test create ${STAGING_URL} --location=Frankfurt --connection=cable
-            # ./node_modules/calibre/bin/linux/calibre site create-snapshot --site reaction-starterkit-frankfurt
+            .circleci/bin/calibre-deploy.sh ${STAGING_URL} Frankfurt
 
   snyk-security:
     <<: *defaults
@@ -304,9 +302,7 @@ workflows:
           context: reaction-validation
           requires:
             - docker-build
-      - test-metrics:
-          requires:
-            - deploy-to-ecs
+      - test-metrics
       - snyk-security:
           context: reaction-validation
           requires:


### PR DESCRIPTION
Impact: **minor**
Type: **test**

## Issue
No standard way of measuring performance metrics on stock Starter Kit. 

## Solution
Integrate Calibre metric measurement as a step after successful deployment to ECS.

## Breaking changes
None

## Testing
1. Verify Calibre snapshots reach to Calibre's Dashboard
2. Verify Calibre runs on CI

Example Output (https://circleci.com/gh/reactioncommerce/reaction-next-starterkit/8269)

```
🇺🇸  Northern California, USA
9:17pm 27-Feb-2019

Performance Grade: 94
Progressive Web App Grade: 32
Best Practices Grade: 100
Accessibility Grade: 79
SEO Grade: 100

Timing

Time to First Byte
■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■ 595 ms

Response time
■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■ 807 ms

First Meaningful Paint
■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■ 1.18 sec

Time to Interactive
■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■ 4.01 sec


Number of requests: 82
Total Page transferred: 3.32 MB

View the full report https://calibreapp.com/tests/b2c2bb9/46ace62
  
✔ Snapshot created: 4
```

