### PR TITLE
chore: only run snyk when package.json changes

### DIFF
--- a/.circleci/bin/should-run-snyk.sh
+++ b/.circleci/bin/should-run-snyk.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+
+# Please Use Google Shell Style: https://google.github.io/styleguide/shell.xml
+
+# ---- Start unofficial bash strict mode boilerplate
+# http://redsymbol.net/articles/unofficial-bash-strict-mode/
+set -o errexit  # always exit on error
+set -o errtrace # trap errors in functions as well
+set -o pipefail # don't ignore exit codes when piping output
+set -o posix    # more strict failures in subshells
+# set -x          # enable debugging
+
+IFS=$'\n\t'
+# ---- End unofficial bash strict mode boilerplate
+
+validate_env() {
+  declare -a missing
+  for var in "$@"; do
+    if [[ -z "${!var}" ]]; then
+      echo "⚠️ ERROR: Missing required environment variable: ${var}" 1>&2
+      missing+=("${var}")
+    fi
+  done
+  if [[ -n "${missing[*]}" ]]; then
+    exit 1
+  fi
+}
+
+main() {
+  validate_env CIRCLE_COMPARE_URL DOCKER_REPOSITORY
+  if [[ -z "${CIRCLE_PULL_REQUEST}" ]]; then
+    echo "NO: Not a PR. Skipping Snyk."
+    exit
+  fi
+  # Determine PR number from pull request link
+  CIRCLE_PR_NUMBER="${CIRCLE_PR_NUMBER:-${CIRCLE_PULL_REQUEST##*/}}"
+  PATH="${PATH}:${CIRCLE_WORKING_DIRECTORY}/node_modules/.bin"
+  if [[ -v CIRCLE_PR_NUMBER ]] && [ -n ${CIRCLE_PR_NUMBER} ]; then
+    # Get PR from github API
+    url="https://api.github.com/repos/${DOCKER_REPOSITORY}/pulls/${CIRCLE_PR_NUMBER}"
+    # Determine target/base branch from API response
+    TARGET_BRANCH=$(curl --silent --location --fail --show-error "${url}" |
+      jq -r '.base.ref')
+  fi
+  if [[ -z "${TARGET_BRANCH}" || ${TARGET_BRANCH} == "null" ]]; then
+    echo "NO: Not a PR. Skipping Snyk."
+    exit
+  fi
+  # If target branch does not exist or is master, run snyk tests
+  if [[ ${TARGET_BRANCH} == "master" ]] || [[ -z "${TARGET_BRANCH/[ ]*\n/}" ]]; then
+    echo "YES: always run when targeting master"
+    exit
+  fi
+  # If package.json is different from the base branch, run snyk
+  if git diff "$(basename "${CIRCLE_COMPARE_URL}")" package.json | grep -q diff; then
+    echo "YES: package.json different. Running Snyk."
+    exit
+  fi
+  echo "NO: package.json identical to target branch. Skipping Snyk."
+  exit
+}
+
+main "$@"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -256,6 +256,7 @@ jobs:
   snyk-security:
     <<: *defaults
     steps:
+      - checkout
       - setup_remote_docker
       - attach_workspace:
           at: docker-cache
@@ -264,25 +265,30 @@ jobs:
           command: |
             docker load < docker-cache/docker-image.tar
       - run:
-          name: Snyk
+          name: Snyk Security
+          # Snyk doesn't look up the directory tree for node_modules as
+          # NodeJS does so we have to take some extra measures to test in the
+          # Docker image. Copy package.json up a directory so that it is a
+          # sibling to node_modules, then run snyk test.
           command: |
-            # Snyk doesn't look up the directory tree for node_modules as
-            # NodeJS does so we have to take some extra measures to test in the
-            # Docker image. Copy package.json up a directory so that it is a
-            # sibling to node_modules, then run snyk test.
-            docker run \
-              --env-file docker-cache/.env \
-              -e "SNYK_TOKEN=$SNYK_TOKEN" \
-              --name reactionapp_next_starterkit \
-              -w /usr/local/src \
-              "$DOCKER_REPOSITORY:$CIRCLE_SHA1" \
-              sh -c "cp reaction-app/package.json ./ && cp reaction-app/.snyk ./ && snyk test"
+            answer=$(./.circleci/bin/should-run-snyk.sh)
+            if [[ "${answer}" =~ "^YES" ]] ; then
+              docker run \
+                --env-file docker-cache/.env \
+                --env "SNYK_TOKEN" \
+                --name reactionapp_next_starterkit \
+                --workdir /usr/local/src \
+                "$DOCKER_REPOSITORY:$CIRCLE_SHA1" \
+                sh -c "cp reaction-app/package.json ./ && cp reaction-app/.snyk ./ && snyk test"
+            else
+              echo "Skipping snyk: ${answer}"
+            fi
 workflows:
   version: 2
   build_and_test:
     jobs:
       - docker-build-nonprod-and-lint:
-          context: reaction-build-read      
+          context: reaction-build-read
       - docker-build:
           context: reaction-build-read
       - docker-push:
@@ -299,7 +305,7 @@ workflows:
           requires:
             - docker-build
       - test-metrics:
-          requires: 
+          requires:
             - deploy-to-ecs
       - snyk-security:
           context: reaction-validation
@@ -312,6 +318,5 @@ workflows:
             branches:
               only: /^develop$/
       - e2e-test:
-          requires: 
+          requires:
             - deploy-to-ecs
-            

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,6 @@ LABEL maintainer="Reaction Commerce <engineering@reactioncommerce.com>" \
       com.reactioncommerce.docker.git.sha1=$GIT_SHA1 \
       com.reactioncommerce.docker.license=$LICENSE
 
-# apk list bash curl less vim | cut -d " " -f 1 | sed 's/-/=/' | xargs
 RUN apk --no-cache add bash curl less vim
 SHELL ["/bin/bash", "-o", "pipefail", "-o", "errexit", "-u", "-c"]
 


### PR DESCRIPTION
Impact: **minor**
Type: **chore**

## Issue
Every PR against this repo was running the snyk security CI test. These tests would sometimes fail when our "ignore this vuln for 30 days" period expired. This would cause a roadblock for contributions and other feature work.

**However**, this PR might be wholly unnecessary as there's a snyk setting on the github repo that possibly achieves the same thing.

## Solution
Only run snyk when package.json changes. This is the same approach we are using in reactioncommerce/reaction.

## Breaking changes

None

## Testing
This scripting is not readily able to be locally tested due to circleci limitations, so we can only look at the output of circleci jobs to verify it's passing and doing what's expected.

## Misc Notes

I extracted the main logic from the `.circleci/config.yaml` we have in rc/reaction. Made it into a separate script. Fixed some curl/jq logic.

