### PR TITLE
chore(license): match license from LICENSE.md and README

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "email": "engineering@reactioncommerce.com",
     "url": "https://reactioncommerce.com"
   },
-  "license": "GPL-3.0",
+  "license": "Apache-2.0",
   "sideEffects": false,
   "scripts": {
     "dev": "NODE_ENV=development node ./src/server.js",


### PR DESCRIPTION
Resolves #509 
Impact: **major**
Type: **docs|chore**

## Issue
The license in the `package.json` does not match the LICENSE.md and README.md licenses. The `package.json` uses GPL, but this repo is Apache.

## Solution
Add `"license": "Apache-2.0"` to package.json
