### PR TITLE
chore: rename project to example-storefront

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,11 @@
 CANONICAL_URL=http://localhost:4000
 ENABLE_SPA_ROUTING=true
-EXTERNAL_GRAPHQL_URL=http://localhost:3000/graphql-alpha
-INTERNAL_GRAPHQL_URL=http://reaction.api.reaction.localhost:3000/graphql-alpha
+EXTERNAL_GRAPHQL_URL=http://localhost:3000/graphql-beta
+INTERNAL_GRAPHQL_URL=http://reaction.api.reaction.localhost:3000/graphql-beta
 NODE_ENV=development
 OAUTH2_ADMIN_PORT=4445
 OAUTH2_AUTH_URL=http://localhost:4444/oauth2/auth
-OAUTH2_CLIENT_ID=reaction-next-starterkit
+OAUTH2_CLIENT_ID=example-storefront
 OAUTH2_CLIENT_SECRET=CHANGEME
 OAUTH2_HOST=hydra.auth.reaction.localhost
 OAUTH2_IDP_HOST_URL=http://reaction.api.reaction.localhost:3000/

--- a/.graphqlrc
+++ b/.graphqlrc
@@ -1,5 +1,5 @@
 {
   "request": {
-    "url": "http://localhost:3000/graphql-alpha"
+    "url": "http://localhost:3000/graphql-beta"
   }
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 FROM node:10-alpine
 
-ARG NAME=reaction-next-starterkit
+ARG NAME=example-storefront
 ARG DESCRIPTION=""
-ARG URL=https://github.com/reactioncommerce/reaction-next-starterkit
-ARG DOC_URL=https://github.com/reactioncommerce/reaction-next-starterkit
-ARG VCS_URL=https://github.com/reactioncommerce/reaction-next-starterkit
+ARG URL=https://github.com/reactioncommerce/example-storefront
+ARG DOC_URL=https://github.com/reactioncommerce/example-storefront
+ARG VCS_URL=https://github.com/reactioncommerce/example-storefront
 ARG VCS_REF
 ARG VENDOR
 ARG BUILD_DATE

--- a/README.md
+++ b/README.md
@@ -1,13 +1,11 @@
-# Reaction Storefront Next.js Starter Kit
+# Example Storefront
 [![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2Freactioncommerce%2Freaction-next-starterkit.svg?type=shield)](https://app.fossa.io/projects/git%2Bgithub.com%2Freactioncommerce%2Freaction-next-starterkit?ref=badge_shield)
 
-_**Note:** This project is a work in progress and should not be used in production at this time._
-
-Reference headless ecommerce storefront for [Reaction Commerce](https://reactioncommerce.com/) v 2.0.0.
+[Reaction Commerce](https://reactioncommerce.com/) is building a headless event-driven e-commerce ecosystem that empowers businesses to create a variety of dynamic shopping experiences. This Example Storefront is to serve as a reference on how to implement a web based storefront using the Reaction Commerce GraphQL API. You can fork this project as a jumping off point or create your own custom experience using your prefered client-side technology. While we feel our example storefront is full featured enough to use in production, it may be missing features your shop requires at this time.
 
 ## Features
 
-- Headless ecommerce starter kit built with [Next.js](https://nextjs.org/), [React](https://reactjs.org/), [MobX](https://mobx.js.org/getting-started.html), [GraphQL](https://graphql.org/), [Apollo Client](https://www.apollographql.com/docs/react/)
+- Headless ecommerce example storefront built with [Next.js](https://nextjs.org/), [React](https://reactjs.org/), [MobX](https://mobx.js.org/getting-started.html), [GraphQL](https://graphql.org/), [Apollo Client](https://www.apollographql.com/docs/react/)
 - [Reaction GraphQL API](https://github.com/reactioncommerce/reaction/tree/master/imports/plugins/core/graphql) integration
 - Server-side rendering
 - Payments with [Stripe](https://stripe.com/)
@@ -19,16 +17,16 @@ Reference headless ecommerce storefront for [Reaction Commerce](https://reaction
 
 ## Getting Started
 
-Follow the [Reaction Platform docs](https://docs.reactioncommerce.com/docs/installation-reaction-platform) to install and run all the services necessary to run the Starter Kit:
+Follow the [Reaction Platform docs](https://docs.reactioncommerce.com/docs/installation-reaction-platform) to install and run all the services necessary to run the storefront:
 
 | Directory: Service                                                                         | URL                                                          |
 | ------------------------------------------------------------------------------------------ | ------------------------------------------------------------ |
-| [`reaction`](https://github.com/reactioncommerce/reaction): GraphQL API                    | [localhost:3000/graphql-alpha](localhost:3000/graphql-alpha) |
+| [`reaction`](https://github.com/reactioncommerce/reaction): GraphQL API                    | [localhost:3000/graphql-beta](localhost:3000/graphql-beta) |
 | [`reaction`](https://github.com/reactioncommerce/reaction): GraphQL API playground         | [localhost:3000/graphiql](localhost:3000/graphiql)           |
-| [`reaction`](https://github.com/reactioncommerce/reaction): Classic UI                     | [localhost:3000](localhost:3000)                             |
+| [`reaction`](https://github.com/reactioncommerce/reaction): Operator UI                     | [localhost:3000](localhost:3000)                             |
 | [`reaction`](https://github.com/reactioncommerce/reaction): MongoDB                        | [localhost:27017](localhost:27017)                           |
-| [`reaction-hydra`](https://github.com/reactioncommerce/reaction-hydra): oryd/hydra         | [localhost:4444](localhost:4444)                             |
-| [`reaction-next-starterkit`](https://github.com/reactioncommerce/reaction-next-starterkit) | [localhost:4000](localhost:4000)                             |
+| [`reaction-hydra`](https://github.com/reactioncommerce/reaction-hydra): Authentication    | [localhost:4444](localhost:4444)                             |
+| [`example-storefront`](https://github.com/reactioncommerce/example-storefront): Storefront | [localhost:4000](localhost:4000)                             |
 
 ## Configuration
 
@@ -46,7 +44,7 @@ When running the storefront and Reaction for the first time, you will need to co
 Read the docs for [setting up Segment or a custom analytics tracker](docs/tracking-events.md)
 
 ## Documentation
-- [Starter Kit full documentation](./docs)
+- [Example Storefront full documentation](./docs)
 - [Reaction Component Library repository](https://github.com/reactioncommerce/reaction-component-library), [documentation](https://github.com/reactioncommerce/reaction-component-library/tree/master/docs), and [component documentation](http://designsystem.reactioncommerce.com/)
 - [Reaction Docs: Using GraphQL](https://docs.reactioncommerce.com/docs/graphql-using)
 - [Reaction Docs: Testing with Jest](https://docs.reactioncommerce.com/docs/testing-reaction)
@@ -55,10 +53,10 @@ Read the docs for [setting up Segment or a custom analytics tracker](docs/tracki
 
 ## Development
 
-The Reaction Platform runs the Starterkit with Docker, so you will have to use Docker commands to view logs, run commands inside the container and more. To run commands specifically for the Starterkit, make sure to change directories into the `reaction-next-starterkit` directory within the `reaction-platform` repository:
+The Reaction Platform runs the storefront with Docker, so you will have to use Docker commands to view logs, run commands inside the container and more. To run commands specifically for the storefront, make sure to change directories into the `example-storefront` directory within the `reaction-platform` repository:
 
 ```sh
-cd reaction-next-starterkit
+cd example-storefront
 ```
 
 ### Build and run in development mode with logs
@@ -69,7 +67,7 @@ docker-compose up -d && docker-compose logs -f
 
 ### Run in development against a production API
 
-Change the `INTERNAL_GRAPHQL_URL` in `.env` to the production API URL. The URL should end in `/graphql-alpha`, like: `https://my-website.com/graphql-alpha`. Save the `.env` file and restart the application with:
+Change the `INTERNAL_GRAPHQL_URL` in `.env` to the production API URL. The URL should end in `/graphql-beta`, like: `https://my-website.com/graphql-beta`. Save the `.env` file and restart the application with:
 
 ```sh
 docker-compose run --rm --service-ports web yarn start
@@ -87,7 +85,7 @@ Run any command inside a Docker container and then remove the container. Use thi
 Run tests locally
 ```sh
 docker-compose run --rm web yarn test
-````
+```
 
 Run tests locally without cache (this can be helpful if changes aren't showing up)
 ```sh
@@ -133,22 +131,22 @@ docker-compose down --rmi local
 docker-compose up -d --build
 ```
 
-### Testing `reaction-component-library` components in the starterkit
+### Testing `reaction-component-library` components in the storefront
 
-Sometimes we need to test [`reaction-component-library`](https://github.com/reactioncommerce/reaction-component-library) components in the context of the starterkit. Unfortunately, there isn't an easy wasy to do this within our Docker containers, so we need to run the `starterkit` outside of docker.
+Sometimes we need to test [`reaction-component-library`](https://github.com/reactioncommerce/reaction-component-library) components in the context of the storefront. Unfortunately, there isn't an easy wasy to do this within our Docker containers, so we need to run the `storefront` outside of docker.
 
 1. `cd` to your local [`reaction-component-library`](https://github.com/reactioncommerce/reaction-component-library) repo.
 1. Git checkout the proper branch that you want to link
 1. `cd` into the `package` folder of this repo, and run the command `yarn install` followed by `yarn build`
-1. After the build is done, `cd` into the new `dist` folder it just built and run `yarn link` to allow the library to be installed into the starterkit. This will link `@reactioncommerce/components`
-1. Inside the `reaction-next-starterkit` repo, temporarily rename your `.yarnrc` file to anything else (i.e. `.yarnrc-temp`)
+1. After the build is done, `cd` into the new `dist` folder it just built and run `yarn link` to allow the library to be installed into the storefront. This will link `@reactioncommerce/components`
+1. Inside the `example-storefront` repo, temporarily rename your `.yarnrc` file to anything else (i.e. `.yarnrc-temp`)
 1. Run `yarn install` and then the command `yarn link "@reactioncommerce/components"` to set the local version as an override of the published npm version
-1. Inside your `.env` file, change `INTERNAL_GRAPHQL_URL` to equal `http://localhost:3030/graphql-alpha`, the same as the `EXTERNAL_GRAPHQL_URL`
-1. Start the starterkit locally by running the command `export $(cat .env | xargs) && yarn dev`
-1. Your starterkit should now be running at `localhost:4000`
+1. Inside your `.env` file, change `INTERNAL_GRAPHQL_URL` to equal `http://localhost:3030/graphql-beta`, the same as the `EXTERNAL_GRAPHQL_URL`
+1. Start the storefront locally by running the command `export $(cat .env | xargs) && yarn dev`
+1. Your storefront should now be running at `localhost:4000`
     - If you see errors about not being able to find peer dependency packages, that seems to be an issues with yarn linking. You can just temporarily `yarn add` each of those packages in the component library `package/dist` folder. (This folder is gitignored anyway.)
-1. After your changes are tested, shut down the starterkit by running the command `CTRL+C`
-1. Run `yarn unlink "@reactioncommerce/components"` in the starterkit repo folder
+1. After your changes are tested, shut down the storefront by running the command `CTRL+C`
+1. Run `yarn unlink "@reactioncommerce/components"` in the storefront repo folder
 1. `cd` to the `package/dist` folder of the `reaction-component-library` repo. Run the command `yarn unlink` to unlink the local version of the component library
 1. Undo the renaming of your `.yarnrc` file
 1. Undo the URL change inside your `.env` file
@@ -192,7 +190,7 @@ _**NOTE:** This is not the way to run the app in actual production deployment. T
 To stop the Docker container after starting it with the above command, use:
 
 ```sh
-docker stop storefront
+docker stop reaction-storefront
 ```
 
 ## License
@@ -210,4 +208,4 @@ docker stop storefront
    See the License for the specific language governing permissions and
    limitations under the License.
 
-[![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2Freactioncommerce%2Freaction-next-starterkit.svg?type=large)](https://app.fossa.io/projects/git%2Bgithub.com%2Freactioncommerce%2Freaction-next-starterkit?ref=badge_large)
+[![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2Freactioncommerce%2Fexample-storefront.svg?type=large)](https://app.fossa.io/projects/git%2Bgithub.com%2Freactioncommerce%2Fexample-storefront?ref=badge_large)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ networks:
 
 services:
   web:
+    user: root
     build:
       context: .
       args:
@@ -18,7 +19,7 @@ services:
     env_file:
       - ./.env
     environment:
-      REACTION_APP_NAME: "reaction-next-starterkit.web"
+      REACTION_APP_NAME: "storefront.web"
     networks:
       api:
         aliases:

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-# Reaction NextJS Starter Kit Documentation
+# Example Storefront Documentation
 
 ## Architectural Decisions Records
 

--- a/docs/static-assets.md
+++ b/docs/static-assets.md
@@ -2,7 +2,7 @@
 Your storefront will probably need to include static assets such as, logo images, timezone/internationalization data, favicons, etc..
 
 ## Handling static assets
-The starterkit follows the approach outlined in the [Next.JS documentation](https://github.com/zeit/next.js/#static-file-serving-eg-images) keeping all static assets in the `/src/static/` folder.
+The example storefront follows the approach outlined in the [Next.JS documentation](https://github.com/zeit/next.js/#static-file-serving-eg-images) keeping all static assets in the `/src/static/` folder.
 
 **Images**
 Logos, placeholders and similar images are placed in the `/static/images/` directory.

--- a/docs/theming.md
+++ b/docs/theming.md
@@ -2,13 +2,13 @@
 
 ## Styling StarterKit and Material UI components
 
-Most of the components in the starter kit are based on the [Material UI](https://material-ui.com) components. As such, they can usually be customized using the same methods as the base Material UI components.
+Most of the components in the example storefront are based on the [Material UI](https://material-ui.com) components. As such, they can usually be customized using the same methods as the base Material UI components.
 
 ### Changing theme variables
 
 Variables for customizing the theme are located in the `[src/lib/theme/reactionTheme.js](https://github.com/reactioncommerce/reaction-next-starterkit/blob/master/src/lib/theme/reactionTheme.js)  file. The [Material UI theme guide](https://material-ui.com/customization/themes/) has additional details on how to customize the theme.
 
-For example, you can change the various colors used for the primary color, fonts used, layout dimensions and more. All of the [default theme variables from Material UI](https://material-ui.com/customization/default-theme/) are available to override as well as any additional variables added for the Starter Kit itself.
+For example, you can change the various colors used for the primary color, fonts used, layout dimensions and more. All of the [default theme variables from Material UI](https://material-ui.com/customization/default-theme/) are available to override as well as any additional variables added for the example storefront itself.
 
 ```js
 import { createMuiTheme } from "@material-ui/core/styles";
@@ -30,7 +30,7 @@ const theme = createMuiTheme({
 
 ### Applying global overrides
 
-Styles for components can be overridden globally from the [src/lib/theme/reactionTheme.js](https://github.com/reactioncommerce/reaction-next-starterkit/blob/master/src/lib/theme/reactionTheme.js) file. **Before applying an override, consider updating the theme variables as it may provide you with better results.**
+Styles for components can be overridden globally from the [src/lib/theme/reactionTheme.js](https://github.com/reactioncommerce/example-storefront/blob/master/src/lib/theme/reactionTheme.js) file. **Before applying an override, consider updating the theme variables as it may provide you with better results.**
 
 When using overrides you cannot add additional class names that aren't already present in the original component. You can add override existing CSS properties or add new CSS properties that may not exist in the original component's style.
 
@@ -43,7 +43,7 @@ For more information on how to override styles please consult the [Material UI g
 
 To add custom overrides, simply add an `overrides` object to the theme. The `overrides` object contains a key which matches the component name with a prefix, and the value being an object with your overrides to apply to that component.
 
-- Starter Kit components are prefixed with `Sk` in the theme. e.g. `SkHeader`.
+- Example Storefront components are prefixed with `Sk` in the theme. e.g. `SkHeader`.
 - Material UI components are prefixed with `Mui` in the theme. e.g. `MuiAppBar`.
 
 **src/lib/theme/reactionTheme.js**

--- a/docs/tracking-events.md
+++ b/docs/tracking-events.md
@@ -1,12 +1,12 @@
 # Tracking Events
 
-`reaction-next-starterkit` uses [NYTimes React Tracking](https://github.com/NYTimes/react-tracking) to track analytics events throughout the app. By default, all events are sent to [Segment](https://segment.com/). To enable tracking you can either configure Segment tracking to send to your account, or you can swap in a different analytics provider that you prefer.
+Our Example Storefront uses [NYTimes React Tracking](https://github.com/NYTimes/react-tracking) to track analytics events throughout the app. By default, all events are sent to [Segment](https://segment.com/). To enable tracking you can either configure Segment tracking to send to your account, or you can swap in a different analytics provider that you prefer.
 
 You can see the source under `/lib/tracking`
 
 ## Set up Segment
 
-By default, this Reaction Starter Kit uses Segment analytics tracking.
+By default, this example storefront uses Segment analytics tracking.
 
 ### Step 1. Obtain your API key from the Segment dashboard
 

--- a/docs/utilities.md
+++ b/docs/utilities.md
@@ -9,8 +9,8 @@
 1. Click the button labeled `Edit HTTP Headers`
 1. Click `+ Add Header`
 1. For `Header name` enter `meteor-login-token`
-1. For `Header value` you'll need your `Meteor.loginToken` from the [Getting Started](https://github.com/reactioncommerce/reaction-next-starterkit#getting-started) guide.
-1. Make your first query by setting GraphQL Endpoint to http://localhost:3030/graphql-alpha and querying for the viewer's name:
+1. For `Header value` you'll need your `Meteor.loginToken` from the [Getting Started](https://github.com/reactioncommerce/example-storefront#getting-started) guide.
+1. Make your first query by setting GraphQL Endpoint to http://localhost:3030/graphql-beta and querying for the viewer's name:
 ```graphql
 {
   viewer {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "reaction-next-starterkit",
-  "version": "2.0.0-rc.9",
+  "name": "example-storefront",
+  "version": "2.0.0",
   "description": " ",
   "main": "index.js",
   "keywords": [],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example-storefront",
-  "version": "2.0.0",
+  "version": "2.0.0-rc.9",
   "description": " ",
   "main": "index.js",
   "keywords": [],


### PR DESCRIPTION
Resolves #476 
Impact: **breaking|critical|major**
Type: *chore**

## Issue
This project was long due for a rename as the "starterkit" name caused some confusion. 

## Solution
This PR get's this project ready for the official 2.0 release by changing the project/repo name to "example-storefront", updating configs to use the `graphql-beta` endpoint and some copy/docs updates.

## Testing
n/a