### PR TITLE
feat: remove unused fields from GQL query

### DIFF
--- a/src/containers/catalog/catalogItemProduct.gql
+++ b/src/containers/catalog/catalogItemProduct.gql
@@ -7,8 +7,6 @@ query catalogItemProductQuery($slugOrId: String!) {
       slug
       description
       vendor
-      inventoryAvailableToSell
-      inventoryInStock
       isLowQuantity
       isSoldOut
       isBackorder
@@ -84,7 +82,6 @@ query catalogItemProductQuery($slugOrId: String!) {
         }
         canBackorder
         inventoryAvailableToSell
-        inventoryInStock
         isBackorder
         isSoldOut
         isLowQuantity
@@ -106,7 +103,6 @@ query catalogItemProductQuery($slugOrId: String!) {
           optionTitle
           canBackorder
           inventoryAvailableToSell
-          inventoryInStock
           isBackorder
           isSoldOut
           isLowQuantity


### PR DESCRIPTION
Impact: **minor**
Type: **chore**

Removes some fields from the GraphQL query because they aren't used and https://github.com/reactioncommerce/reaction/pull/5164 will remove these fields from being available once it is merged.

## Testing
Verify that the pages related to catalog items work as expected. This can be tested and merged before the linked API PR.