### PR TITLE
WIP: Run docker container using particular uid:gid

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -4,27 +4,47 @@ __dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 env_file=${__dir}/../.env
 env_example_file=${__dir}/../.env.example
 
-function main {
+function main() {
   set -e
 
   add_new_env_vars
+  add_reaction_user
 }
 
-function add_new_env_vars {
+function add_new_env_vars() {
   # create .env and set perms if it does not exist
-  [ ! -f "${env_file}" ] && { touch "${env_file}" ; chmod 0600 "${env_file}" ; }
+  if [[ ! -f "${env_file}" ]]; then
+    touch "${env_file}"
+    chmod 0600 "${env_file}"
+  fi
 
-  export IFS=$'\n'
-  for var in $(cat "${env_example_file}"); do
-    key="${var%%=*}"     # get var key
+  while IFS=$'\n' read -r var; do
+    key="${var%%=*}"        # get var key
     var=$(eval echo "$var") # generate dynamic values
 
     # If .env doesn't contain this env key, add it
-    if ! $(grep -qLE "^$key=" "${env_file}"); then
+    if ! grep -qLE "^$key=" "${env_file}"; then
       echo "Adding $key to .env"
-      echo "$var" >> "${env_file}"
+      echo "$var" >>"${env_file}"
     fi
-  done
+  done <"${env_example_file}"
+}
+
+function add_reaction_user() {
+  if grep -qLE "^REACTION_USER" "${env_file}"; then
+    # line is already present, leave unchanged
+    return
+  fi
+  # line is not present
+  if [[ -n "${REACTION_USER}" ]]; then
+    # if set in environment, just add the name but no = and no value
+    line="REACTION_USER"
+  else
+    # if unset in environment, default to the current user's uid
+    line="REACTION_USER=$(id -u):$(id -g)"
+  fi
+  echo "Adding ${line} to .env"
+  echo "${line}" >>"${env_file}"
 }
 
 main

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,7 @@ services:
       auth.reaction.localhost:
     ports:
       - 4000:4000
+    user: ${REACTION_USER:-1000:1000}
     volumes:
       - $HOME/.cache/yarn-offline-mirror:/home/node/.cache/yarn-offline-mirror
       - web-yarn:/home/node/.cache/yarn


### PR DESCRIPTION
Impact: **breaking**
Type: **feature|bugfix**


## Issue

On linux, the docker container runs as uid 1000, which in many cases is not the same as the developer's host OS uid. This can cause mismatches in ownership of files that are shared between the host and the container via docker mounts. Ultimately this surfaces as filesystem errors (`EACCESS`, `permission denied`, etc) at various times including when trying to run `yarn`. Mac has automatic mapping that avoids this issue largely.


## Related issues

- https://github.com/reactioncommerce/reaction-platform/issues/14
- https://github.com/reactioncommerce/reaction-platform/issues/7
- https://github.com/reactioncommerce/reaction-next-starterkit/pull/530

## Solution

Configure docker-compose to run the container as the same UID as the host OS user. This is initialized in the `bin/setup` script.

## Breaking changes

Existing files both in the host filesystem and in the docker volumes may be owned by uid 1000 (for this repo). That will probably cause some errors.

For docker volumes: `docker-compose down -v` should resolve them. (at the cost of blowing away your node_modules)

For the host OS: `sudo chown -R "${USER}" ~/.cache/yarn-offline-mirror` should fix it.

## Testing

- Without having run `bin/setup` start the storefront. It should default to empty string and still work barring ownership issues
- Run `bin/setup` and then restart the storefront. It should work.
- Create some permutations of ownership mismatches and test the fix scripts.