### PR TITLE
chore: ignore snyk js-yaml vuln for 30 days

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,4 +1,13 @@
 # Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
-version: v1.13.3
+version: v1.13.4
 patch: {}
-ignore: {}
+# ignores vulnerabilities until expiry date; change duration by modifying expiry date
+ignore:
+  SNYK-JS-JSYAML-174129:
+    - '@reactioncommerce/components > react-select > emotion > babel-plugin-emotion > babel-plugin-macros > cosmiconfig > js-yaml':
+        reason: No easy update path near term
+        expires: '2019-05-09T16:47:09.529Z'
+  SNYK-JS-JSYAML-173999:
+    - '*':
+        reason: Updating deps breaks snapshot tests
+        expires: 2019-05-09T00:00:00.000Z


### PR DESCRIPTION

Impact: **minor**
Type: **chore|security**

## Issue

We have a snyk vuln deep in our dep tree that is non-trivial to avoid with npm dependency updates at this time.

## Solution

Delay 30 days and hope some new deps show up that don't break when we update.

## Breaking changes
N/A

## Testing
N/A