### PR TITLE
fix: prettier config was in the wrong place

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,9 +129,6 @@
       "!**/vendor/**"
     ],
     "coverageDirectory": "reports/coverage",
-    "prettier": {
-      "arrowParens": "always"
-    },
     "reporters": [
       "default",
       "jest-junit"
@@ -150,5 +147,8 @@
   "jest-junit": {
     "output": "reports/junit/junit.xml",
     "suiteName": "jest-tests"
+  },
+  "prettier": {
+    "arrowParens": "always"
   }
 }


### PR DESCRIPTION
Fixes this warning: 

```
● Validation Warning:

  Unknown option "prettier" with value {"arrowParens": "always"} was found.
  This is probably a typing mistake. Fixing it will remove this message.

  Configuration Documentation:
  https://jestjs.io/docs/configuration.html
```