### PR TITLE
fix: change calibre ci step to use npx

### DIFF
--- a/.circleci/bin/calibre-deploy.sh
+++ b/.circleci/bin/calibre-deploy.sh
@@ -6,13 +6,13 @@ URL=$1
 LOCATION=$2
 
 # Run One Off Test
-npx calibre test create $URL --location=$LOCATION
+npx calibre@2.0.2 test create $URL --location=$LOCATION
 
 # Run Snapshot
 # California Snapshot Only (Be more generic as we add more site locations to track)
 if [ $LOCATION = "California" ]
 then
-    npx calibre site create-snapshot --site reaction-core-"$(echo $LOCATION | tr '[A-Z]' '[a-z]')"
+    npx calibre@2.0.2 site create-snapshot --site reaction-core-"$(echo $LOCATION | tr '[A-Z]' '[a-z]')"
 else
     echo "No Snapshot Configured for Location"
 fi

--- a/.circleci/bin/calibre-deploy.sh
+++ b/.circleci/bin/calibre-deploy.sh
@@ -6,13 +6,13 @@ URL=$1
 LOCATION=$2
 
 # Run One Off Test
-./../node_modules/calibre/bin/linux/calibre test create $URL --location=$LOCATION
+npx calibre test create $URL --location=$LOCATION
 
 # Run Snapshot
 # California Snapshot Only (Be more generic as we add more site locations to track)
 if [ $LOCATION = "California" ]
 then
-    ./../node_modules/calibre/bin/linux/calibre site create-snapshot --site reaction-core-"$(echo $LOCATION | tr '[A-Z]' '[a-z]')"
+    npx calibre site create-snapshot --site reaction-core-"$(echo $LOCATION | tr '[A-Z]' '[a-z]')"
 else
     echo "No Snapshot Configured for Location"
 fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -237,11 +237,6 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Install Calibre CLI
-          command: |
-            cd ~
-            sudo npm install calibre
-      - run:
           name: California
           command: |
             .circleci/bin/calibre-deploy.sh ${STAGING_URL} California
@@ -303,9 +298,9 @@ workflows:
           context: reaction-validation
           requires:
             - docker-build
-      - test-metrics:
-          requires: 
-            - deploy-to-ecs
+      - test-metrics
+          # requires: 
+          #   - deploy-to-ecs
       - snyk-security:
           context: reaction-validation
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -298,9 +298,9 @@ workflows:
           context: reaction-validation
           requires:
             - docker-build
-      - test-metrics
-          # requires: 
-          #   - deploy-to-ecs
+      - test-metrics:
+          requires: 
+            - deploy-to-ecs
       - snyk-security:
           context: reaction-validation
           requires:


### PR DESCRIPTION
Impact: **minor**
Type: **performance|chore**

## Issue
It is recommended to avoid using `sudo` as much as possible which was being used to install `calibre` globally as part of the CI step. Due to not specifying the version of `calibre` there was a failure in the CI steps.

## Solution
Change from `sudo npm install calibre` to `npx calibre@x.y.z`