### PR TITLE
Always send a response to logout requests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,7 @@ defaults: &defaults
 #    - DOCKER_REPOSITORY: "202687395681.dkr.ecr.us-west-2.amazonaws.com/reactioncommerce/reaction-next-starterkit"
     - DOCKER_NAMESPACE: "reactioncommerce"
     - DOCKER_NAME: "reaction-next-starterkit"
+    - GLOBAL_CACHE_VERSION: “v3”
 
   docker:
     - image: circleci/node:8-stretch

--- a/package.json
+++ b/package.json
@@ -129,6 +129,9 @@
       "!**/vendor/**"
     ],
     "coverageDirectory": "reports/coverage",
+    "prettier": {
+      "arrowParens": "always"
+    },
     "reporters": [
       "default",
       "jest-junit"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "reaction-next-starterkit",
   "version": "2.0.0-rc.9",
-  "description": "",
+  "description": " ",
   "main": "index.js",
   "keywords": [],
   "author": {

--- a/src/serverAuth.js
+++ b/src/serverAuth.js
@@ -10,17 +10,23 @@ OAuth2Strategy.prototype.authorizationParams = function (options = {}) {
   return { loginAction: options.loginAction };
 };
 
-passport.use("oauth2", new OAuth2Strategy({
-  authorizationURL: config.OAUTH2_AUTH_URL,
-  tokenURL: config.OAUTH2_TOKEN_URL,
-  clientID: config.OAUTH2_CLIENT_ID,
-  clientSecret: config.OAUTH2_CLIENT_SECRET,
-  callbackURL: config.OAUTH2_REDIRECT_URL,
-  state: true,
-  scope: ["offline"]
-}, (accessToken, refreshToken, profile, cb) => {
-  cb(null, { accessToken });
-}));
+passport.use(
+  "oauth2",
+  new OAuth2Strategy(
+    {
+      authorizationURL: config.OAUTH2_AUTH_URL,
+      tokenURL: config.OAUTH2_TOKEN_URL,
+      clientID: config.OAUTH2_CLIENT_ID,
+      clientSecret: config.OAUTH2_CLIENT_SECRET,
+      callbackURL: config.OAUTH2_REDIRECT_URL,
+      state: true,
+      scope: ["offline"]
+    },
+    (accessToken, refreshToken, profile, cb) => {
+      cb(null, { accessToken });
+    }
+  )
+);
 
 // The value passed to `done` here is stored on the session.
 // We save the full user object in the session.
@@ -44,15 +50,23 @@ function configureAuthForServer(server) {
   server.use(passport.initialize());
   server.use(passport.session());
 
-  server.get("/signin", (req, res, next) => {
-    req.session.redirectTo = req.get("Referer");
-    next(); // eslint-disable-line promise/no-callback-in-promise
-  }, passport.authenticate("oauth2", { loginAction: "signin" }));
+  server.get(
+    "/signin",
+    (req, res, next) => {
+      req.session.redirectTo = req.get("Referer");
+      next(); // eslint-disable-line promise/no-callback-in-promise
+    },
+    passport.authenticate("oauth2", { loginAction: "signin" })
+  );
 
-  server.get("/signup", (req, res, next) => {
-    req.session.redirectTo = req.get("Referer");
-    next(); // eslint-disable-line promise/no-callback-in-promise
-  }, passport.authenticate("oauth2", { loginAction: "signup" }));
+  server.get(
+    "/signup",
+    (req, res, next) => {
+      req.session.redirectTo = req.get("Referer");
+      next(); // eslint-disable-line promise/no-callback-in-promise
+    },
+    passport.authenticate("oauth2", { loginAction: "signup" })
+  );
 
   // This endpoint handles OAuth2 requests (exchanges code for token)
   server.get("/callback", passport.authenticate("oauth2"), (req, res) => {


### PR DESCRIPTION
Resolves #519 
Impact: **major**
Type: **bugfix|style|chore**

## Issue

See #519 

## Solution

Make sure each code branch performs some type of express response.

## Breaking changes

N/A

## Testing

See #519 

If you log out while reaction core is down, you'll see a plain text response with this error in your browser, but at least it's an intelligible error message not just a loading spinner

```
Error while logging out: request to http://reaction.api.reaction.localhost:3000/logout?userId=uG4sZqiJuZPY8LFJ3 failed, reason: connect ECONNREFUSED 127.0.0.1:3000
```
