### PR TITLE
chore: only run snyk when package.json changes

### DIFF
--- a/.circleci/bin/snyk-test.sh
+++ b/.circleci/bin/snyk-test.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+# Please Use Google Shell Style: https://google.github.io/styleguide/shell.xml
+
+# ---- Start unofficial bash strict mode boilerplate
+# http://redsymbol.net/articles/unofficial-bash-strict-mode/
+set -o errexit  # always exit on error
+set -o errtrace # trap errors in functions as well
+set -o pipefail # don't ignore exit codes when piping output
+set -o posix    # more strict failures in subshells
+# set -x          # enable debugging
+
+IFS=$'\n\t'
+# ---- End unofficial bash strict mode boilerplate
+
+DOCKER_REPOSITORY="reactioncommerce/reaction-next-starterkit"
+
+CIRCLE_PR_NUMBER="${CIRCLE_PR_NUMBER:-${CIRCLE_PULL_REQUEST##*/}}" # Determine PR number from pull request link
+PATH="${PATH}:${CIRCLE_WORKING_DIRECTORY}/node_modules/.bin"
+if [[ -v CIRCLE_PR_NUMBER ]] && [ -n ${CIRCLE_PR_NUMBER} ]; then
+  url="https://api.github.com/repos/${DOCKER_REPOSITORY}/pulls/${CIRCLE_PR_NUMBER}"          # Get PR from github API
+  TARGET_BRANCH=$(curl --silent --location --fail --show-error "${url}" | jq -r '.base.ref') # Determine target/base branch from API response
+fi
+if [ -z "${TARGET_BRANCH}" ] || [ ${TARGET_BRANCH} == "null" ]; then
+  echo "Not a PR. Skipping Snyk."
+  exit 0
+fi
+# If target branch does not exist or is master, run snyk tests
+if [ ${TARGET_BRANCH} == "master" ] || [ -z "${TARGET_BRANCH/[ ]*\n/}" ]; then
+  snyk test
+else
+  # If package.json is different from the base branch, run snyk
+  if git diff "origin/${CIRCLE_BRANCH}..origin/${TARGET_BRANCH}" package.json | grep diff; then
+    echo "package.json different. Running Snyk."
+    snyk test
+  else
+    echo "package.json identical to target branch. Skipping Snyk."
+  fi
+fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -272,17 +272,22 @@ jobs:
             # sibling to node_modules, then run snyk test.
             docker run \
               --env-file docker-cache/.env \
-              -e "SNYK_TOKEN=$SNYK_TOKEN" \
+              -e "CIRCLE_BRANCH" \
+              -e "CIRCLE_PR_NUMBER" \
+              -e "CIRCLE_PULL_REQUEST" \
+              -e "CIRCLE_WORKING_DIRECTORY" \
+              -e "DOCKER_REPOSITORY" \
+              -e "SNYK_TOKEN" \
               --name reactionapp_next_starterkit \
               -w /usr/local/src \
               "$DOCKER_REPOSITORY:$CIRCLE_SHA1" \
-              sh -c "cp reaction-app/package.json ./ && cp reaction-app/.snyk ./ && snyk test"
+              sh -c "cp reaction-app/package.json ./ && cp reaction-app/.snyk ./ && ./reaction-app/.circleci/bin/snyk-test.sh"
 workflows:
   version: 2
   build_and_test:
     jobs:
       - docker-build-nonprod-and-lint:
-          context: reaction-build-read      
+          context: reaction-build-read
       - docker-build:
           context: reaction-build-read
       - docker-push:
@@ -299,7 +304,7 @@ workflows:
           requires:
             - docker-build
       - test-metrics:
-          requires: 
+          requires:
             - deploy-to-ecs
       - snyk-security:
           context: reaction-validation
@@ -312,6 +317,5 @@ workflows:
             branches:
               only: /^develop$/
       - e2e-test:
-          requires: 
+          requires:
             - deploy-to-ecs
-            

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,8 +54,7 @@ LABEL maintainer="Reaction Commerce <engineering@reactioncommerce.com>" \
       com.reactioncommerce.docker.git.sha1=$GIT_SHA1 \
       com.reactioncommerce.docker.license=$LICENSE
 
-# apk list bash curl less vim | cut -d " " -f 1 | sed 's/-/=/' | xargs
-RUN apk --no-cache add bash curl less vim
+RUN apk --no-cache add bash curl git jq less vim
 SHELL ["/bin/bash", "-o", "pipefail", "-o", "errexit", "-u", "-c"]
 
 # Because Docker Compose uses a volume for node_modules and volumes are owned


### PR DESCRIPTION
Impact: **minor**
Type: **chore**

## Issue
Every PR against this repo was running the snyk security CI test. These tests would sometimes fail when our "ignore this vuln for 30 days" period expired. This would cause a roadblock for contributions and other feature work.

## Solution
Only run snyk when package.json changes. This is the same approach we are using in reactioncommerce/reaction.

## Breaking changes

None

## Testing
This scripting is not readily able to be locally tested due to circleci limitations, so we can only look at the output of circleci jobs to verify it's passing and doing what's expected.

## Misc Notes

I extracted the main logic from the `.circleci/config.yaml` we have in rc/reaction. Made it into a separate script. Fixed some curl/jq logic. This required adding jq to the docker image, but it's super useful to have around for dev/debug so that's fine and good by me.

