### PR TITLE
feat: check fs perms on startup

### DIFF
--- a/bin/check-fs-perms.sh
+++ b/bin/check-fs-perms.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+# Please Use Google Shell Style: https://google.github.io/styleguide/shell.xml
+
+# ---- Start unofficial bash strict mode boilerplate
+# http://redsymbol.net/articles/unofficial-bash-strict-mode/
+set -o errexit  # always exit on error
+set -o errtrace # trap errors in functions as well
+set -o pipefail # don't ignore exit codes when piping output
+set -o posix    # more strict failures in subshells
+# set -x          # enable debugging
+
+IFS=$'\n\t'
+# ---- End unofficial bash strict mode boilerplate
+
+# Want to use literal ${HOME} in the help message
+home_var='${HOME}'
+suffix=".cache/yarn-offline-mirror"
+dir="${HOME}/${suffix}"
+test_file="${dir}/.check-fs-perms"
+how_to_fix="Error: Filesystem permissions are wrong on ${home_var}/.cache/yarn-offline-mirror
+Fix with the following commands run from your host OS shell:
+
+sudo chgrp -R $(id -g) \"${home_var}/${suffix}\"
+sudo chmod -R g+rwx \"${home_var}/${suffix}\"
+"
+echo -n "Checking filesystem permissions…"
+# We expect some commands to fail so allow that
+set +o errexit
+ec=0
+ls "${dir}" &>/dev/null
+ec=$(($? + ec))
+if [[ $ec -eq 0 ]]; then
+  echo -n "✓ read(r) and list(x)"
+else
+  echo -n "🚫 read(r) and list(x)"
+fi
+touch "${test_file}" &>/dev/null
+ec=$(($? + ec))
+if [[ -e "${test_file}" ]]; then
+  rm "${test_file}"
+fi
+if [[ $ec -eq 0 ]]; then
+  echo " ✓ write(w)"
+else
+  echo " 🚫 write(w)"
+  echo "${how_to_fix}" 1>&2
+  exit 10
+fi

--- a/bin/start
+++ b/bin/start
@@ -11,4 +11,5 @@ yarn install
 printf "Creating hydra client…"
 ./bin/wait-for.sh "${OAUTH2_HOST}:${OAUTH2_ADMIN_PORT}"
 ./bin/create-hydra-client.js
+./bin/check-fs-perms.sh
 yarn dev


### PR DESCRIPTION
We had a user [report filesystem errors launching storefront](https://github.com/reactioncommerce/reaction/issues/5194). I'm adding this script so we can detect this on startup time and print a clear error message with the commands necessary to fix this.

Note that I'm proposing the following solution to the tricky problem of userid mismatch between the container and the host OS. If anyone has a better suggestion, I'm all ears. We recommend changing the group of files to match what we use in the container (1000) and allowing group read/write/execute (for directories). I think this will allow harmonious use in both the host OS as the user's normal user and in the container as the `node` user.

## Testing

- Use `chown`, `chgrp`, and `chmod` to configure various permutations of owner/group/read/write/execute permissions on `"${HOME}/.cache/yarn-offline-mirror"`
  - You may also want to test permutations of `.cache` not existing at all, `yarn-offline-mirror` not existing, etc
- Run `./bin/check-fs-perms.sh` from both the host OS and from within the running container
- Verify you get errors and a good error message when perms are wrong
- Verify you get a zero exit code and just a 1-line status indication when perms are OK
- Verify starterkit fails at startup with a clear error message when perms are wrong
- Verify starterkit starts properly when perms are OK, and no noticeable amount of time is added to startup time
- Verify a straight copy/paste of the commands in the error message to a host shell properly resolves the problem
- Test on both linux and mac

## Further instances

If we are happy with this solution, I will recommend we make similar changes to other projects that use docker volume mounts from the host filesystem. This includes at least reaction core, maybe other projects as well.