### PR TITLE
remove blocking code to allow starterkit to start

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,11 +54,6 @@ LABEL maintainer="Reaction Commerce <engineering@reactioncommerce.com>" \
       com.reactioncommerce.docker.git.sha1=$GIT_SHA1 \
       com.reactioncommerce.docker.license=$LICENSE
 
-# Get versions to pin with this command:
-# apk list bash curl less vim | cut -d " " -f 1 | sed 's/-/=/' | xargs
-RUN apk --no-cache add bash=4.4.19-r1 curl=7.61.1-r1 less=530-r0 vim=8.1.0115-r0
-SHELL ["/bin/bash", "-o", "pipefail", "-o", "errexit", "-u", "-c"]
-
 # Because Docker Compose uses a volume for node_modules and volumes are owned
 # by root by default, we have to initially create node_modules here with correct owner.
 # Without this Yarn cannot write packages into node_modules later, when running in a container.

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,6 +54,10 @@ LABEL maintainer="Reaction Commerce <engineering@reactioncommerce.com>" \
       com.reactioncommerce.docker.git.sha1=$GIT_SHA1 \
       com.reactioncommerce.docker.license=$LICENSE
 
+# apk list bash curl less vim | cut -d " " -f 1 | sed 's/-/=/' | xargs
+RUN apk --no-cache add bash curl less vim
+SHELL ["/bin/bash", "-o", "pipefail", "-o", "errexit", "-u", "-c"]
+
 # Because Docker Compose uses a volume for node_modules and volumes are owned
 # by root by default, we have to initially create node_modules here with correct owner.
 # Without this Yarn cannot write packages into node_modules later, when running in a container.


### PR DESCRIPTION
Resolves #513 
Impact: **breaking**
Type: **bugfix**

## Issue
Starterkit docker container was throwing errors, and not being created:
```
ERROR: unsatisfiable constraints:
  curl-7.61.1-r2:
    breaks: world[curl=7.61.1-r1]
ERROR: Service 'web' failed to build: The command '/bin/sh -c apk --no-cache add bash=4.4.19-r1 curl=7.61.1-r1 less=530-r0 vim=8.1.0115-r0' returned a non-zero code: 1
```

## Solution
Remove two lines of code contributing to this error. It seems like this code might have been transferred over from https://github.com/reactioncommerce/reaction-cli, and isn't working in its current form.


## Testing
1. Clone `reaction-platform`
1. run `make`
1. See that `starterkit` starts with no errors