### PR TITLE
fix: de-duplicate styled-components package

### DIFF
--- a/src/next.config.js
+++ b/src/next.config.js
@@ -41,6 +41,11 @@ module.exports = {
       type: "javascript/auto"
     });
 
+    // Duplicate versions of the styled-components package were being loaded, this config removes the duplication.
+    // It creates an alias to import the es modules version of the styled-components package.
+    // This is a workaround until the root issue is resolved: https://github.com/webpack/webpack/issues/9329
+    webpackConfig.resolve.alias["styled-components"] = "styled-components/dist/styled-components.browser.esm.js";
+
     return webpackConfig;
   }
 };


### PR DESCRIPTION
Resolves #503 
Impact: minor
Type: bugfix

## Issue
The `styled-components` package was being loaded twice.

## Solution
Add a resolve alias to the WebPack config to import only the es modules version of `styled-components`

## Testing
1. Start storefront
2. Inspect browser console, and verify there is no error regarding duplicate `styled-components`

