### PR TITLE
fix: Update component theming example

### DIFF
--- a/src/custom/componentTheme.js
+++ b/src/custom/componentTheme.js
@@ -8,7 +8,11 @@
  */
 
 export default {
-  // This is an example. Uncomment this line to change the color of all buttons with the "important" action type.
+  // This is an example. Uncomment these lines to change the color of all buttons with the "important" action type.
   // Go to /cart with an empty cart to see this change on the "Continue shopping" button
-  // rui_buttonBackgroundColor_important: "#20427B"
+  // "rui_components": {
+  //   "Button": {
+  //     "backgroundColor_important": "#20427B"
+  //   }
+  // }
 };


### PR DESCRIPTION
Resolves #510 
Impact: **major**
Type: **docs**

## Issue
The theming example at `src/custom/componentTheme.js` is outdated and doesn't work anymore.

## Solution
Update the component theming example.

## Breaking changes
None.

## Testing
1. Open `src/custom/componentTheme.js`.
2. Uncomment line 13 to 17.
3. Browse localhost:4000/cart with an empty cart.
4. See that the background color of the "Continue shopping" button has changed.