### PR TITLE
docs: remove production warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # Reaction Storefront Next.js Starter Kit
 [![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2Freactioncommerce%2Freaction-next-starterkit.svg?type=shield)](https://app.fossa.io/projects/git%2Bgithub.com%2Freactioncommerce%2Freaction-next-starterkit?ref=badge_shield)
 
-_**Note:** This project is a work in progress and should not be used in production at this time._
-
 Reference headless ecommerce storefront for [Reaction Commerce](https://reactioncommerce.com/) v 2.0.0.
 
 ## Features


### PR DESCRIPTION
Resolves #487 
Impact: **minor**
Type: **docs**

## Summary
This project is our example for how to build a storefront on top of the headless [Reaction Commerce GraphQL API](https://github.com/reactioncommerce/reaction). This PR removes the "Not Ready For Production" warning from the README for this project. This project does not yet provide a feature-complete implementation of the GraphQL API, but it is does provide an example of how to build a storefront that consumes the Reaction Commerce API.